### PR TITLE
Reduce Performance tab to optional diagnostics

### DIFF
--- a/MainWindow.Behaviors.partial.cs
+++ b/MainWindow.Behaviors.partial.cs
@@ -340,15 +340,7 @@ namespace ThreadPilot
                 await powerPlanTask; // Ensure we get any exceptions
                 this.LogDebug("PowerPlanViewModel loaded successfully");
 
-                this.LogDebug("About to initialize PerformanceViewModel...");
-                var performanceTask = this.performanceViewModel.InitializeAsync();
-                var performanceResult = await Task.WhenAny(performanceTask, Task.Delay(5000));
-                if (performanceResult != performanceTask)
-                {
-                    throw new TimeoutException("PerformanceViewModel.InitializeAsync() timed out after 5 seconds");
-                }
-                await performanceTask; // Ensure we get any exceptions
-                this.LogDebug("PerformanceViewModel initialized successfully");
+                this.LogDebug("Skipping optional diagnostics initialization until the diagnostics page is opened.");
 
                 this.LogDebug("About to load SystemTweaksViewModel...");
                 var systemTweaksTask = this.systemTweaksViewModel.LoadCommand.ExecuteAsync(null);
@@ -1365,8 +1357,13 @@ namespace ThreadPilot
 
         private AppActivityState GetForegroundActivityState()
         {
-            return this.ProcessManagementTab.Visibility == Visibility.Visible
-                ? AppActivityState.ForegroundProcessView
+            if (this.ProcessManagementTab.Visibility == Visibility.Visible)
+            {
+                return AppActivityState.ForegroundProcessView;
+            }
+
+            return this.PerformanceViewControl.Visibility == Visibility.Visible
+                ? AppActivityState.ForegroundDiagnosticsView
                 : AppActivityState.ForegroundOtherTab;
         }
 
@@ -1408,7 +1405,7 @@ namespace ThreadPilot
 
             if (decision.PerformanceUiMonitoringEnabled)
             {
-                _ = this.performanceViewModel.ResumeBackgroundMonitoringAsync();
+                _ = this.performanceViewModel.ActivateDiagnosticsAsync();
             }
             else
             {
@@ -1791,9 +1788,14 @@ namespace ThreadPilot
                 return;
             }
 
-            this.ApplyAppRefreshPolicy(string.Equals(tag, "Process", StringComparison.Ordinal)
-                ? AppActivityState.ForegroundProcessView
-                : AppActivityState.ForegroundOtherTab);
+            var activityState = tag switch
+            {
+                "Process" => AppActivityState.ForegroundProcessView,
+                "Performance" => AppActivityState.ForegroundDiagnosticsView,
+                _ => AppActivityState.ForegroundOtherTab,
+            };
+
+            this.ApplyAppRefreshPolicy(activityState);
         }
 
         private void NavMenuItem_Click(object sender, RoutedEventArgs e)

--- a/MainWindow.Behaviors.partial.cs
+++ b/MainWindow.Behaviors.partial.cs
@@ -49,9 +49,6 @@ namespace ThreadPilot
             // Set DataContext for the association view
             this.AssociationView.DataContext = this.associationViewModel;
 
-            // Set DataContext for the performance view
-            this.PerformanceViewControl.DataContext = this.performanceViewModel;
-
             // Set DataContext for the log viewer view
             this.LogViewerViewControl.DataContext = this.logViewerViewModel;
 
@@ -1001,57 +998,7 @@ namespace ThreadPilot
         {
             try
             {
-                // Update power plans in system tray
-                var powerPlanService = this.serviceProvider.GetRequiredService<IPowerPlanService>();
-                var powerPlans = await powerPlanService.GetPowerPlansAsync();
-                var activePowerPlan = await powerPlanService.GetActivePowerPlan();
-                this.systemTrayService.UpdatePowerPlans(powerPlans, activePowerPlan);
-
-                // Update profiles in system tray
-                var profilesDirectory = StoragePaths.ProfilesDirectory;
-                var profileNames = new List<string>();
-
-                if (Directory.Exists(profilesDirectory))
-                {
-                    profileNames = Directory.GetFiles(profilesDirectory, "*.json")
-                        .Select(Path.GetFileNameWithoutExtension)
-                        .Where(name => !string.IsNullOrWhiteSpace(name))
-                        .ToList()!;
-                }
-
-                this.systemTrayService.UpdateProfiles(profileNames);
-
-                // Update system status (with timeout to prevent hanging)
-                try
-                {
-                    var performanceService = this.serviceProvider.GetRequiredService<IPerformanceMonitoringService>();
-                    var metricsTask = performanceService.GetSystemMetricsAsync(lightweight: true);
-                    var metricsResult = await Task.WhenAny(metricsTask, Task.Delay(2000)); // 2 second timeout
-
-                    if (metricsResult == metricsTask)
-                    {
-                        var currentMetrics = await metricsTask;
-                        this.systemTrayService.UpdateSystemStatus(
-                            activePowerPlan?.Name ?? "Unknown",
-                            currentMetrics?.TotalCpuUsage ?? 0.0,
-                            currentMetrics?.MemoryUsagePercentage ?? 0.0);
-                    }
-                    else
-                    {
-                        // Timeout - use default values
-                        this.systemTrayService.UpdateSystemStatus(
-                            activePowerPlan?.Name ?? "Unknown",
-                            0.0, 0.0);
-                    }
-                }
-                catch (Exception metricsEx)
-                {
-                    System.Diagnostics.Debug.WriteLine($"Failed to get performance metrics for tray: {metricsEx.Message}");
-                    // Use default values
-                    this.systemTrayService.UpdateSystemStatus(
-                        activePowerPlan?.Name ?? "Unknown",
-                        0.0, 0.0);
-                }
+                await this.systemTrayStatusUpdater.UpdateContextMenuAsync(this.systemTrayService);
             }
             catch (Exception ex)
             {
@@ -1065,6 +1012,12 @@ namespace ThreadPilot
             {
                 this.systemTrayUpdateTimer?.Stop();
                 this.systemTrayUpdateTimer?.Dispose();
+                this.systemTrayUpdateTimer = null;
+
+                if (!this.systemTrayStatusUpdater.ShouldRunPerformanceStatusUpdates)
+                {
+                    return;
+                }
 
                 this.systemTrayUpdateFailureStreak = 0;
                 this.systemTrayUpdateTimer = new System.Timers.Timer(SystemTrayUpdateBaseIntervalMs);
@@ -1142,21 +1095,9 @@ namespace ThreadPilot
         {
             try
             {
-                var powerPlanService = this.serviceProvider.GetRequiredService<IPowerPlanService>();
-                var performanceService = this.serviceProvider.GetRequiredService<IPerformanceMonitoringService>();
-
-                var activePowerPlan = await powerPlanService.GetActivePowerPlan();
-                var currentMetrics = await performanceService.GetSystemMetricsAsync(lightweight: true);
-
-                await this.Dispatcher.InvokeAsync(() =>
-                {
-                    this.systemTrayService.UpdateSystemStatus(
-                        activePowerPlan?.Name ?? "Unknown",
-                        currentMetrics?.TotalCpuUsage ?? 0.0,
-                        currentMetrics?.MemoryUsagePercentage ?? 0.0);
-                });
-
-                return true;
+                return await this.systemTrayStatusUpdater.UpdateStatusAsync(
+                    this.systemTrayService,
+                    action => this.Dispatcher.InvokeAsync(action).Task);
             }
             catch (Exception ex)
             {
@@ -1335,6 +1276,12 @@ namespace ThreadPilot
             this.isSystemTrayUpdatesSuspended = false;
             this.systemTrayUpdateFailureStreak = 0;
             this.systemTrayUpdateTimer?.Stop();
+
+            if (!this.systemTrayStatusUpdater.ShouldRunPerformanceStatusUpdates)
+            {
+                return;
+            }
+
             if (this.systemTrayUpdateTimer != null)
             {
                 this.systemTrayUpdateTimer.Interval = SystemTrayUpdateBaseIntervalMs;
@@ -1405,9 +1352,9 @@ namespace ThreadPilot
 
             if (decision.PerformanceUiMonitoringEnabled)
             {
-                _ = this.performanceViewModel.ActivateDiagnosticsAsync();
+                _ = this.GetPerformanceViewModel().ActivateDiagnosticsAsync();
             }
-            else
+            else if (this.performanceViewModel != null)
             {
                 _ = this.performanceViewModel.SuspendBackgroundMonitoringAsync();
             }
@@ -1536,6 +1483,11 @@ namespace ThreadPilot
             if (string.IsNullOrEmpty(tag))
             {
                 return;
+            }
+
+            if (string.Equals(tag, "Performance", StringComparison.Ordinal))
+            {
+                this.GetPerformanceViewModel();
             }
 
             this.ApplySectionVisibility(tag);
@@ -1842,6 +1794,11 @@ namespace ThreadPilot
                     return;
                 }
 
+                if (string.Equals(tag, "Performance", StringComparison.Ordinal))
+                {
+                    this.GetPerformanceViewModel();
+                }
+
                 this.ApplySectionVisibility(tag);
 
                 if (string.Equals(tag, "Performance", StringComparison.Ordinal))
@@ -1897,6 +1854,7 @@ namespace ThreadPilot
 
                 this.initializationTimeoutTimer?.Stop();
                 this.initializationTimeoutTimer?.Dispose();
+                this.performanceViewModel?.Dispose();
 
                 this.selfResourceManagementService.RestoreForegroundMode();
                 this.navigationBehavior.Dispose();

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -138,7 +138,7 @@
                             <ui:SymbolIcon Symbol="TasksApp24"/>
                         </ui:NavigationViewItem.Icon>
                     </ui:NavigationViewItem>
-                    <ui:NavigationViewItem x:Name="NavPerf" Content="Performance" Tag="Performance" TargetPageTag="Performance" Click="NavMenuItem_Click">
+                    <ui:NavigationViewItem x:Name="NavPerf" Content="Diagnostics" Tag="Performance" TargetPageTag="Performance" Click="NavMenuItem_Click">
                         <ui:NavigationViewItem.Icon>
                             <ui:SymbolIcon Symbol="DataHistogram24"/>
                         </ui:NavigationViewItem.Icon>
@@ -325,14 +325,14 @@
                     </Border.Effect>
                     <StackPanel>
                         <TextBlock x:Name="PerformanceIntroTitle"
-                                   Text="Performance Dashboard"
+                                   Text="Optional Diagnostics"
                                    FontSize="24"
                                    FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                    Margin="0,0,0,10"/>
 
                         <TextBlock x:Name="PerformanceIntroDescription"
-                                   Text="This page gives you live CPU, memory and hotspot visibility so you can build precise optimization rules."
+                                   Text="Diagnostics are optional and intended for troubleshooting. For in-game overlays and detailed performance graphs, use dedicated tools."
                                    TextWrapping="Wrap"
                                    Margin="0,0,0,10"
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
@@ -344,21 +344,21 @@
                                    Margin="0,0,0,6"/>
 
                         <TextBlock x:Name="PerformanceIntroTip1"
-                                   Text="1. Start live metrics to collect a current system snapshot."
+                                   Text="1. Open diagnostics only when you need a focused troubleshooting snapshot."
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                    Margin="0,0,0,4"/>
                         <TextBlock x:Name="PerformanceIntroTip2"
-                                   Text="2. Review top processes and pick recurring workloads."
+                                   Text="2. Review hotspots only as a hint before creating automation rules."
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                    Margin="0,0,0,4"/>
                         <TextBlock x:Name="PerformanceIntroTip3"
-                                   Text="3. Create rules from hotspots to automate power plan and affinity behavior."
+                                   Text="3. Stop live metrics when you are done troubleshooting."
                                    TextWrapping="Wrap"
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                    Margin="0,0,0,16"/>
 
                         <Button x:Name="PerformanceIntroContinueButton"
-                                Content="Continue to Performance"
+                                Content="Continue to Diagnostics"
                                 Click="PerformanceIntroContinue_Click"
                                 HorizontalAlignment="Right"
                                 Background="{DynamicResource AccentFillColorDefaultBrush}"

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -109,6 +109,7 @@ namespace ThreadPilot
 
                 this.InitializeComponent();
                 System.Diagnostics.Debug.WriteLine("InitializeComponent completed");
+                this.ConfigureDiagnosticsNavigation();
 
                 // Initialize loading overlay
                 this.InitializeLoadingOverlay();
@@ -158,6 +159,13 @@ namespace ThreadPilot
                     "MainWindow Initialization Error", MessageBoxButton.OK, MessageBoxImage.Error);
                 throw;
             }
+        }
+
+        private void ConfigureDiagnosticsNavigation()
+        {
+            this.NavPerf.Visibility = AppNavigationOptions.ShowAdvancedDiagnostics
+                ? Visibility.Visible
+                : Visibility.Collapsed;
         }
     }
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -42,10 +42,11 @@ namespace ThreadPilot
 
         private readonly ProcessViewModel processViewModel;
         private readonly PowerPlanViewModel powerPlanViewModel;
-        private readonly PerformanceViewModel performanceViewModel;
+        private readonly IDiagnosticsViewModelProvider diagnosticsViewModelProvider;
         private readonly ProcessPowerPlanAssociationViewModel associationViewModel;
         private readonly LogViewerViewModel logViewerViewModel;
         private readonly ISystemTrayService systemTrayService;
+        private readonly ISystemTrayStatusUpdater systemTrayStatusUpdater;
         private readonly IApplicationSettingsService settingsService;
         private readonly INotificationService notificationService;
         private readonly IProcessMonitorService processMonitorService;
@@ -59,6 +60,7 @@ namespace ThreadPilot
         private readonly IServiceProvider serviceProvider;
         private readonly IThemeService themeService;
         private System.Timers.Timer? systemTrayUpdateTimer;
+        private PerformanceViewModel? performanceViewModel;
         private bool isSystemTrayUpdatesSuspended;
         private int isSystemTrayUpdateInProgress;
         private int systemTrayUpdateFailureStreak;
@@ -84,10 +86,11 @@ namespace ThreadPilot
         public MainWindow(
             ProcessViewModel processViewModel,
             PowerPlanViewModel powerPlanViewModel,
-            PerformanceViewModel performanceViewModel,
+            IDiagnosticsViewModelProvider diagnosticsViewModelProvider,
             ProcessPowerPlanAssociationViewModel associationViewModel,
             LogViewerViewModel logViewerViewModel,
             ISystemTrayService systemTrayService,
+            ISystemTrayStatusUpdater systemTrayStatusUpdater,
             IApplicationSettingsService settingsService,
             INotificationService notificationService,
             IProcessMonitorService processMonitorService,
@@ -118,10 +121,11 @@ namespace ThreadPilot
 
                 this.processViewModel = processViewModel;
                 this.powerPlanViewModel = powerPlanViewModel;
-                this.performanceViewModel = performanceViewModel;
+                this.diagnosticsViewModelProvider = diagnosticsViewModelProvider;
                 this.associationViewModel = associationViewModel;
                 this.logViewerViewModel = logViewerViewModel;
                 this.systemTrayService = systemTrayService;
+                this.systemTrayStatusUpdater = systemTrayStatusUpdater;
                 this.settingsService = settingsService;
                 this.notificationService = notificationService;
                 this.processMonitorService = processMonitorService;
@@ -166,6 +170,18 @@ namespace ThreadPilot
             this.NavPerf.Visibility = AppNavigationOptions.ShowAdvancedDiagnostics
                 ? Visibility.Visible
                 : Visibility.Collapsed;
+        }
+
+        private PerformanceViewModel GetPerformanceViewModel()
+        {
+            if (this.performanceViewModel != null)
+            {
+                return this.performanceViewModel;
+            }
+
+            this.performanceViewModel = this.diagnosticsViewModelProvider.GetOrCreate();
+            this.PerformanceViewControl.DataContext = this.performanceViewModel;
+            return this.performanceViewModel;
         }
     }
 }

--- a/Services/AppNavigationOptions.cs
+++ b/Services/AppNavigationOptions.cs
@@ -1,0 +1,26 @@
+/*
+ * ThreadPilot - Advanced Windows Process and Power Plan Manager
+ * Copyright (C) 2025 Prime Build
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace ThreadPilot.Services
+{
+    /// <summary>
+    /// Compile-time navigation switches for optional surfaces.
+    /// </summary>
+    public static class AppNavigationOptions
+    {
+        public static bool ShowAdvancedDiagnostics => false;
+    }
+}

--- a/Services/AppRefreshPolicy.cs
+++ b/Services/AppRefreshPolicy.cs
@@ -22,6 +22,7 @@ namespace ThreadPilot.Services
     public enum AppActivityState
     {
         ForegroundProcessView,
+        ForegroundDiagnosticsView,
         ForegroundOtherTab,
         Minimized,
         TrayHidden,
@@ -56,6 +57,13 @@ namespace ThreadPilot.Services
                     ProcessUiRefreshEnabled: true,
                     ImmediateProcessRefresh: true,
                     VirtualizedPreloadEnabled: true,
+                    PerformanceUiMonitoringEnabled: false,
+                    PowerPlanUiRefreshEnabled: true,
+                    BackgroundAutomationEnabled: true),
+                AppActivityState.ForegroundDiagnosticsView => new AppRefreshDecision(
+                    ProcessUiRefreshEnabled: false,
+                    ImmediateProcessRefresh: false,
+                    VirtualizedPreloadEnabled: false,
                     PerformanceUiMonitoringEnabled: true,
                     PowerPlanUiRefreshEnabled: true,
                     BackgroundAutomationEnabled: true),
@@ -63,7 +71,7 @@ namespace ThreadPilot.Services
                     ProcessUiRefreshEnabled: false,
                     ImmediateProcessRefresh: false,
                     VirtualizedPreloadEnabled: false,
-                    PerformanceUiMonitoringEnabled: true,
+                    PerformanceUiMonitoringEnabled: false,
                     PowerPlanUiRefreshEnabled: true,
                     BackgroundAutomationEnabled: true),
                 AppActivityState.Minimized or AppActivityState.TrayHidden => new AppRefreshDecision(

--- a/Services/ISystemTrayService.cs
+++ b/Services/ISystemTrayService.cs
@@ -138,6 +138,11 @@ namespace ThreadPilot.Services
         /// <summary>
         /// Updates the current system status in the tray.
         /// </summary>
+        void UpdateSystemStatus(string currentPowerPlan);
+
+        /// <summary>
+        /// Updates the current system status in the tray with diagnostics metrics.
+        /// </summary>
         void UpdateSystemStatus(string currentPowerPlan, double cpuUsage, double memoryUsage);
     }
 

--- a/Services/PerformanceMonitoringService.cs
+++ b/Services/PerformanceMonitoringService.cs
@@ -37,8 +37,9 @@ namespace ThreadPilot.Services
         private readonly IApplicationSettingsService settingsService;
         private readonly IEnhancedLoggingService enhancedLoggingService;
         private readonly Queue<SystemPerformanceMetrics> historicalData;
-        private readonly PerformanceCounter totalCpuCounter;
-        private readonly PerformanceCounter memoryCounter;
+        private readonly object counterInitializationLock = new();
+        private PerformanceCounter? totalCpuCounter;
+        private PerformanceCounter? memoryCounter;
         private readonly List<PerformanceCounter> cpuCoreCounters;
         private System.Threading.Timer? monitoringTimer;
         private readonly object totalMemoryCacheLock = new();
@@ -81,13 +82,7 @@ namespace ThreadPilot.Services
             this.settingsService = settingsService;
             this.enhancedLoggingService = enhancedLoggingService;
             this.historicalData = new Queue<SystemPerformanceMetrics>(HistoricalDataCapacity);
-
-            // Initialize performance counters
-            this.totalCpuCounter = this.CreatePrimedCounter("Processor", "% Processor Time", "_Total");
-            this.memoryCounter = this.CreatePrimedCounter("Memory", "Available MBytes");
             this.cpuCoreCounters = new List<PerformanceCounter>();
-
-            this.InitializeCpuCoreCounters();
         }
 
         public async Task<SystemPerformanceMetrics> GetSystemMetricsAsync(bool lightweight = false)
@@ -146,6 +141,7 @@ namespace ThreadPilot.Services
 
             try
             {
+                this.EnsureCpuCoreCountersInitialized();
                 var topology = await this.cpuTopologyService.DetectTopologyAsync().ConfigureAwait(false);
 
                 for (int i = 0; i < this.cpuCoreCounters.Count; i++)
@@ -178,6 +174,7 @@ namespace ThreadPilot.Services
         {
             try
             {
+                this.EnsureSystemCountersInitialized();
                 var memoryInfo = new MemoryUsageInfo();
 
                 // Get physical memory info
@@ -189,7 +186,7 @@ namespace ThreadPilot.Services
                 }
 
                 // Get available memory
-                memoryInfo.AvailablePhysicalMemory = (long)this.memoryCounter.NextValue() * 1024 * 1024; // Convert MB to bytes
+                memoryInfo.AvailablePhysicalMemory = (long)(this.memoryCounter?.NextValue() ?? 0) * 1024 * 1024; // Convert MB to bytes
                 memoryInfo.UsedPhysicalMemory = memoryInfo.TotalPhysicalMemory - memoryInfo.AvailablePhysicalMemory;
                 memoryInfo.PhysicalMemoryUsagePercentage = memoryInfo.TotalPhysicalMemory > 0
                     ? ((double)memoryInfo.UsedPhysicalMemory / memoryInfo.TotalPhysicalMemory) * 100
@@ -376,6 +373,58 @@ namespace ThreadPilot.Services
             }
         }
 
+        private void EnsureSystemCountersInitialized()
+        {
+            if (this.totalCpuCounter != null && this.memoryCounter != null)
+            {
+                return;
+            }
+
+            lock (this.counterInitializationLock)
+            {
+                if (this.totalCpuCounter != null && this.memoryCounter != null)
+                {
+                    return;
+                }
+
+                PerformanceCounter? totalCpu = null;
+                PerformanceCounter? memory = null;
+
+                try
+                {
+                    totalCpu = this.CreatePrimedCounter("Processor", "% Processor Time", "_Total");
+                    memory = this.CreatePrimedCounter("Memory", "Available MBytes");
+
+                    this.totalCpuCounter = totalCpu;
+                    this.memoryCounter = memory;
+                }
+                catch
+                {
+                    totalCpu?.Dispose();
+                    memory?.Dispose();
+                    throw;
+                }
+            }
+        }
+
+        private void EnsureCpuCoreCountersInitialized()
+        {
+            if (this.cpuCoreCounters.Count > 0)
+            {
+                return;
+            }
+
+            lock (this.counterInitializationLock)
+            {
+                if (this.cpuCoreCounters.Count > 0)
+                {
+                    return;
+                }
+
+                this.InitializeCpuCoreCounters();
+            }
+        }
+
         private PerformanceCounter CreatePrimedCounter(string categoryName, string counterName, string? instanceName = null)
         {
             try
@@ -403,7 +452,8 @@ namespace ThreadPilot.Services
         {
             try
             {
-                return this.totalCpuCounter.NextValue();
+                this.EnsureSystemCountersInitialized();
+                return this.totalCpuCounter?.NextValue() ?? 0;
             }
             catch (Exception ex)
             {
@@ -416,7 +466,8 @@ namespace ThreadPilot.Services
         {
             try
             {
-                return (long)this.memoryCounter.NextValue() * 1024 * 1024; // Convert MB to bytes
+                this.EnsureSystemCountersInitialized();
+                return (long)(this.memoryCounter?.NextValue() ?? 0) * 1024 * 1024; // Convert MB to bytes
             }
             catch (Exception ex)
             {

--- a/Services/ServiceConfiguration.cs
+++ b/Services/ServiceConfiguration.cs
@@ -147,6 +147,9 @@ namespace ThreadPilot.Services
 
             // Performance monitoring services
             services.AddSingleton<IPerformanceMonitoringService, PerformanceMonitoringService>();
+            services.AddSingleton(sp => new Lazy<IPerformanceMonitoringService>(
+                () => sp.GetRequiredService<IPerformanceMonitoringService>()));
+            services.AddSingleton<ISystemTrayStatusUpdater, SystemTrayStatusUpdater>();
 
             return services;
         }
@@ -202,6 +205,9 @@ namespace ThreadPilot.Services
             services.AddTransient<SettingsViewModel>();
             services.AddTransient<MainWindowViewModel>();
             services.AddTransient<PerformanceViewModel>();
+            services.AddTransient(sp => new Lazy<PerformanceViewModel>(
+                () => sp.GetRequiredService<PerformanceViewModel>()));
+            services.AddTransient<IDiagnosticsViewModelProvider, DiagnosticsViewModelProvider>();
             services.AddTransient<LogViewerViewModel>();
             services.AddTransient<SystemTweaksViewModel>();
 

--- a/Services/SystemTrayService.cs
+++ b/Services/SystemTrayService.cs
@@ -127,12 +127,15 @@ namespace ThreadPilot.Services
             openDashboardMenuItem.Click += this.OnDashboardClick;
             this.contextMenu.Items.Add(openDashboardMenuItem);
 
-            this.performanceMenuItem = new ToolStripMenuItem("Open Performance")
+            if (AppNavigationOptions.ShowAdvancedDiagnostics)
             {
-                Font = new Font(this.menuFont, FontStyle.Regular),
-            };
-            this.performanceMenuItem.Click += this.OnPerformanceDashboardClick;
-            this.contextMenu.Items.Add(this.performanceMenuItem);
+                this.performanceMenuItem = new ToolStripMenuItem("Open Diagnostics")
+                {
+                    Font = new Font(this.menuFont, FontStyle.Regular),
+                };
+                this.performanceMenuItem.Click += this.OnPerformanceDashboardClick;
+                this.contextMenu.Items.Add(this.performanceMenuItem);
+            }
 
             this.monitoringToggleMenuItem = new ToolStripMenuItem("Pause Automation Monitoring");
             this.monitoringToggleMenuItem.Click += this.OnMonitoringToggleClick;
@@ -743,4 +746,3 @@ namespace ThreadPilot.Services
         }
     }
 }
-

--- a/Services/SystemTrayService.cs
+++ b/Services/SystemTrayService.cs
@@ -482,6 +482,24 @@ namespace ThreadPilot.Services
             }
         }
 
+        public void UpdateSystemStatus(string currentPowerPlan)
+        {
+            if (this.systemStatusMenuItem == null)
+            {
+                return;
+            }
+
+            try
+            {
+                this.systemStatusMenuItem.Text = $"Power Plan: {currentPowerPlan}";
+                this.logger.LogDebug("Updated non-performance system status in context menu");
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogWarning(ex, "Failed to update system status in context menu");
+            }
+        }
+
         public void Dispose()
         {
             if (this.disposed)

--- a/Services/SystemTrayStatusUpdater.cs
+++ b/Services/SystemTrayStatusUpdater.cs
@@ -1,0 +1,144 @@
+/*
+ * ThreadPilot - Advanced Windows Process and Power Plan Manager
+ * Copyright (C) 2025 Prime Build
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace ThreadPilot.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using ThreadPilot.Models;
+
+    public interface ISystemTrayStatusUpdater
+    {
+        bool ShouldRunPerformanceStatusUpdates { get; }
+
+        Task UpdateContextMenuAsync(ISystemTrayService systemTrayService);
+
+        Task<bool> UpdateStatusAsync(ISystemTrayService systemTrayService, Func<Action, Task> dispatchAsync);
+    }
+
+    public sealed class SystemTrayStatusUpdater : ISystemTrayStatusUpdater
+    {
+        private readonly IPowerPlanService powerPlanService;
+        private readonly Lazy<IPerformanceMonitoringService> performanceService;
+
+        public SystemTrayStatusUpdater(
+            IPowerPlanService powerPlanService,
+            Lazy<IPerformanceMonitoringService> performanceService)
+        {
+            this.powerPlanService = powerPlanService ?? throw new ArgumentNullException(nameof(powerPlanService));
+            this.performanceService = performanceService ?? throw new ArgumentNullException(nameof(performanceService));
+        }
+
+        public bool ShouldRunPerformanceStatusUpdates => AppNavigationOptions.ShowAdvancedDiagnostics;
+
+        public async Task UpdateContextMenuAsync(ISystemTrayService systemTrayService)
+        {
+            ArgumentNullException.ThrowIfNull(systemTrayService);
+
+            var activePowerPlan = await this.UpdatePowerPlanMenuAsync(systemTrayService).ConfigureAwait(false);
+            this.UpdateProfileMenu(systemTrayService);
+
+            await this.UpdateStatusCoreAsync(
+                systemTrayService,
+                activePowerPlan,
+                action =>
+                {
+                    action();
+                    return Task.CompletedTask;
+                }).ConfigureAwait(false);
+        }
+
+        public async Task<bool> UpdateStatusAsync(ISystemTrayService systemTrayService, Func<Action, Task> dispatchAsync)
+        {
+            ArgumentNullException.ThrowIfNull(systemTrayService);
+            ArgumentNullException.ThrowIfNull(dispatchAsync);
+
+            try
+            {
+                var activePowerPlan = await this.powerPlanService.GetActivePowerPlan().ConfigureAwait(false);
+                await this.UpdateStatusCoreAsync(systemTrayService, activePowerPlan, dispatchAsync).ConfigureAwait(false);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private async Task<PowerPlanModel?> UpdatePowerPlanMenuAsync(ISystemTrayService systemTrayService)
+        {
+            var powerPlans = await this.powerPlanService.GetPowerPlansAsync().ConfigureAwait(false);
+            var activePowerPlan = await this.powerPlanService.GetActivePowerPlan().ConfigureAwait(false);
+            systemTrayService.UpdatePowerPlans(powerPlans, activePowerPlan);
+            return activePowerPlan;
+        }
+
+        private void UpdateProfileMenu(ISystemTrayService systemTrayService)
+        {
+            var profilesDirectory = StoragePaths.ProfilesDirectory;
+            var profileNames = new List<string>();
+
+            if (Directory.Exists(profilesDirectory))
+            {
+                profileNames = Directory.GetFiles(profilesDirectory, "*.json")
+                    .Select(Path.GetFileNameWithoutExtension)
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .ToList()!;
+            }
+
+            systemTrayService.UpdateProfiles(profileNames);
+        }
+
+        private async Task UpdateStatusCoreAsync(
+            ISystemTrayService systemTrayService,
+            PowerPlanModel? activePowerPlan,
+            Func<Action, Task> dispatchAsync)
+        {
+            var planName = activePowerPlan?.Name ?? "Unknown";
+
+            if (!this.ShouldRunPerformanceStatusUpdates)
+            {
+                await dispatchAsync(() => systemTrayService.UpdateSystemStatus(planName)).ConfigureAwait(false);
+                return;
+            }
+
+            try
+            {
+                var metricsTask = this.performanceService.Value.GetSystemMetricsAsync(lightweight: true);
+                var metricsResult = await Task.WhenAny(metricsTask, Task.Delay(2000)).ConfigureAwait(false);
+
+                if (metricsResult == metricsTask)
+                {
+                    var currentMetrics = await metricsTask.ConfigureAwait(false);
+                    await dispatchAsync(() => systemTrayService.UpdateSystemStatus(
+                        planName,
+                        currentMetrics?.TotalCpuUsage ?? 0.0,
+                        currentMetrics?.MemoryUsagePercentage ?? 0.0)).ConfigureAwait(false);
+                    return;
+                }
+            }
+            catch
+            {
+                // Fall back to non-performance status below.
+            }
+
+            await dispatchAsync(() => systemTrayService.UpdateSystemStatus(planName)).ConfigureAwait(false);
+        }
+    }
+}

--- a/Tests/ThreadPilot.Core.Tests/AppRefreshPolicyTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/AppRefreshPolicyTests.cs
@@ -5,8 +5,9 @@ namespace ThreadPilot.Core.Tests
     public sealed class AppRefreshPolicyTests
     {
         [Theory]
-        [InlineData(AppActivityState.ForegroundProcessView, true, true, true, true, true, true)]
-        [InlineData(AppActivityState.ForegroundOtherTab, false, false, false, true, true, true)]
+        [InlineData(AppActivityState.ForegroundProcessView, true, true, true, false, true, true)]
+        [InlineData(AppActivityState.ForegroundDiagnosticsView, false, false, false, true, true, true)]
+        [InlineData(AppActivityState.ForegroundOtherTab, false, false, false, false, true, true)]
         [InlineData(AppActivityState.Minimized, false, false, false, false, false, true)]
         [InlineData(AppActivityState.TrayHidden, false, false, false, false, false, true)]
         public void Evaluate_ReturnsExpectedRefreshDecision(
@@ -44,11 +45,13 @@ namespace ThreadPilot.Core.Tests
         [Theory]
         [InlineData(null, AppActivityState.ForegroundProcessView, true)]
         [InlineData(AppActivityState.ForegroundProcessView, AppActivityState.ForegroundProcessView, false)]
+        [InlineData(AppActivityState.ForegroundDiagnosticsView, AppActivityState.ForegroundDiagnosticsView, false)]
         [InlineData(AppActivityState.ForegroundOtherTab, AppActivityState.ForegroundOtherTab, false)]
         [InlineData(AppActivityState.Minimized, AppActivityState.Minimized, false)]
         [InlineData(AppActivityState.TrayHidden, AppActivityState.TrayHidden, false)]
         [InlineData(AppActivityState.TrayHidden, AppActivityState.ForegroundProcessView, true)]
         [InlineData(AppActivityState.ForegroundProcessView, AppActivityState.ForegroundOtherTab, true)]
+        [InlineData(AppActivityState.ForegroundOtherTab, AppActivityState.ForegroundDiagnosticsView, true)]
         public void ShouldApplyTransition_SkipsRedundantStateTransitions(
             AppActivityState? previousState,
             AppActivityState nextState,

--- a/Tests/ThreadPilot.Core.Tests/DiagnosticsViewModelProviderTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/DiagnosticsViewModelProviderTests.cs
@@ -1,0 +1,70 @@
+namespace ThreadPilot.Core.Tests
+{
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Moq;
+    using ThreadPilot.Models;
+    using ThreadPilot.Services;
+    using ThreadPilot.ViewModels;
+
+    public sealed class DiagnosticsViewModelProviderTests
+    {
+        [Fact]
+        public void Constructor_DoesNotCreatePerformanceViewModel()
+        {
+            var factoryCalls = 0;
+            var provider = new DiagnosticsViewModelProvider(
+                new Lazy<PerformanceViewModel>(() =>
+                {
+                    factoryCalls++;
+                    throw new InvalidOperationException("PerformanceViewModel should be lazy.");
+                }));
+
+            Assert.False(provider.IsCreated);
+            Assert.Equal(0, factoryCalls);
+        }
+
+        [Fact]
+        public void GetOrCreate_CreatesPerformanceViewModelOnce()
+        {
+            var performanceViewModel = CreatePerformanceViewModel();
+            var factoryCalls = 0;
+            var provider = new DiagnosticsViewModelProvider(
+                new Lazy<PerformanceViewModel>(() =>
+                {
+                    factoryCalls++;
+                    return performanceViewModel;
+                }));
+
+            var first = provider.GetOrCreate();
+            var second = provider.GetOrCreate();
+
+            Assert.Same(performanceViewModel, first);
+            Assert.Same(first, second);
+            Assert.True(provider.IsCreated);
+            Assert.Equal(1, factoryCalls);
+        }
+
+        private static PerformanceViewModel CreatePerformanceViewModel()
+        {
+            var performance = new Mock<IPerformanceMonitoringService>(MockBehavior.Strict);
+            var process = new Mock<IProcessService>(MockBehavior.Strict);
+            var associations = new Mock<IProcessPowerPlanAssociationService>(MockBehavior.Strict);
+            var powerPlan = new Mock<IPowerPlanService>(MockBehavior.Strict);
+            var processMonitorManager = new Mock<IProcessMonitorManagerService>(MockBehavior.Strict);
+            var systemTweaks = new Mock<ISystemTweaksService>(MockBehavior.Strict);
+
+            associations
+                .Setup(x => x.GetAssociationsAsync())
+                .ReturnsAsync(Array.Empty<ProcessPowerPlanAssociation>());
+
+            return new PerformanceViewModel(
+                performance.Object,
+                process.Object,
+                associations.Object,
+                powerPlan.Object,
+                processMonitorManager.Object,
+                systemTweaks.Object,
+                NullLogger<PerformanceViewModel>.Instance);
+        }
+    }
+}

--- a/Tests/ThreadPilot.Core.Tests/PerformanceViewModelDiagnosticsTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/PerformanceViewModelDiagnosticsTests.cs
@@ -1,0 +1,120 @@
+namespace ThreadPilot.Core.Tests
+{
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Moq;
+    using ThreadPilot.Models;
+    using ThreadPilot.Services;
+    using ThreadPilot.ViewModels;
+
+    public sealed class PerformanceViewModelDiagnosticsTests
+    {
+        [Fact]
+        public async Task InitializeAsync_DoesNotStartLiveMonitoringOrScanProcesses()
+        {
+            var harness = new Harness();
+            var viewModel = harness.CreateViewModel();
+
+            await viewModel.InitializeAsync();
+
+            harness.Performance.Verify(x => x.StartMonitoringAsync(), Times.Never);
+            harness.Performance.Verify(x => x.GetSystemMetricsAsync(It.IsAny<bool>()), Times.Never);
+            harness.Performance.Verify(x => x.GetTopCpuProcessesAsync(It.IsAny<int>()), Times.Never);
+            harness.Performance.Verify(x => x.GetTopMemoryProcessesAsync(It.IsAny<int>()), Times.Never);
+            harness.PowerPlan.Verify(x => x.GetActivePowerPlan(), Times.Never);
+        }
+
+        [Fact]
+        public async Task ActivateDiagnosticsAsync_LoadsSnapshotWithoutStartingLiveMonitoring()
+        {
+            var harness = new Harness();
+            var viewModel = harness.CreateViewModel();
+
+            await viewModel.ActivateDiagnosticsAsync();
+
+            harness.Performance.Verify(x => x.GetSystemMetricsAsync(false), Times.Once);
+            harness.Performance.Verify(x => x.GetHistoricalDataAsync(TimeSpan.FromHours(1)), Times.Once);
+            harness.Performance.Verify(x => x.GetTopCpuProcessesAsync(25), Times.Once);
+            harness.Performance.Verify(x => x.GetTopMemoryProcessesAsync(25), Times.Once);
+            harness.PowerPlan.Verify(x => x.GetActivePowerPlan(), Times.Once);
+            harness.Performance.Verify(x => x.StartMonitoringAsync(), Times.Never);
+            Assert.False(viewModel.IsMonitoring);
+        }
+
+        [Fact]
+        public async Task SuspendBackgroundMonitoringAsync_StopsLiveMonitoringAndDoesNotAutoResume()
+        {
+            var harness = new Harness();
+            var viewModel = harness.CreateViewModel();
+
+            await viewModel.StartMonitoringCommand.ExecuteAsync(null);
+            await viewModel.SuspendBackgroundMonitoringAsync();
+            await viewModel.ResumeBackgroundMonitoringAsync();
+
+            harness.Performance.Verify(x => x.StartMonitoringAsync(), Times.Once);
+            harness.Performance.Verify(x => x.StopMonitoringAsync(), Times.Once);
+            Assert.False(viewModel.IsMonitoring);
+            Assert.Equal("Stopped", viewModel.MonitoringStateText);
+        }
+
+        [Fact]
+        public void ShowAdvancedDiagnostics_DefaultsToHidden()
+        {
+            Assert.False(AppNavigationOptions.ShowAdvancedDiagnostics);
+        }
+
+        private sealed class Harness
+        {
+            public Mock<IPerformanceMonitoringService> Performance { get; } = new(MockBehavior.Strict);
+
+            public Mock<IProcessService> Process { get; } = new(MockBehavior.Strict);
+
+            public Mock<IProcessPowerPlanAssociationService> Associations { get; } = new(MockBehavior.Strict);
+
+            public Mock<IPowerPlanService> PowerPlan { get; } = new(MockBehavior.Strict);
+
+            public Mock<IProcessMonitorManagerService> ProcessMonitorManager { get; } = new(MockBehavior.Strict);
+
+            public Mock<ISystemTweaksService> SystemTweaks { get; } = new(MockBehavior.Strict);
+
+            public Harness()
+            {
+                this.Performance
+                    .Setup(x => x.GetSystemMetricsAsync(It.IsAny<bool>()))
+                    .ReturnsAsync(new SystemPerformanceMetrics());
+                this.Performance
+                    .Setup(x => x.GetHistoricalDataAsync(It.IsAny<TimeSpan>()))
+                    .ReturnsAsync(new List<SystemPerformanceMetrics>());
+                this.Performance
+                    .Setup(x => x.GetTopCpuProcessesAsync(It.IsAny<int>()))
+                    .ReturnsAsync(new List<ProcessPerformanceInfo>());
+                this.Performance
+                    .Setup(x => x.GetTopMemoryProcessesAsync(It.IsAny<int>()))
+                    .ReturnsAsync(new List<ProcessPerformanceInfo>());
+                this.Performance
+                    .Setup(x => x.StartMonitoringAsync())
+                    .Returns(Task.CompletedTask);
+                this.Performance
+                    .Setup(x => x.StopMonitoringAsync())
+                    .Returns(Task.CompletedTask);
+
+                this.Associations
+                    .Setup(x => x.GetAssociationsAsync())
+                    .ReturnsAsync(Array.Empty<ProcessPowerPlanAssociation>());
+
+                this.PowerPlan
+                    .Setup(x => x.GetActivePowerPlan())
+                    .ReturnsAsync(new PowerPlanModel { Guid = "balanced", Name = "Balanced" });
+            }
+
+            public PerformanceViewModel CreateViewModel() =>
+                new(
+                    this.Performance.Object,
+                    this.Process.Object,
+                    this.Associations.Object,
+                    this.PowerPlan.Object,
+                    this.ProcessMonitorManager.Object,
+                    this.SystemTweaks.Object,
+                    NullLogger<PerformanceViewModel>.Instance);
+        }
+    }
+}

--- a/Tests/ThreadPilot.Core.Tests/SystemTrayStatusUpdaterTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/SystemTrayStatusUpdaterTests.cs
@@ -1,0 +1,72 @@
+namespace ThreadPilot.Core.Tests
+{
+    using System.Collections.ObjectModel;
+    using Moq;
+    using ThreadPilot.Models;
+    using ThreadPilot.Services;
+
+    public sealed class SystemTrayStatusUpdaterTests
+    {
+        [Fact]
+        public async Task UpdateContextMenuAsync_DiagnosticsHidden_DoesNotResolvePerformanceService()
+        {
+            var harness = new Harness();
+            var updater = harness.CreateUpdater(performanceFactory: () => throw new InvalidOperationException("Performance service should not be resolved."));
+
+            await updater.UpdateContextMenuAsync(harness.Tray.Object);
+
+            harness.Tray.Verify(x => x.UpdatePowerPlans(It.IsAny<IEnumerable<PowerPlanModel>>(), It.IsAny<PowerPlanModel?>()), Times.Once);
+            harness.Tray.Verify(x => x.UpdateProfiles(It.IsAny<IEnumerable<string>>()), Times.Once);
+            harness.Tray.Verify(x => x.UpdateSystemStatus("Balanced"), Times.Once);
+            harness.Tray.Verify(x => x.UpdateSystemStatus(It.IsAny<string>(), It.IsAny<double>(), It.IsAny<double>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task UpdateStatusAsync_DiagnosticsHidden_DoesNotRequestLightweightMetrics()
+        {
+            var harness = new Harness();
+            var updater = harness.CreateUpdater(performanceFactory: () => throw new InvalidOperationException("Performance service should not be resolved."));
+
+            var updated = await updater.UpdateStatusAsync(harness.Tray.Object, action =>
+            {
+                action();
+                return Task.CompletedTask;
+            });
+
+            Assert.True(updated);
+            Assert.False(updater.ShouldRunPerformanceStatusUpdates);
+            harness.Tray.Verify(x => x.UpdateSystemStatus("Balanced"), Times.Once);
+            harness.Tray.Verify(x => x.UpdateSystemStatus(It.IsAny<string>(), It.IsAny<double>(), It.IsAny<double>()), Times.Never);
+        }
+
+        private sealed class Harness
+        {
+            public Mock<ISystemTrayService> Tray { get; } = new(MockBehavior.Strict);
+
+            public Mock<IPowerPlanService> PowerPlan { get; } = new(MockBehavior.Strict);
+
+            public Harness()
+            {
+                var activePlan = new PowerPlanModel { Guid = "balanced", Name = "Balanced" };
+                this.PowerPlan
+                    .Setup(x => x.GetPowerPlansAsync())
+                    .ReturnsAsync(new ObservableCollection<PowerPlanModel> { activePlan });
+                this.PowerPlan
+                    .Setup(x => x.GetActivePowerPlan())
+                    .ReturnsAsync(activePlan);
+
+                this.Tray
+                    .Setup(x => x.UpdatePowerPlans(It.IsAny<IEnumerable<PowerPlanModel>>(), It.IsAny<PowerPlanModel?>()));
+                this.Tray
+                    .Setup(x => x.UpdateProfiles(It.IsAny<IEnumerable<string>>()));
+                this.Tray
+                    .Setup(x => x.UpdateSystemStatus(It.IsAny<string>()));
+            }
+
+            public SystemTrayStatusUpdater CreateUpdater(Func<IPerformanceMonitoringService> performanceFactory) =>
+                new(
+                    this.PowerPlan.Object,
+                    new Lazy<IPerformanceMonitoringService>(performanceFactory));
+        }
+    }
+}

--- a/ViewModels/DiagnosticsViewModelProvider.cs
+++ b/ViewModels/DiagnosticsViewModelProvider.cs
@@ -1,0 +1,41 @@
+/*
+ * ThreadPilot - Advanced Windows Process and Power Plan Manager
+ * Copyright (C) 2025 Prime Build
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace ThreadPilot.ViewModels
+{
+    using System;
+
+    public interface IDiagnosticsViewModelProvider
+    {
+        bool IsCreated { get; }
+
+        PerformanceViewModel GetOrCreate();
+    }
+
+    public sealed class DiagnosticsViewModelProvider : IDiagnosticsViewModelProvider
+    {
+        private readonly Lazy<PerformanceViewModel> performanceViewModel;
+
+        public DiagnosticsViewModelProvider(Lazy<PerformanceViewModel> performanceViewModel)
+        {
+            this.performanceViewModel = performanceViewModel ?? throw new ArgumentNullException(nameof(performanceViewModel));
+        }
+
+        public bool IsCreated => this.performanceViewModel.IsValueCreated;
+
+        public PerformanceViewModel GetOrCreate() => this.performanceViewModel.Value;
+    }
+}

--- a/ViewModels/PerformanceViewModel.cs
+++ b/ViewModels/PerformanceViewModel.cs
@@ -166,9 +166,9 @@ namespace ThreadPilot.ViewModels
         private int blurRadius;
 
         private readonly Dictionary<string, DateTime> lastRuleApplyByExecutable = new(StringComparer.OrdinalIgnoreCase);
-        private bool monitoringWasActiveBeforeSuspend;
         private readonly SemaphoreSlim topProcessRefreshGate = new(1, 1);
         private bool pendingTopProcessRefresh;
+        private bool diagnosticsActivated;
 
         public PerformanceViewModel(
             IPerformanceMonitoringService performanceService,
@@ -196,22 +196,51 @@ namespace ThreadPilot.ViewModels
 
         public override async Task InitializeAsync()
         {
+            this.MonitoringStateText = "Stopped";
+            this.MonitoringStatusText = "Diagnostics inactive";
+            this.SetStatus("Diagnostics are inactive until opened.", false);
+            await Task.CompletedTask;
+        }
+
+        public async Task ActivateDiagnosticsAsync()
+        {
             try
             {
-                this.SetStatus("Initializing performance dashboard...");
+                this.SetStatus("Loading optional diagnostics...");
 
-                await this.RefreshMetricsAsync();
+                await this.RefreshMetricsSnapshotAsync();
                 await this.LoadHistoricalDataAsync();
-                await this.LoadTopProcessesAsync();
-                await this.RefreshGlobalPowerPlanAsync();
 
+                this.diagnosticsActivated = true;
                 this.MonitoringStateText = this.IsMonitoring ? "Active" : "Stopped";
-                this.SetStatus("Performance dashboard initialized", false);
+                this.MonitoringStatusText = this.IsMonitoring ? "Live metrics active" : "Diagnostics snapshot loaded";
+                this.SetStatus("Optional diagnostics loaded", false);
             }
             catch (Exception ex)
             {
-                this.SetError("Failed to initialize performance dashboard", ex);
-                this.logger.LogError(ex, "Error initializing performance dashboard");
+                this.SetError("Failed to load optional diagnostics", ex);
+                this.logger.LogError(ex, "Error loading optional diagnostics");
+            }
+        }
+
+        public async Task DeactivateDiagnosticsAsync()
+        {
+            try
+            {
+                if (this.IsMonitoring)
+                {
+                    await this.performanceService.StopMonitoringAsync();
+                }
+
+                this.IsMonitoring = false;
+                this.MonitoringStatusText = this.diagnosticsActivated
+                    ? "Diagnostics inactive"
+                    : "Live metrics stopped";
+                this.MonitoringStateText = "Stopped";
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogWarning(ex, "Failed to deactivate optional diagnostics");
             }
         }
 
@@ -220,6 +249,11 @@ namespace ThreadPilot.ViewModels
         {
             try
             {
+                if (!this.diagnosticsActivated)
+                {
+                    await this.ActivateDiagnosticsAsync();
+                }
+
                 this.SetStatus("Starting performance monitoring...");
                 await this.performanceService.StartMonitoringAsync();
 
@@ -261,51 +295,32 @@ namespace ThreadPilot.ViewModels
         {
             try
             {
-                if (!this.IsMonitoring)
-                {
-                    this.monitoringWasActiveBeforeSuspend = false;
-                    return;
-                }
-
-                this.monitoringWasActiveBeforeSuspend = true;
-                await this.performanceService.StopMonitoringAsync();
-
-                this.IsMonitoring = false;
-                this.MonitoringStatusText = "Live metrics paused";
-                this.MonitoringStateText = "Paused";
-                this.AddTimelineEvent("Live Metrics", "Live metrics paused while app is minimized.", "Info");
+                await this.DeactivateDiagnosticsAsync();
             }
             catch (Exception ex)
             {
-                this.logger.LogWarning(ex, "Failed to suspend performance monitoring while minimized");
+                this.logger.LogWarning(ex, "Failed to suspend performance diagnostics");
             }
         }
 
         public async Task ResumeBackgroundMonitoringAsync()
         {
-            try
-            {
-                if (!this.monitoringWasActiveBeforeSuspend || this.IsMonitoring)
-                {
-                    return;
-                }
-
-                await this.performanceService.StartMonitoringAsync();
-
-                this.IsMonitoring = true;
-                this.MonitoringStatusText = "Live metrics active";
-                this.MonitoringStateText = "Active";
-                this.AddTimelineEvent("Live Metrics", "Live metrics resumed after restore.", "Info");
-                this.monitoringWasActiveBeforeSuspend = false;
-            }
-            catch (Exception ex)
-            {
-                this.logger.LogWarning(ex, "Failed to resume performance monitoring after restore");
-            }
+            await Task.CompletedTask;
         }
 
         [RelayCommand]
         private async Task RefreshMetricsAsync()
+        {
+            if (!this.diagnosticsActivated)
+            {
+                await this.ActivateDiagnosticsAsync();
+                return;
+            }
+
+            await this.RefreshMetricsSnapshotAsync();
+        }
+
+        private async Task RefreshMetricsSnapshotAsync()
         {
             try
             {
@@ -486,22 +501,34 @@ namespace ThreadPilot.ViewModels
 
         partial void OnShowOnlyRuleBackedHotspotsChanged(bool value)
         {
-            _ = LoadTopProcessesAsync();
+            if (this.diagnosticsActivated)
+            {
+                _ = LoadTopProcessesAsync();
+            }
         }
 
         partial void OnShowOnlyActionableHotspotsChanged(bool value)
         {
-            _ = LoadTopProcessesAsync();
+            if (this.diagnosticsActivated)
+            {
+                _ = LoadTopProcessesAsync();
+            }
         }
 
         partial void OnSortModeChanged(string value)
         {
-            _ = LoadTopProcessesAsync();
+            if (this.diagnosticsActivated)
+            {
+                _ = LoadTopProcessesAsync();
+            }
         }
 
         partial void OnProcessSearchTextChanged(string value)
         {
-            _ = LoadTopProcessesAsync();
+            if (this.diagnosticsActivated)
+            {
+                _ = LoadTopProcessesAsync();
+            }
         }
 
         partial void OnIsPopupVisibleChanged(bool value)
@@ -618,7 +645,8 @@ namespace ThreadPilot.ViewModels
 
                     var snapshot = filtered.Take(50).ToList();
 
-                    await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
+                    var dispatcher = System.Windows.Application.Current?.Dispatcher;
+                    void Apply()
                     {
                         this.TopCpuProcesses = new ObservableCollection<ProcessPerformanceInfo>(snapshot);
 
@@ -630,7 +658,16 @@ namespace ThreadPilot.ViewModels
                                 this.SelectedHotspotProcess = refreshedSelection;
                             }
                         }
-                    });
+                    }
+
+                    if (dispatcher != null && !dispatcher.CheckAccess())
+                    {
+                        await dispatcher.InvokeAsync(Apply);
+                    }
+                    else
+                    {
+                        Apply();
+                    }
 
                     await this.RefreshSelectedProcessRuleImpactAsync();
                 }

--- a/Views/PerformanceView.xaml
+++ b/Views/PerformanceView.xaml
@@ -75,9 +75,9 @@
                         </Grid.ColumnDefinitions>
 
                         <StackPanel Grid.Column="0">
-                            <TextBlock Text="Performance Intelligence" Style="{StaticResource TitleTextStyle}"/>
-                            <TextBlock Text="System snapshot, actionable hotspots, rule impact, and stability timeline." Style="{StaticResource LabelTextStyle}" Margin="0,4,0,0"/>
-                            <TextBlock Text="All actions are safety-first and route through existing Rules and Tweaks workflows." Style="{StaticResource LabelTextStyle}" Margin="0,2,0,0"/>
+                            <TextBlock Text="Optional Diagnostics" Style="{StaticResource TitleTextStyle}"/>
+                            <TextBlock Text="Diagnostics are optional and intended for troubleshooting." Style="{StaticResource LabelTextStyle}" Margin="0,4,0,0"/>
+                            <TextBlock Text="For in-game overlays and detailed performance graphs, use dedicated tools." Style="{StaticResource LabelTextStyle}" Margin="0,2,0,0"/>
                         </StackPanel>
 
                         <WrapPanel Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center" ItemHeight="32">


### PR DESCRIPTION
## Summary
- Hide the Performance/Diagnostics entry from primary navigation and the tray by default with `AppNavigationOptions.ShowAdvancedDiagnostics = false`.
- Remove `PerformanceViewModel` from `MainWindow` startup construction; diagnostics now lazy-create the view model only when the diagnostics page is explicitly opened or activated.
- Gate tray CPU/RAM metrics behind `ShowAdvancedDiagnostics`; hidden diagnostics now show non-performance tray status and do not schedule the lightweight metrics timer.
- Lazily allocate `PerformanceMonitoringService` performance counters on first metrics use instead of service construction.
- Preserve the existing diagnostics view, snapshots, live metrics command, hotspot list, and create/update rule command for future selected-process diagnostics work.

## Tests
- Added diagnostics provider tests proving startup construction does not create `PerformanceViewModel` and explicit creation is cached.
- Added tray status updater tests proving hidden diagnostics do not resolve/call `IPerformanceMonitoringService` and do not request lightweight metrics.
- Existing diagnostics ViewModel tests still cover no startup scans, explicit diagnostics activation, stop-on-suspend behavior, and default hidden diagnostics navigation flag.
- `dotnet test "ThreadPilot_1.sln" --configuration Release --no-restore` passed: 303 passed, 0 failed, 0 skipped.

## Limitations / next PR
- The diagnostics route and view remain available internally; this PR only hides primary access by default and removes the hidden startup/tray runtime cost.
- Selected-process diagnostics, CPU affinity changes, memory priority changes, persistent rule changes, versioning, and release notes are intentionally out of scope.