### PR TITLE
Update Chocolatey package for ThreadPilot 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Release](https://img.shields.io/github/v/release/PrimeBuild-pc/ThreadPilot?sort=semver)](https://github.com/PrimeBuild-pc/ThreadPilot/releases)
 [![Downloads](https://img.shields.io/github/downloads/PrimeBuild-pc/ThreadPilot/latest/total?label=latest%20downloads&logo=github)](https://github.com/PrimeBuild-pc/ThreadPilot/releases/latest)
 [![winget](https://img.shields.io/winget/v/PrimeBuild.ThreadPilot?label=winget)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/p/PrimeBuild/ThreadPilot)
+[![Chocolatey](https://img.shields.io/chocolatey/v/threadpilot?label=chocolatey)](https://community.chocolatey.org/packages/threadpilot)
 [![Windows](https://img.shields.io/badge/Windows-11-blue?logo=windows)](https://www.microsoft.com/windows)
 [![.NET](https://img.shields.io/badge/.NET-8.0-512BD4?logo=dotnet&logoColor=white)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-AGPLv3-blue.svg)](LICENSE)
@@ -62,6 +63,20 @@ To refresh your local WinGet source first:
 ```cmd
 winget source update
 winget search ThreadPilot
+```
+
+### Install with Chocolatey
+
+Install ThreadPilot from Chocolatey Community:
+
+```powershell
+choco install threadpilot
+```
+
+Upgrade an existing installation:
+
+```powershell
+choco upgrade threadpilot
 ```
 
 ### Download from GitHub Releases

--- a/chocolatey/tools/VERIFICATION.txt
+++ b/chocolatey/tools/VERIFICATION.txt
@@ -1,0 +1,17 @@
+VERIFICATION
+
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+ThreadPilot release:
+https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.4.0
+
+Installer:
+https://github.com/PrimeBuild-pc/ThreadPilot/releases/download/v1.4.0/ThreadPilot_v1.4.0_Setup.exe
+
+Download the installer, then calculate its SHA256 checksum with PowerShell:
+
+Get-FileHash .\ThreadPilot_v1.4.0_Setup.exe -Algorithm SHA256
+
+Expected SHA256:
+3280bb39258d6bc9d16537f07f0ed1017f9d67b675c62c8b86d53c9d8a4a1ad5

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -2,9 +2,9 @@ $ErrorActionPreference = 'Stop'
 
 $packageName = 'threadpilot'
 $toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-# Installer URL and checksum for ThreadPilot v1.1.2
-$url64 = 'https://github.com/PrimeBuild-pc/ThreadPilot/releases/download/v1.1.2/ThreadPilot_v1.1.2_Setup.exe'
-$checksum64 = '326864ead100edd134f3a41f5d4631fcb1fdf6a689101bb0c2d4b7330b9cf032'
+# Installer URL and checksum for ThreadPilot v1.4.0
+$url64 = 'https://github.com/PrimeBuild-pc/ThreadPilot/releases/download/v1.4.0/ThreadPilot_v1.4.0_Setup.exe'
+$checksum64 = '3280bb39258d6bc9d16537f07f0ed1017f9d67b675c62c8b86d53c9d8a4a1ad5'
 
 $packageArgs = @{
     packageName    = $packageName


### PR DESCRIPTION
- Updates Chocolatey packaging for ThreadPilot 1.4.0
- Adds Chocolatey install instructions to README
- Updates installer URL, SHA256 checksum, and verification notes
- Local validation passed
- Chocolatey push succeeded; package is awaiting automated checks/moderation