### PR TITLE
Add Process tab context menu actions

### DIFF
--- a/Tests/ThreadPilot.Core.Tests/ProcessViewModelContextMenuTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessViewModelContextMenuTests.cs
@@ -1,0 +1,280 @@
+namespace ThreadPilot.Core.Tests
+{
+    using System.Collections.ObjectModel;
+    using System.Diagnostics;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Moq;
+    using ThreadPilot.Models;
+    using ThreadPilot.Services;
+    using ThreadPilot.ViewModels;
+
+    public sealed class ProcessViewModelContextMenuTests
+    {
+        [Fact]
+        public async Task ContextCpuPriorityCommand_CallsSafePriorityServicePath()
+        {
+            var processService = CreateProcessService();
+            var viewModel = CreateViewModel(processService.Object);
+            var process = CreateProcess(priority: ProcessPriorityClass.Normal);
+
+            await viewModel.SetContextHighPriorityCommand.ExecuteAsync(process);
+
+            processService.Verify(
+                service => service.SetProcessPriority(process, ProcessPriorityClass.High),
+                Times.Once);
+            Assert.Equal(ProcessOperationUserMessages.HighPriorityWarning, viewModel.StatusMessage);
+            Assert.False(viewModel.HasError);
+        }
+
+        [Fact]
+        public void ContextCpuPriorityActions_DoNotExposeRealtimeAsNormalAction()
+        {
+            var viewModel = CreateViewModel(CreateProcessService().Object);
+
+            Assert.DoesNotContain(ProcessPriorityClass.RealTime, viewModel.ContextMenuCpuPriorityActions);
+            Assert.Contains(ProcessPriorityClass.High, viewModel.ContextMenuCpuPriorityActions);
+        }
+
+        [Fact]
+        public async Task ContextMemoryPriorityCommand_CallsMemoryPriorityService()
+        {
+            var memoryPriorityService = new Mock<IProcessMemoryPriorityService>(MockBehavior.Strict);
+            memoryPriorityService
+                .Setup(service => service.SetMemoryPriorityAsync(It.IsAny<ProcessModel>(), ProcessMemoryPriority.Low))
+                .ReturnsAsync(ProcessOperationResult.Succeeded("Memory priority applied.", "ok"));
+            memoryPriorityService
+                .Setup(service => service.GetMemoryPriorityAsync(It.IsAny<ProcessModel>()))
+                .ReturnsAsync(ProcessMemoryPriority.Low);
+            var process = CreateProcess();
+            var viewModel = CreateViewModel(
+                CreateProcessService().Object,
+                memoryPriorityService: memoryPriorityService.Object);
+
+            await viewModel.SetContextMemoryPriorityLowCommand.ExecuteAsync(process);
+
+            memoryPriorityService.Verify(
+                service => service.SetMemoryPriorityAsync(process, ProcessMemoryPriority.Low),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ContextMemoryPriorityCommand_WhenServiceFails_ShowsSafeUserMessage()
+        {
+            var memoryPriorityService = new Mock<IProcessMemoryPriorityService>(MockBehavior.Strict);
+            memoryPriorityService
+                .Setup(service => service.SetMemoryPriorityAsync(It.IsAny<ProcessModel>(), ProcessMemoryPriority.Normal))
+                .ReturnsAsync(ProcessOperationResult.Failed(
+                    "AccessDenied",
+                    ProcessOperationUserMessages.AccessDenied,
+                    "Access is denied.",
+                    isAccessDenied: true));
+            var process = CreateProcess();
+            var viewModel = CreateViewModel(
+                CreateProcessService().Object,
+                memoryPriorityService: memoryPriorityService.Object);
+
+            await viewModel.SetContextMemoryPriorityNormalCommand.ExecuteAsync(process);
+
+            Assert.Equal(ProcessOperationUserMessages.AccessDenied, viewModel.StatusMessage);
+            Assert.True(viewModel.HasError);
+        }
+
+        [Fact]
+        public async Task ContextMemoryPriorityCommand_WhenSuccessful_UpdatesSelectedProcessSummary()
+        {
+            var memoryPriorityService = new Mock<IProcessMemoryPriorityService>(MockBehavior.Strict);
+            memoryPriorityService
+                .Setup(service => service.SetMemoryPriorityAsync(It.IsAny<ProcessModel>(), ProcessMemoryPriority.BelowNormal))
+                .ReturnsAsync(ProcessOperationResult.Succeeded("Memory priority applied.", "ok"));
+            memoryPriorityService
+                .Setup(service => service.GetMemoryPriorityAsync(It.IsAny<ProcessModel>()))
+                .ReturnsAsync(ProcessMemoryPriority.BelowNormal);
+            var process = CreateProcess();
+            var viewModel = CreateViewModel(
+                CreateProcessService().Object,
+                memoryPriorityService: memoryPriorityService.Object);
+
+            await viewModel.SetContextMemoryPriorityBelowNormalCommand.ExecuteAsync(process);
+
+            Assert.Equal(ProcessMemoryPriority.BelowNormal, viewModel.SelectedProcessSummary.MemoryPriority);
+            Assert.Equal("Memory priority: BelowNormal", viewModel.SelectedProcessSummary.MemoryPriorityText);
+        }
+
+        [Fact]
+        public async Task CopyContextProcessInfo_IncludesNamePidAndPath()
+        {
+            string? copiedText = null;
+            var process = CreateProcess();
+            var viewModel = CreateViewModel(
+                CreateProcessService().Object,
+                clipboardSetter: text => copiedText = text);
+
+            await viewModel.CopyContextProcessInfoCommand.ExecuteAsync(process);
+
+            Assert.NotNull(copiedText);
+            Assert.Contains("Name: Game.exe", copiedText);
+            Assert.Contains("PID: 42", copiedText);
+            Assert.Contains(@"Path: C:\Games\Game.exe", copiedText);
+        }
+
+        [Fact]
+        public async Task CopyContextProcessInfo_WhenPathMissing_DoesNotThrow()
+        {
+            string? copiedText = null;
+            var process = CreateProcess(path: string.Empty);
+            var viewModel = CreateViewModel(
+                CreateProcessService().Object,
+                clipboardSetter: text => copiedText = text);
+
+            var exception = await Record.ExceptionAsync(
+                () => viewModel.CopyContextProcessInfoCommand.ExecuteAsync(process));
+
+            Assert.Null(exception);
+            Assert.Contains("Path: unavailable", copiedText);
+        }
+
+        [Fact]
+        public async Task OpenContextExecutableLocation_WhenPathMissing_DoesNotThrow()
+        {
+            var viewModel = CreateViewModel(CreateProcessService().Object);
+
+            var exception = await Record.ExceptionAsync(
+                () => viewModel.OpenContextExecutableLocationCommand.ExecuteAsync(CreateProcess(path: string.Empty)));
+
+            Assert.Null(exception);
+            Assert.Equal("Executable path is unavailable for Game.exe.", viewModel.StatusMessage);
+            Assert.True(viewModel.HasError);
+        }
+
+        [Fact]
+        public async Task ClearContextCpuSetsCommand_CallsSafeCpuSetClearPath()
+        {
+            var processService = CreateProcessService();
+            processService
+                .Setup(service => service.ClearProcessCpuSetAsync(It.IsAny<ProcessModel>()))
+                .ReturnsAsync(true);
+            var process = CreateProcess();
+            var viewModel = CreateViewModel(processService.Object);
+
+            await viewModel.ClearContextCpuSetsCommand.ExecuteAsync(process);
+
+            processService.Verify(service => service.ClearProcessCpuSetAsync(process), Times.Once);
+        }
+
+        [Fact]
+        public async Task RefreshContextProcessInfoCommand_RefreshesSelectedProcessInfo()
+        {
+            var processService = CreateProcessService();
+            var process = CreateProcess();
+            var viewModel = CreateViewModel(processService.Object);
+
+            await viewModel.RefreshContextProcessInfoCommand.ExecuteAsync(process);
+
+            processService.Verify(service => service.RefreshProcessInfo(process), Times.Once);
+            Assert.Equal("Process info refreshed for Game.exe.", viewModel.StatusMessage);
+        }
+
+        [Fact]
+        public async Task ContextMenuActions_DoNotCreatePersistentRules()
+        {
+            var processService = CreateProcessService();
+            var memoryPriorityService = new Mock<IProcessMemoryPriorityService>(MockBehavior.Strict);
+            memoryPriorityService
+                .Setup(service => service.SetMemoryPriorityAsync(It.IsAny<ProcessModel>(), ProcessMemoryPriority.VeryLow))
+                .ReturnsAsync(ProcessOperationResult.Succeeded("Memory priority applied.", "ok"));
+            memoryPriorityService
+                .Setup(service => service.GetMemoryPriorityAsync(It.IsAny<ProcessModel>()))
+                .ReturnsAsync(ProcessMemoryPriority.VeryLow);
+            var ruleStore = new Mock<IPersistentProcessRuleStore>(MockBehavior.Strict);
+            ruleStore
+                .Setup(store => store.LoadAsync())
+                .ReturnsAsync(Array.Empty<PersistentProcessRule>());
+            var viewModel = CreateViewModel(
+                processService.Object,
+                memoryPriorityService: memoryPriorityService.Object,
+                persistentRuleStore: ruleStore.Object,
+                clipboardSetter: _ => { });
+            var process = CreateProcess();
+
+            await viewModel.SetContextAboveNormalPriorityCommand.ExecuteAsync(process);
+            await viewModel.SetContextMemoryPriorityVeryLowCommand.ExecuteAsync(process);
+            await viewModel.CopyContextProcessInfoCommand.ExecuteAsync(process);
+
+            ruleStore.Verify(store => store.SaveAsync(It.IsAny<IReadOnlyList<PersistentProcessRule>>()), Times.Never);
+        }
+
+        private static Mock<IProcessService> CreateProcessService()
+        {
+            var processService = new Mock<IProcessService>(MockBehavior.Loose);
+            processService
+                .Setup(service => service.GetProcessesAsync())
+                .ReturnsAsync(new ObservableCollection<ProcessModel>());
+            processService
+                .Setup(service => service.GetActiveApplicationsAsync())
+                .ReturnsAsync(new ObservableCollection<ProcessModel>());
+            processService
+                .Setup(service => service.IsProcessStillRunning(It.IsAny<ProcessModel>()))
+                .ReturnsAsync(true);
+            processService
+                .Setup(service => service.RefreshProcessInfo(It.IsAny<ProcessModel>()))
+                .Returns(Task.CompletedTask);
+            return processService;
+        }
+
+        private static ProcessViewModel CreateViewModel(
+            IProcessService processService,
+            IProcessMemoryPriorityService? memoryPriorityService = null,
+            IPersistentProcessRuleStore? persistentRuleStore = null,
+            Action<string>? clipboardSetter = null,
+            Action<string>? executableLocationOpener = null)
+        {
+            var virtualizedProcessService = new Mock<IVirtualizedProcessService>(MockBehavior.Loose);
+            virtualizedProcessService.SetupProperty(
+                service => service.Configuration,
+                new VirtualizedProcessConfig());
+
+            var cpuTopologyService = new Mock<ICpuTopologyService>(MockBehavior.Loose);
+            var powerPlanService = new Mock<IPowerPlanService>(MockBehavior.Loose);
+            var notificationService = new Mock<INotificationService>(MockBehavior.Loose);
+            var systemTrayService = new Mock<ISystemTrayService>(MockBehavior.Loose);
+            var coreMaskService = new Mock<ICoreMaskService>(MockBehavior.Loose);
+            var associationService = new Mock<IProcessPowerPlanAssociationService>(MockBehavior.Loose);
+            var gameModeService = new Mock<IGameModeService>(MockBehavior.Loose);
+
+            return new ProcessViewModel(
+                NullLogger<ProcessViewModel>.Instance,
+                processService,
+                new ProcessFilterService(),
+                virtualizedProcessService.Object,
+                cpuTopologyService.Object,
+                powerPlanService.Object,
+                notificationService.Object,
+                systemTrayService.Object,
+                coreMaskService.Object,
+                associationService.Object,
+                gameModeService.Object,
+                memoryPriorityService: memoryPriorityService,
+                persistentRuleStore: persistentRuleStore,
+                persistentRuleMatcher: new PersistentProcessRuleMatcher(),
+                clipboardSetter: clipboardSetter,
+                executableLocationOpener: executableLocationOpener);
+        }
+
+        private static ProcessModel CreateProcess(
+            string name = "Game.exe",
+            int processId = 42,
+            string path = @"C:\Games\Game.exe",
+            ProcessPriorityClass priority = ProcessPriorityClass.Normal)
+            => new()
+            {
+                ProcessId = processId,
+                Name = name,
+                ExecutablePath = path,
+                CpuUsage = 1.5,
+                MemoryUsage = 128 * 1024 * 1024,
+                Priority = priority,
+                ProcessorAffinity = 0xF,
+                Classification = ProcessClassification.ForegroundApp,
+            };
+    }
+}

--- a/Tests/ThreadPilot.Core.Tests/ProcessViewModelContextMenuTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessViewModelContextMenuTests.cs
@@ -27,6 +27,97 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
+        public async Task ApplyContextAffinityCommand_UsesProvidedRowProcess()
+        {
+            var processService = CreateProcessService();
+            var coordinator = CreateAffinityCoordinator();
+            var viewModel = CreateViewModel(
+                processService.Object,
+                processAffinityApplyCoordinator: coordinator.Object);
+            viewModel.CpuCores =
+            [
+                new CpuCoreModel { LogicalCoreId = 0, IsSelected = true },
+                new CpuCoreModel { LogicalCoreId = 1, IsSelected = false },
+            ];
+            var rowProcess = CreateProcess(processId: 100);
+
+            await viewModel.ApplyContextAffinityCommand.ExecuteAsync(rowProcess);
+
+            coordinator.Verify(
+                service => service.ApplyCoreSelectionAsync(
+                    rowProcess,
+                    It.Is<IReadOnlyList<bool>>(mask => mask.Count == 2 && mask[0] && !mask[1]),
+                    "Manual Process tab context menu CPU selection",
+                    default),
+                Times.Once);
+            Assert.Same(rowProcess, viewModel.SelectedProcess);
+        }
+
+        [Fact]
+        public async Task ApplyContextAffinityCommand_WhenRowProcessDiffersFromSelectedProcess_UsesRowProcess()
+        {
+            var processService = CreateProcessService();
+            var coordinator = CreateAffinityCoordinator();
+            var viewModel = CreateViewModel(
+                processService.Object,
+                processAffinityApplyCoordinator: coordinator.Object);
+            viewModel.CpuCores =
+            [
+                new CpuCoreModel { LogicalCoreId = 0, IsSelected = true },
+                new CpuCoreModel { LogicalCoreId = 1, IsSelected = true },
+            ];
+            var oldSelectedProcess = CreateProcess(processId: 1, name: "Old.exe");
+            var rowProcess = CreateProcess(processId: 2, name: "Row.exe");
+            viewModel.SelectedProcess = oldSelectedProcess;
+
+            await viewModel.ApplyContextAffinityCommand.ExecuteAsync(rowProcess);
+
+            coordinator.Verify(
+                service => service.ApplyCoreSelectionAsync(
+                    rowProcess,
+                    It.IsAny<IReadOnlyList<bool>>(),
+                    "Manual Process tab context menu CPU selection",
+                    default),
+                Times.Once);
+            coordinator.Verify(
+                service => service.ApplyCoreSelectionAsync(
+                    oldSelectedProcess,
+                    It.IsAny<IReadOnlyList<bool>>(),
+                    It.IsAny<string>(),
+                    default),
+                Times.Never);
+            Assert.Same(rowProcess, viewModel.SelectedProcess);
+        }
+
+        [Fact]
+        public async Task ApplyContextAffinityCommand_DoesNotCallLegacyLongDirectly()
+        {
+            var processService = CreateProcessService();
+            var coordinator = CreateAffinityCoordinator();
+            var viewModel = CreateViewModel(
+                processService.Object,
+                processAffinityApplyCoordinator: coordinator.Object);
+            viewModel.CpuCores =
+            [
+                new CpuCoreModel { LogicalCoreId = 0, IsSelected = true },
+            ];
+            var rowProcess = CreateProcess();
+
+            await viewModel.ApplyContextAffinityCommand.ExecuteAsync(rowProcess);
+
+            coordinator.Verify(
+                service => service.ApplyCoreSelectionAsync(
+                    rowProcess,
+                    It.IsAny<IReadOnlyList<bool>>(),
+                    "Manual Process tab context menu CPU selection",
+                    default),
+                Times.Once);
+            processService.Verify(
+                service => service.SetProcessorAffinity(It.IsAny<ProcessModel>(), It.IsAny<long>()),
+                Times.Never);
+        }
+
+        [Fact]
         public void ContextCpuPriorityActions_DoNotExposeRealtimeAsNormalAction()
         {
             var viewModel = CreateViewModel(CreateProcessService().Object);
@@ -221,8 +312,22 @@ namespace ThreadPilot.Core.Tests
             return processService;
         }
 
+        private static Mock<IProcessAffinityApplyCoordinator> CreateAffinityCoordinator()
+        {
+            var coordinator = new Mock<IProcessAffinityApplyCoordinator>(MockBehavior.Strict);
+            coordinator
+                .Setup(service => service.ApplyCoreSelectionAsync(
+                    It.IsAny<ProcessModel>(),
+                    It.IsAny<IReadOnlyList<bool>>(),
+                    It.IsAny<string>(),
+                    default))
+                .ReturnsAsync(AffinityApplyResult.Succeeded(1, 1));
+            return coordinator;
+        }
+
         private static ProcessViewModel CreateViewModel(
             IProcessService processService,
+            IProcessAffinityApplyCoordinator? processAffinityApplyCoordinator = null,
             IProcessMemoryPriorityService? memoryPriorityService = null,
             IPersistentProcessRuleStore? persistentRuleStore = null,
             Action<string>? clipboardSetter = null,
@@ -253,6 +358,7 @@ namespace ThreadPilot.Core.Tests
                 coreMaskService.Object,
                 associationService.Object,
                 gameModeService.Object,
+                processAffinityApplyCoordinator: processAffinityApplyCoordinator,
                 memoryPriorityService: memoryPriorityService,
                 persistentRuleStore: persistentRuleStore,
                 persistentRuleMatcher: new PersistentProcessRuleMatcher(),

--- a/ViewModels/ProcessViewModel.Behaviors.partial.cs
+++ b/ViewModels/ProcessViewModel.Behaviors.partial.cs
@@ -728,11 +728,32 @@ namespace ThreadPilot.ViewModels
                 return;
             }
 
+            await this.ApplyAffinityToProcessAsync(selectedProcess, "Manual Process tab CPU selection");
+        }
+
+        [RelayCommand]
+        private async Task ApplyContextAffinity(ProcessModel? process)
+        {
+            if (process == null)
+            {
+                return;
+            }
+
+            if (!ReferenceEquals(this.SelectedProcess, process))
+            {
+                this.SelectedProcess = process;
+            }
+
+            await this.ApplyAffinityToProcessAsync(process, "Manual Process tab context menu CPU selection");
+        }
+
+        private async Task ApplyAffinityToProcessAsync(ProcessModel selectedProcess, string selectionReason)
+        {
             try
             {
                 var pendingSelection = this.GetPendingCoreSelectionMask();
 
-                await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
+                await InvokeOnUiAsync(() =>
                 {
                     this.SetStatus($"Setting affinity for {selectedProcess.Name}...");
                 });
@@ -740,9 +761,9 @@ namespace ThreadPilot.ViewModels
                 var result = await this.processAffinityApplyCoordinator.ApplyCoreSelectionAsync(
                     selectedProcess,
                     pendingSelection,
-                    "Manual Process tab CPU selection");
+                    selectionReason);
 
-                await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
+                await InvokeOnUiAsync(() =>
                 {
                     if (!result.UsedCpuSets)
                     {
@@ -789,13 +810,15 @@ namespace ThreadPilot.ViewModels
                         _ = this.notificationService.ShowNotificationAsync("Affinity error", result.Message, NotificationType.Error);
                     }
                 });
+
+                await this.UpdateSelectedProcessSummaryAsync(selectedProcess);
             }
             catch (Exception ex)
             {
                 var friendly = ex.Message;
                 _ = this.notificationService.ShowNotificationAsync("Affinity error", friendly, NotificationType.Error);
 
-                await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
+                await InvokeOnUiAsync(() =>
                 {
                     this.SetCriticalStatus($"Error setting affinity: {friendly}");
                 });
@@ -808,7 +831,7 @@ namespace ThreadPilot.ViewModels
                         await this.processService.RefreshProcessInfo(this.SelectedProcess);
                     }
 
-                    await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
+                    await InvokeOnUiAsync(() =>
                     {
                         if (this.SelectedProcess != null)
                         {
@@ -821,14 +844,28 @@ namespace ThreadPilot.ViewModels
                 {
                     // Process may have terminated
                 }
+
+                await this.UpdateSelectedProcessSummaryAsync(selectedProcess);
             }
             finally
             {
-                await System.Windows.Application.Current.Dispatcher.InvokeAsync(() =>
+                await InvokeOnUiAsync(() =>
                 {
                     this.ClearStatus();
                 });
             }
+        }
+
+        private static Task InvokeOnUiAsync(Action action)
+        {
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher == null || dispatcher.CheckAccess())
+            {
+                action();
+                return Task.CompletedTask;
+            }
+
+            return dispatcher.InvokeAsync(action).Task;
         }
 
         [RelayCommand]

--- a/ViewModels/ProcessViewModel.Behaviors.partial.cs
+++ b/ViewModels/ProcessViewModel.Behaviors.partial.cs
@@ -20,7 +20,9 @@ namespace ThreadPilot.ViewModels
     using System.Collections.ObjectModel;
     using System.ComponentModel;
     using System.Diagnostics;
+    using System.IO;
     using System.Linq;
+    using System.Text;
     using System.Threading.Tasks;
     using System.Windows.Input;
     using CommunityToolkit.Mvvm.ComponentModel;
@@ -179,8 +181,13 @@ namespace ThreadPilot.ViewModels
         private void UpdateSelectedProcessSummary(ProcessModel? process)
         {
             TaskSafety.FireAndForget(
-                this.SelectedProcessSummary.UpdateAsync(process, this.StatusMessage, this.HasError),
+                this.UpdateSelectedProcessSummaryAsync(process),
                 ex => this.Logger.LogWarning(ex, "Failed to update selected process summary"));
+        }
+
+        private Task UpdateSelectedProcessSummaryAsync(ProcessModel? process)
+        {
+            return this.SelectedProcessSummary.UpdateAsync(process, this.StatusMessage, this.HasError);
         }
 
         private async Task HandleSelectedProcessChangedAsync(ProcessModel value)
@@ -1252,6 +1259,285 @@ namespace ThreadPilot.ViewModels
             {
                 await System.Windows.Application.Current.Dispatcher.InvokeAsync(this.ClearStatus);
             }
+        }
+
+        [RelayCommand]
+        private Task SetContextBelowNormalPriority(ProcessModel? process) =>
+            this.SetContextCpuPriorityAsync(process, ProcessPriorityClass.BelowNormal);
+
+        [RelayCommand]
+        private Task SetContextNormalPriority(ProcessModel? process) =>
+            this.SetContextCpuPriorityAsync(process, ProcessPriorityClass.Normal);
+
+        [RelayCommand]
+        private Task SetContextAboveNormalPriority(ProcessModel? process) =>
+            this.SetContextCpuPriorityAsync(process, ProcessPriorityClass.AboveNormal);
+
+        [RelayCommand]
+        private Task SetContextHighPriority(ProcessModel? process) =>
+            this.SetContextCpuPriorityAsync(process, ProcessPriorityClass.High);
+
+        [RelayCommand]
+        private Task SetContextMemoryPriorityVeryLow(ProcessModel? process) =>
+            this.SetContextMemoryPriorityAsync(process, ProcessMemoryPriority.VeryLow);
+
+        [RelayCommand]
+        private Task SetContextMemoryPriorityLow(ProcessModel? process) =>
+            this.SetContextMemoryPriorityAsync(process, ProcessMemoryPriority.Low);
+
+        [RelayCommand]
+        private Task SetContextMemoryPriorityMedium(ProcessModel? process) =>
+            this.SetContextMemoryPriorityAsync(process, ProcessMemoryPriority.Medium);
+
+        [RelayCommand]
+        private Task SetContextMemoryPriorityBelowNormal(ProcessModel? process) =>
+            this.SetContextMemoryPriorityAsync(process, ProcessMemoryPriority.BelowNormal);
+
+        [RelayCommand]
+        private Task SetContextMemoryPriorityNormal(ProcessModel? process) =>
+            this.SetContextMemoryPriorityAsync(process, ProcessMemoryPriority.Normal);
+
+        [RelayCommand]
+        private async Task ClearContextCpuSets(ProcessModel? process)
+        {
+            if (process == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var success = await this.processService.ClearProcessCpuSetAsync(process);
+                if (!success)
+                {
+                    this.SetContextError(ProcessOperationUserMessages.AccessDenied);
+                    await this.UpdateSelectedProcessSummaryAsync(process);
+                    return;
+                }
+
+                await this.processService.RefreshProcessInfo(process);
+                this.SetStatus($"CPU Sets cleared for {process.Name}.", false);
+                await this.UpdateSelectedProcessSummaryAsync(process);
+            }
+            catch (Exception ex)
+            {
+                this.SetContextError(MapProcessOperationException(ex));
+                await this.TryRefreshContextProcessSummaryAsync(process);
+            }
+        }
+
+        [RelayCommand]
+        private async Task RefreshContextProcessInfo(ProcessModel? process)
+        {
+            if (process == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await this.processService.RefreshProcessInfo(process);
+                this.SetStatus($"Process info refreshed for {process.Name}.", false);
+                await this.UpdateSelectedProcessSummaryAsync(process);
+            }
+            catch (Exception ex)
+            {
+                this.SetContextError(MapProcessOperationException(ex));
+                await this.TryRefreshContextProcessSummaryAsync(process);
+            }
+        }
+
+        [RelayCommand]
+        private async Task OpenContextExecutableLocation(ProcessModel? process)
+        {
+            if (process == null)
+            {
+                return;
+            }
+
+            var path = process.ExecutablePath;
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                this.SetContextError($"Executable path is unavailable for {process.Name}.");
+                await this.UpdateSelectedProcessSummaryAsync(process);
+                return;
+            }
+
+            try
+            {
+                this.executableLocationOpener(path);
+                this.SetStatus($"Opened executable location for {process.Name}.", false);
+                await this.UpdateSelectedProcessSummaryAsync(process);
+            }
+            catch (Exception ex)
+            {
+                this.SetContextError($"Could not open executable location: {ex.Message}");
+                await this.UpdateSelectedProcessSummaryAsync(process);
+            }
+        }
+
+        [RelayCommand]
+        private async Task CopyContextProcessInfo(ProcessModel? process)
+        {
+            if (process == null)
+            {
+                return;
+            }
+
+            await this.UpdateSelectedProcessSummaryAsync(process);
+
+            var path = string.IsNullOrWhiteSpace(process.ExecutablePath)
+                ? "unavailable"
+                : process.ExecutablePath;
+            var builder = new StringBuilder()
+                .AppendLine($"Name: {process.Name}")
+                .AppendLine($"PID: {process.ProcessId}")
+                .AppendLine($"Path: {path}")
+                .AppendLine($"CPU priority: {process.Priority}")
+                .AppendLine($"Memory priority: {this.SelectedProcessSummary.MemoryPriority?.ToString() ?? "unavailable"}")
+                .AppendLine($"Affinity: 0x{process.ProcessorAffinity:X}")
+                .AppendLine($"Rule status: {this.SelectedProcessSummary.RuleStatusText}");
+
+            try
+            {
+                this.clipboardSetter(builder.ToString().TrimEnd());
+                this.SetStatus($"Copied process info for {process.Name}.", false);
+                await this.UpdateSelectedProcessSummaryAsync(process);
+            }
+            catch (Exception ex)
+            {
+                this.SetContextError($"Could not copy process info: {ex.Message}");
+                await this.UpdateSelectedProcessSummaryAsync(process);
+            }
+        }
+
+        private async Task SetContextCpuPriorityAsync(ProcessModel? process, ProcessPriorityClass priority)
+        {
+            if (process == null)
+            {
+                return;
+            }
+
+            if (ProcessPriorityGuardrails.IsBlocked(priority))
+            {
+                this.SetContextError(ProcessOperationUserMessages.RealtimePriorityBlocked);
+                await this.UpdateSelectedProcessSummaryAsync(process);
+                return;
+            }
+
+            try
+            {
+                await this.processService.SetProcessPriority(process, priority);
+                await this.processService.RefreshProcessInfo(process);
+
+                var warning = ProcessPriorityGuardrails.GetWarning(priority);
+                if (!string.IsNullOrWhiteSpace(warning))
+                {
+                    this.SetCriticalStatus(warning);
+                    _ = this.notificationService.ShowNotificationAsync("Priority warning", warning, NotificationType.Warning);
+                }
+                else
+                {
+                    this.SetStatus($"Priority applied successfully to {process.Name}: {priority}.", false);
+                    _ = this.notificationService.ShowNotificationAsync("Priority applied", $"{process.Name}: {priority}", NotificationType.Success);
+                }
+
+                await this.UpdateSelectedProcessSummaryAsync(process);
+            }
+            catch (Exception ex)
+            {
+                var message = MapProcessOperationException(ex);
+                this.SetContextError(message);
+                _ = this.notificationService.ShowNotificationAsync("Priority blocked", message, NotificationType.Warning);
+                await this.TryRefreshContextProcessSummaryAsync(process);
+            }
+        }
+
+        private async Task SetContextMemoryPriorityAsync(ProcessModel? process, ProcessMemoryPriority priority)
+        {
+            if (process == null)
+            {
+                return;
+            }
+
+            if (this.memoryPriorityService == null)
+            {
+                this.SetContextError("Memory priority is unavailable on this system.");
+                await this.UpdateSelectedProcessSummaryAsync(process);
+                return;
+            }
+
+            try
+            {
+                var result = await this.memoryPriorityService.SetMemoryPriorityAsync(process, priority);
+                if (!result.Success)
+                {
+                    this.SetContextError(string.IsNullOrWhiteSpace(result.UserMessage)
+                        ? ProcessOperationUserMessages.AccessDenied
+                        : result.UserMessage);
+                    await this.UpdateSelectedProcessSummaryAsync(process);
+                    return;
+                }
+
+                this.SetStatus($"Memory priority applied successfully to {process.Name}: {priority}.", false);
+                await this.UpdateSelectedProcessSummaryAsync(process);
+            }
+            catch (Exception ex)
+            {
+                this.SetContextError(MapProcessOperationException(ex));
+                await this.UpdateSelectedProcessSummaryAsync(process);
+            }
+        }
+
+        private async Task TryRefreshContextProcessSummaryAsync(ProcessModel process)
+        {
+            try
+            {
+                await this.processService.RefreshProcessInfo(process);
+            }
+            catch
+            {
+                // The selected process may have exited or become inaccessible; keep the safe user message.
+            }
+
+            await this.UpdateSelectedProcessSummaryAsync(process);
+        }
+
+        private void SetContextError(string message)
+        {
+            this.SetStatus(message, false);
+            this.SetError(message);
+        }
+
+        private static string MapProcessOperationException(Exception exception)
+        {
+            var message = exception.Message ?? string.Empty;
+            if (message.Contains("Realtime priority", StringComparison.OrdinalIgnoreCase))
+            {
+                return ProcessOperationUserMessages.RealtimePriorityBlocked;
+            }
+
+            if (message.Contains("anti-cheat", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("protected", StringComparison.OrdinalIgnoreCase))
+            {
+                return ProcessOperationUserMessages.AntiCheatProtectedLikely;
+            }
+
+            if (message.Contains("exited", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("terminated", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("no longer exists", StringComparison.OrdinalIgnoreCase))
+            {
+                return ProcessOperationUserMessages.ProcessExited;
+            }
+
+            if (exception is UnauthorizedAccessException ||
+                message.Contains("access denied", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("denied", StringComparison.OrdinalIgnoreCase))
+            {
+                return ProcessOperationUserMessages.AccessDenied;
+            }
+
+            return string.IsNullOrWhiteSpace(message) ? ProcessOperationUserMessages.AccessDenied : message;
         }
 
         [RelayCommand]

--- a/ViewModels/ProcessViewModel.cs
+++ b/ViewModels/ProcessViewModel.cs
@@ -17,6 +17,7 @@
 namespace ThreadPilot.ViewModels
 {
     using System;
+    using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.ComponentModel;
     using System.Diagnostics;
@@ -46,6 +47,9 @@ namespace ThreadPilot.ViewModels
         private readonly IGameModeService gameModeService;
         private readonly IAffinityApplyService affinityApplyService;
         private readonly IProcessAffinityApplyCoordinator processAffinityApplyCoordinator;
+        private readonly IProcessMemoryPriorityService? memoryPriorityService;
+        private readonly Action<string> clipboardSetter;
+        private readonly Action<string> executableLocationOpener;
         private System.Timers.Timer? refreshTimer;
         private bool isUiRefreshPaused;
         private bool isProcessViewActive = true;
@@ -183,7 +187,9 @@ namespace ThreadPilot.ViewModels
             IEnhancedLoggingService? enhancedLoggingService = null,
             IProcessMemoryPriorityService? memoryPriorityService = null,
             IPersistentProcessRuleStore? persistentRuleStore = null,
-            IPersistentProcessRuleMatcher? persistentRuleMatcher = null)
+            IPersistentProcessRuleMatcher? persistentRuleMatcher = null,
+            Action<string>? clipboardSetter = null,
+            Action<string>? executableLocationOpener = null)
             : base(logger, enhancedLoggingService)
         {
             this.processService = processService ?? throw new ArgumentNullException(nameof(processService));
@@ -205,6 +211,9 @@ namespace ThreadPilot.ViewModels
                 cpuTopologyProvider,
                 new CpuSelectionMigrationService(),
                 NullLogger<ProcessAffinityApplyCoordinator>.Instance);
+            this.memoryPriorityService = memoryPriorityService;
+            this.clipboardSetter = clipboardSetter ?? System.Windows.Clipboard.SetText;
+            this.executableLocationOpener = executableLocationOpener ?? OpenExecutableLocationInExplorer;
             this.SelectedProcessSummary = new SelectedProcessSummaryViewModel(
                 memoryPriorityService,
                 persistentRuleStore,
@@ -231,6 +240,26 @@ namespace ThreadPilot.ViewModels
             // Note: InitializeAsync() will be called explicitly by MainWindow loading overlay
         }
 
+        public IReadOnlyList<ProcessPriorityClass> ContextMenuCpuPriorityActions { get; } =
+        [
+            ProcessPriorityClass.BelowNormal,
+            ProcessPriorityClass.Normal,
+            ProcessPriorityClass.AboveNormal,
+            ProcessPriorityClass.High,
+        ];
+
         public SelectedProcessSummaryViewModel SelectedProcessSummary { get; }
+
+        private static void OpenExecutableLocationInExplorer(string executablePath)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "explorer.exe",
+                Arguments = $"/select,\"{executablePath}\"",
+                UseShellExecute = true,
+            };
+
+            Process.Start(startInfo);
+        }
     }
 }

--- a/Views/ProcessView.xaml
+++ b/Views/ProcessView.xaml
@@ -150,7 +150,8 @@
                                     <Setter.Value>
                                         <ContextMenu DataContext="{Binding PlacementTarget.Tag, RelativeSource={RelativeSource Self}}">
                                             <MenuItem Header="Apply Affinity"
-                                                      Command="{Binding SetAffinityCommand}"/>
+                                                      Command="{Binding ApplyContextAffinityCommand}"
+                                                      CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                             <MenuItem Header="Clear CPU Sets"
                                                       Command="{Binding ClearContextCpuSetsCommand}"
                                                       CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>

--- a/Views/ProcessView.xaml
+++ b/Views/ProcessView.xaml
@@ -142,6 +142,69 @@
                               ScrollViewer.CanContentScroll="True"
                               AutomationProperties.Name="Running process list"
                               AutomationProperties.HelpText="Virtualized process table with sorting and selection">
+                        <DataGrid.RowStyle>
+                            <Style TargetType="DataGridRow">
+                                <Setter Property="Tag" Value="{Binding DataContext, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                                <EventSetter Event="PreviewMouseRightButtonDown" Handler="ProcessRow_PreviewMouseRightButtonDown"/>
+                                <Setter Property="ContextMenu">
+                                    <Setter.Value>
+                                        <ContextMenu DataContext="{Binding PlacementTarget.Tag, RelativeSource={RelativeSource Self}}">
+                                            <MenuItem Header="Apply Affinity"
+                                                      Command="{Binding SetAffinityCommand}"/>
+                                            <MenuItem Header="Clear CPU Sets"
+                                                      Command="{Binding ClearContextCpuSetsCommand}"
+                                                      CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                            <Separator/>
+                                            <MenuItem Header="Set CPU Priority">
+                                                <MenuItem Header="Below Normal"
+                                                          Command="{Binding SetContextBelowNormalPriorityCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                <MenuItem Header="Normal"
+                                                          Command="{Binding SetContextNormalPriorityCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                <MenuItem Header="Above Normal"
+                                                          Command="{Binding SetContextAboveNormalPriorityCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                <MenuItem Header="High"
+                                                          Command="{Binding SetContextHighPriorityCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                <MenuItem Header="Realtime (blocked)"
+                                                          IsEnabled="False"
+                                                          ToolTipService.ShowOnDisabled="True"
+                                                          ToolTip="Realtime priority is blocked by ThreadPilot because it can make Windows unstable or unresponsive."/>
+                                            </MenuItem>
+                                            <MenuItem Header="Set Memory Priority">
+                                                <MenuItem Header="Very Low"
+                                                          Command="{Binding SetContextMemoryPriorityVeryLowCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                <MenuItem Header="Low"
+                                                          Command="{Binding SetContextMemoryPriorityLowCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                <MenuItem Header="Medium"
+                                                          Command="{Binding SetContextMemoryPriorityMediumCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                <MenuItem Header="Below Normal"
+                                                          Command="{Binding SetContextMemoryPriorityBelowNormalCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                <MenuItem Header="Normal"
+                                                          Command="{Binding SetContextMemoryPriorityNormalCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                            </MenuItem>
+                                            <Separator/>
+                                            <MenuItem Header="Open Executable Location"
+                                                      Command="{Binding OpenContextExecutableLocationCommand}"
+                                                      CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                            <MenuItem Header="Copy Process Info"
+                                                      Command="{Binding CopyContextProcessInfoCommand}"
+                                                      CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                            <MenuItem Header="Refresh Process Info"
+                                                      Command="{Binding RefreshContextProcessInfoCommand}"
+                                                      CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                        </ContextMenu>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </DataGrid.RowStyle>
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="160"/>
                             <DataGridTextColumn Header="ID" Binding="{Binding ProcessId}" Width="70"/>

--- a/Views/ProcessView.xaml.cs
+++ b/Views/ProcessView.xaml.cs
@@ -17,6 +17,7 @@
 namespace ThreadPilot.Views
 {
     using System.Windows.Controls;
+    using System.Windows.Input;
     using ThreadPilot.Helpers;
     using ThreadPilot.ViewModels;
 
@@ -26,6 +27,17 @@ namespace ThreadPilot.Views
         {
             this.InitializeComponent();
             this.DataContext = ServiceProviderExtensions.GetService<ProcessViewModel>();
+        }
+
+        private void ProcessRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is not DataGridRow row)
+            {
+                return;
+            }
+
+            row.IsSelected = true;
+            row.Focus();
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a lightweight right-click context menu to the Process tab process list. The menu reuses existing safe ViewModel and service paths for affinity, CPU Sets clearing, CPU priority, memory priority, process info refresh, opening executable location, and copying process details.

## Changes

- Adds a DataGrid row context menu for Process tab process rows.
- Wires Apply Affinity through a row-specific `ApplyContextAffinityCommand` that selects the row process and delegates to `IProcessAffinityApplyCoordinator.ApplyCoreSelectionAsync`.
- Wires CPU priority actions to `IProcessService.SetProcessPriority` guardrails, with Realtime shown disabled and High retaining the existing warning behavior.
- Wires memory priority actions to `IProcessMemoryPriorityService.SetMemoryPriorityAsync` with safe user-message failures.
- Adds safe selected-process summary refresh after context actions.
- Adds open executable location validation and copy-process-info clipboard support.
- Adds ViewModel tests for the menu-backed commands and confirms context actions do not create persistent rules.

## Validation

- `dotnet test "ThreadPilot_1.sln" --configuration Release --no-restore`
- Result: Passed, 328 passed, 0 failed, 0 skipped.

## Notes

No version bump, tag, release notes, persistent rule creation, rules editing UI, save-as-rule flow, affinity core logic, memory-priority backend logic, diagnostics changes, or Process tab redesign are included.