### PR TITLE
Reduce foreground and background runtime overhead

### DIFF
--- a/Services/PersistentProcessRuleJsonStore.cs
+++ b/Services/PersistentProcessRuleJsonStore.cs
@@ -17,6 +17,8 @@ namespace ThreadPilot.Services
 
         private readonly Func<string> filePathProvider;
         private readonly ILogger<PersistentProcessRuleJsonStore>? logger;
+        private readonly SemaphoreSlim cacheLock = new(1, 1);
+        private volatile IReadOnlyList<PersistentProcessRule>? cachedRules;
 
         public PersistentProcessRuleJsonStore(ILogger<PersistentProcessRuleJsonStore>? logger = null)
             : this(() => StoragePaths.PersistentRulesFilePath, logger)
@@ -33,25 +35,43 @@ namespace ThreadPilot.Services
 
         public async Task<IReadOnlyList<PersistentProcessRule>> LoadAsync()
         {
-            var filePath = this.filePathProvider();
-            this.logger?.LogDebug("Loading persistent process rules from {FilePath}", filePath);
-            if (!File.Exists(filePath))
+            if (this.cachedRules != null)
             {
-                this.logger?.LogDebug("Persistent process rules file does not exist at {FilePath}", filePath);
-                return [];
+                return this.cachedRules;
             }
 
+            await this.cacheLock.WaitAsync().ConfigureAwait(false);
             try
             {
-                var json = await File.ReadAllTextAsync(filePath).ConfigureAwait(false);
-                var rules = JsonSerializer.Deserialize<List<PersistentProcessRule>>(json, JsonOptions) ?? [];
-                this.logger?.LogDebug("Loaded {RuleCount} persistent process rules from {FilePath}", rules.Count, filePath);
-                return rules;
+                if (this.cachedRules != null)
+                {
+                    return this.cachedRules;
+                }
+
+                var filePath = this.filePathProvider();
+                this.logger?.LogDebug("Loading persistent process rules from {FilePath}", filePath);
+                if (!File.Exists(filePath))
+                {
+                    this.logger?.LogDebug("Persistent process rules file does not exist at {FilePath}", filePath);
+                    return this.cachedRules = [];
+                }
+
+                try
+                {
+                    var json = await File.ReadAllTextAsync(filePath).ConfigureAwait(false);
+                    var rules = JsonSerializer.Deserialize<List<PersistentProcessRule>>(json, JsonOptions) ?? [];
+                    this.logger?.LogDebug("Loaded {RuleCount} persistent process rules from {FilePath}", rules.Count, filePath);
+                    return this.cachedRules = rules.ToArray();
+                }
+                catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+                {
+                    this.logger?.LogWarning(ex, "Could not load persistent process rules from {FilePath}", filePath);
+                    return this.cachedRules = [];
+                }
             }
-            catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+            finally
             {
-                this.logger?.LogWarning(ex, "Could not load persistent process rules from {FilePath}", filePath);
-                return [];
+                this.cacheLock.Release();
             }
         }
 
@@ -59,18 +79,27 @@ namespace ThreadPilot.Services
         {
             ArgumentNullException.ThrowIfNull(rules);
 
-            var filePath = this.filePathProvider();
-            this.logger?.LogDebug("Saving {RuleCount} persistent process rules to {FilePath}", rules.Count, filePath);
+            await this.cacheLock.WaitAsync().ConfigureAwait(false);
             try
             {
-                var json = JsonSerializer.Serialize(rules, JsonOptions);
-                await AtomicFileWriter.WriteAllTextAsync(filePath, json).ConfigureAwait(false);
-                this.logger?.LogDebug("Saved {RuleCount} persistent process rules to {FilePath}", rules.Count, filePath);
+                var filePath = this.filePathProvider();
+                this.logger?.LogDebug("Saving {RuleCount} persistent process rules to {FilePath}", rules.Count, filePath);
+                try
+                {
+                    var json = JsonSerializer.Serialize(rules, JsonOptions);
+                    await AtomicFileWriter.WriteAllTextAsync(filePath, json).ConfigureAwait(false);
+                    this.cachedRules = rules.ToArray();
+                    this.logger?.LogDebug("Saved {RuleCount} persistent process rules to {FilePath}", rules.Count, filePath);
+                }
+                catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+                {
+                    this.logger?.LogError(ex, "Could not save {RuleCount} persistent process rules to {FilePath}", rules.Count, filePath);
+                    throw;
+                }
             }
-            catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+            finally
             {
-                this.logger?.LogError(ex, "Could not save {RuleCount} persistent process rules to {FilePath}", rules.Count, filePath);
-                throw;
+                this.cacheLock.Release();
             }
         }
     }

--- a/Services/PersistentRuleAutoApplyService.cs
+++ b/Services/PersistentRuleAutoApplyService.cs
@@ -4,6 +4,7 @@
 namespace ThreadPilot.Services
 {
     using System.Collections.Concurrent;
+    using System.IO;
     using Microsoft.Extensions.Logging;
     using ThreadPilot.Models;
 
@@ -86,6 +87,7 @@ namespace ThreadPilot.Services
         private readonly ILogger<PersistentRuleAutoApplyService> logger;
         private readonly IActivityAuditService? activityAuditService;
         private readonly IPersistentRulePriorityVerificationService? priorityVerificationService;
+        private readonly IProcessService? processService;
         private readonly Func<DateTimeOffset> nowProvider;
         private readonly TimeSpan cooldown;
         private readonly ConcurrentDictionary<RuleAttemptKey, DateTimeOffset> recentAttempts = new();
@@ -97,8 +99,9 @@ namespace ThreadPilot.Services
             IApplicationSettingsService settingsService,
             ILogger<PersistentRuleAutoApplyService> logger,
             IActivityAuditService? activityAuditService = null,
-            IPersistentRulePriorityVerificationService? priorityVerificationService = null)
-            : this(ruleStore, matcher, rulesEngine, settingsService, logger, () => DateTimeOffset.UtcNow, DefaultCooldown, activityAuditService, priorityVerificationService)
+            IPersistentRulePriorityVerificationService? priorityVerificationService = null,
+            IProcessService? processService = null)
+            : this(ruleStore, matcher, rulesEngine, settingsService, logger, () => DateTimeOffset.UtcNow, DefaultCooldown, activityAuditService, priorityVerificationService, processService)
         {
         }
 
@@ -111,7 +114,8 @@ namespace ThreadPilot.Services
             Func<DateTimeOffset> nowProvider,
             TimeSpan cooldown,
             IActivityAuditService? activityAuditService = null,
-            IPersistentRulePriorityVerificationService? priorityVerificationService = null)
+            IPersistentRulePriorityVerificationService? priorityVerificationService = null,
+            IProcessService? processService = null)
         {
             this.ruleStore = ruleStore ?? throw new ArgumentNullException(nameof(ruleStore));
             this.matcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
@@ -122,6 +126,7 @@ namespace ThreadPilot.Services
             this.cooldown = cooldown <= TimeSpan.Zero ? DefaultCooldown : cooldown;
             this.activityAuditService = activityAuditService;
             this.priorityVerificationService = priorityVerificationService;
+            this.processService = processService;
         }
 
         public async Task<IReadOnlyList<PersistentRuleAutoApplyResult>> ApplyForDiscoveredProcessesAsync(
@@ -190,8 +195,35 @@ namespace ThreadPilot.Services
             CancellationToken cancellationToken)
         {
             var now = this.nowProvider();
-            var candidates = rules
-                .Where(rule => rule.IsEnabled && this.matcher.IsMatch(rule, process))
+            var potentialRules = rules
+                .Where(rule => rule.IsEnabled && IsPotentialNameMatch(rule, process.Name))
+                .ToList();
+
+            if (potentialRules.Count == 0)
+            {
+                return Array.Empty<PersistentRuleAutoApplyResult>();
+            }
+
+            if (this.processService != null &&
+                string.IsNullOrWhiteSpace(process.ExecutablePath) &&
+                potentialRules.Any(rule => !string.IsNullOrWhiteSpace(rule.ExecutablePath)))
+            {
+                try
+                {
+                    await this.processService.RefreshProcessInfo(process).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    this.logger.LogDebug(
+                        ex,
+                        "Could not enrich process {ProcessName} (PID: {ProcessId}) for path-based persistent rule matching",
+                        process.Name,
+                        process.ProcessId);
+                }
+            }
+
+            var candidates = potentialRules
+                .Where(rule => this.matcher.IsMatch(rule, process))
                 .ToList();
 
             if (candidates.Count == 0)
@@ -392,6 +424,18 @@ namespace ThreadPilot.Services
 
         private bool IsEnabled() =>
             this.settingsService.Settings.ApplyPersistentRulesOnProcessStart;
+
+        private static bool IsPotentialNameMatch(PersistentProcessRule rule, string processName)
+        {
+            var candidateName = !string.IsNullOrWhiteSpace(rule.ProcessName)
+                ? rule.ProcessName
+                : Path.GetFileNameWithoutExtension(rule.ExecutablePath);
+            return !string.IsNullOrWhiteSpace(candidateName) &&
+                string.Equals(
+                    Path.GetFileNameWithoutExtension(candidateName.Trim()),
+                    Path.GetFileNameWithoutExtension(processName.Trim()),
+                    StringComparison.OrdinalIgnoreCase);
+        }
 
         private static bool IsProcessEligible(ProcessModel process) =>
             process.ProcessId > 0 && !string.IsNullOrWhiteSpace(process.Name);

--- a/Services/ProcessMonitorManagerService.cs
+++ b/Services/ProcessMonitorManagerService.cs
@@ -432,12 +432,11 @@ namespace ThreadPilot.Services
             try
             {
                 this.persistentRuleAutoApplyService.MarkProcessExited(e.Process.ProcessId);
+                this.coreMaskService.UnregisterMaskApplication(e.Process.ProcessId);
+                this.processService.UntrackProcess(e.Process.ProcessId);
 
                 if (this.runningAssociatedProcesses.TryRemove(e.Process.ProcessId, out _))
                 {
-                    this.coreMaskService.UnregisterMaskApplication(e.Process.ProcessId);
-                    this.processService.UntrackProcess(e.Process.ProcessId);
-
                     // Check if there are any other associated processes still running
                     var remainingProcesses = this.runningAssociatedProcesses.Values.ToList();
                     await this.DeterminePowerPlanAsync(remainingProcesses);

--- a/Services/ProcessMonitorManagerService.cs
+++ b/Services/ProcessMonitorManagerService.cs
@@ -346,13 +346,34 @@ namespace ThreadPilot.Services
 
             try
             {
-                await this.enhancedLogger.LogProcessMonitoringEventAsync(
-                    LogEventTypes.ProcessMonitoring.Started,
-                    e.Process.Name, e.Process.ProcessId, "Process started and detected by monitoring");
+                this.logger.LogDebug(
+                    "Process started: {ProcessName} (PID: {ProcessId})",
+                    e.Process.Name,
+                    e.Process.ProcessId);
 
                 await this.ApplyPersistentRulesForProcessStartAsync(e.Process);
 
-                var association = this.configuration.FindMatchingAssociation(e.Process);
+                var associationCandidates = this.configuration
+                    .GetEnabledAssociations()
+                    .Where(association => association.MatchesExecutable(e.Process.Name))
+                    .ToList();
+                if (associationCandidates.Count > 0)
+                {
+                    try
+                    {
+                        await this.processService.RefreshProcessInfo(e.Process);
+                    }
+                    catch (Exception ex)
+                    {
+                        this.logger.LogDebug(
+                            ex,
+                            "Could not enrich process {ProcessName} (PID: {ProcessId}) for association matching",
+                            e.Process.Name,
+                            e.Process.ProcessId);
+                    }
+                }
+
+                var association = associationCandidates.FirstOrDefault(candidate => candidate.MatchesProcess(e.Process));
                 if (association != null)
                 {
                     this.runningAssociatedProcesses[e.Process.ProcessId] = e.Process;

--- a/Services/ProcessMonitorService.cs
+++ b/Services/ProcessMonitorService.cs
@@ -3,7 +3,6 @@ namespace ThreadPilot.Services
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Management;
@@ -371,11 +370,11 @@ namespace ThreadPilot.Services
             });
         }
 
-        private async Task HandleProcessStartedAsync(EventArrivedEventArgs e)
+        private Task HandleProcessStartedAsync(EventArrivedEventArgs e)
         {
             if (!this.isMonitoring || this.IsDisposed)
             {
-                return;
+                return Task.CompletedTask;
             }
 
             try
@@ -383,11 +382,14 @@ namespace ThreadPilot.Services
                 var processId = Convert.ToInt32(e.NewEvent["ProcessID"]);
                 var processName = e.NewEvent["ProcessName"]?.ToString() ?? string.Empty;
 
-                // Get detailed process information
-                var process = await this.CreateProcessModelFromId(processId, processName).ConfigureAwait(false)
-                    ?? (!string.IsNullOrWhiteSpace(processName)
-                        ? new ProcessModel { ProcessId = processId, Name = NormalizeProcessName(processName) }
-                        : null);
+                var process = !string.IsNullOrWhiteSpace(processName)
+                    ? new ProcessModel
+                    {
+                        ProcessId = processId,
+                        Name = NormalizeProcessName(processName),
+                        Classification = ProcessClassification.Unknown,
+                    }
+                    : null;
 
                 if (process != null)
                 {
@@ -399,6 +401,8 @@ namespace ThreadPilot.Services
             {
                 this.OnMonitoringStatusChanged($"Error handling process start event: {ex.Message}", ex);
             }
+
+            return Task.CompletedTask;
         }
 
         private void OnProcessStopped(object sender, EventArrivedEventArgs e)
@@ -578,36 +582,6 @@ namespace ThreadPilot.Services
             finally
             {
                 Interlocked.Exchange(ref this.isWmiRecoveryInProgress, 0);
-            }
-        }
-
-        private async Task<ProcessModel?> CreateProcessModelFromId(int processId, string processName)
-        {
-            try
-            {
-                using var process = Process.GetProcessById(processId);
-                var normalizedName = !string.IsNullOrWhiteSpace(processName)
-                    ? NormalizeProcessName(processName)
-                    : NormalizeProcessName(process.ProcessName);
-
-                return new ProcessModel
-                {
-                    ProcessId = process.Id,
-                    Name = normalizedName,
-                    CpuUsage = 0,
-                    MemoryUsage = process.PrivateMemorySize64,
-                    Priority = process.PriorityClass,
-                    ProcessorAffinity = (long)process.ProcessorAffinity,
-                    MainWindowHandle = process.MainWindowHandle,
-                    MainWindowTitle = process.MainWindowTitle ?? string.Empty,
-                    HasVisibleWindow = process.MainWindowHandle != IntPtr.Zero && !string.IsNullOrWhiteSpace(process.MainWindowTitle),
-                    ExecutablePath = process.MainModule?.FileName ?? string.Empty,
-                };
-            }
-            catch (Exception ex)
-            {
-                this.logger?.LogDebug(ex, "Process {ProcessId} terminated before access", processId);
-                return null;
             }
         }
 

--- a/Services/ProcessService.cs
+++ b/Services/ProcessService.cs
@@ -110,15 +110,26 @@ namespace ThreadPilot.Services
         public async Task<ObservableCollection<ProcessModel>> GetProcessesAsync()
         {
             return await Task.Run(() =>
-            {
-                var foregroundProcessId = this.foregroundProcessService?.TryGetForegroundProcessId();
-                var processes = Process.GetProcesses()
-                    .Select(process => this.TryCreateProcessModel(process, foregroundProcessId))
-                    .OfType<ProcessModel>()
-                    .OrderBy(p => p.Name);
+                new ObservableCollection<ProcessModel>(this.EnumerateProcessModels())).ConfigureAwait(false);
+        }
 
-                return new ObservableCollection<ProcessModel>(processes);
-            }).ConfigureAwait(false);
+        private List<ProcessModel> EnumerateProcessModels(Func<ProcessModel, bool>? filter = null)
+        {
+            var foregroundProcessId = this.foregroundProcessService?.TryGetForegroundProcessId();
+            var models = new List<ProcessModel>();
+            foreach (var process in Process.GetProcesses())
+            {
+                using (process)
+                {
+                    var model = this.TryCreateProcessModel(process, foregroundProcessId);
+                    if (model != null && (filter == null || filter(model)))
+                    {
+                        models.Add(model);
+                    }
+                }
+            }
+
+            return models.OrderBy(process => process.Name).ToList();
         }
 
         private sealed class CpuSample
@@ -988,7 +999,7 @@ namespace ThreadPilot.Services
             {
                 try
                 {
-                    var process = Process.GetProcessById(processId);
+                    using var process = Process.GetProcessById(processId);
                     return this.CreateProcessModel(process);
                 }
                 catch
@@ -1000,20 +1011,29 @@ namespace ThreadPilot.Services
 
         public async Task<IEnumerable<ProcessModel>> GetProcessesByNameAsync(string executableName)
         {
-            return await Task.Run(() =>
+            return await Task.Run<IEnumerable<ProcessModel>>(() =>
             {
                 try
                 {
                     var foregroundProcessId = this.foregroundProcessService?.TryGetForegroundProcessId();
-                    var processes = Process.GetProcessesByName(executableName)
-                        .Select(process => this.TryCreateProcessModel(process, foregroundProcessId))
-                        .OfType<ProcessModel>();
+                    var models = new List<ProcessModel>();
+                    foreach (var process in Process.GetProcessesByName(executableName))
+                    {
+                        using (process)
+                        {
+                            var model = this.TryCreateProcessModel(process, foregroundProcessId);
+                            if (model != null)
+                            {
+                                models.Add(model);
+                            }
+                        }
+                    }
 
-                    return processes;
+                    return models;
                 }
                 catch
                 {
-                    return Enumerable.Empty<ProcessModel>();
+                    return Array.Empty<ProcessModel>();
                 }
             }).ConfigureAwait(false);
         }
@@ -1026,32 +1046,15 @@ namespace ThreadPilot.Services
 
         public async Task<IEnumerable<ProcessModel>> GetProcessesWithPathsAsync()
         {
-            return await Task.Run(() =>
-            {
-                var foregroundProcessId = this.foregroundProcessService?.TryGetForegroundProcessId();
-                var processes = Process.GetProcesses()
-                    .Select(process => this.TryCreateProcessModel(process, foregroundProcessId))
-                    .OfType<ProcessModel>()
-                    .Where(p => !string.IsNullOrEmpty(p.ExecutablePath))
-                    .OrderBy(p => p.Name);
-
-                return processes;
-            }).ConfigureAwait(false);
+            return await Task.Run<IEnumerable<ProcessModel>>(() =>
+                this.EnumerateProcessModels(process => !string.IsNullOrEmpty(process.ExecutablePath))).ConfigureAwait(false);
         }
 
         public async Task<ObservableCollection<ProcessModel>> GetActiveApplicationsAsync()
         {
             return await Task.Run(() =>
-            {
-                var foregroundProcessId = this.foregroundProcessService?.TryGetForegroundProcessId();
-                var processes = Process.GetProcesses()
-                    .Select(process => this.TryCreateProcessModel(process, foregroundProcessId))
-                    .OfType<ProcessModel>()
-                    .Where(p => p.HasVisibleWindow)
-                    .OrderBy(p => p.Name);
-
-                return new ObservableCollection<ProcessModel>(processes);
-            }).ConfigureAwait(false);
+                new ObservableCollection<ProcessModel>(
+                    this.EnumerateProcessModels(process => process.HasVisibleWindow))).ConfigureAwait(false);
         }
 
         public async Task<bool> IsProcessStillRunning(ProcessModel process)
@@ -1060,8 +1063,8 @@ namespace ThreadPilot.Services
             {
                 try
                 {
-                    var p = Process.GetProcessById(process.ProcessId);
-                    return !p.HasExited;
+                    using var targetProcess = Process.GetProcessById(process.ProcessId);
+                    return !targetProcess.HasExited;
                 }
                 catch (ArgumentException)
                 {

--- a/Services/ProcessService.cs
+++ b/Services/ProcessService.cs
@@ -771,6 +771,11 @@ namespace ThreadPilot.Services
                     process.MainWindowHandle = p.MainWindowHandle;
                     process.MainWindowTitle = p.MainWindowTitle ?? string.Empty;
                     process.HasVisibleWindow = process.MainWindowHandle != IntPtr.Zero && !string.IsNullOrWhiteSpace(process.MainWindowTitle);
+                    if (string.IsNullOrWhiteSpace(process.ExecutablePath))
+                    {
+                        process.ExecutablePath = p.MainModule?.FileName ?? string.Empty;
+                    }
+
                     this.ApplyProcessClassification(
                         process,
                         this.foregroundProcessService?.TryGetForegroundProcessId(),

--- a/Tests/ThreadPilot.Core.Tests/PersistentProcessRuleJsonStoreTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/PersistentProcessRuleJsonStoreTests.cs
@@ -137,6 +137,74 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
+        public async Task LoadAsync_AfterFirstRead_ReturnsCachedSnapshot()
+        {
+            var filePath = CreateTemporaryFilePath();
+            var store = new PersistentProcessRuleJsonStore(() => filePath);
+
+            try
+            {
+                await store.SaveAsync([CreateRule("cached", "Cached.exe", ProcessPriorityClass.High)]);
+                var first = await store.LoadAsync();
+                await new PersistentProcessRuleJsonStore(() => filePath)
+                    .SaveAsync([CreateRule("external", "External.exe", ProcessPriorityClass.Normal)]);
+
+                var second = await store.LoadAsync();
+
+                Assert.Same(first, second);
+                Assert.Equal("cached", Assert.Single(second).Id);
+            }
+            finally
+            {
+                DeleteFile(filePath);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsync_AfterCachedLoad_UpdatesSnapshot()
+        {
+            var filePath = CreateTemporaryFilePath();
+            var store = new PersistentProcessRuleJsonStore(() => filePath);
+
+            try
+            {
+                await store.SaveAsync([CreateRule("first", "First.exe", ProcessPriorityClass.High)]);
+                _ = await store.LoadAsync();
+                await store.SaveAsync([CreateRule("second", "Second.exe", ProcessPriorityClass.AboveNormal)]);
+
+                Assert.Equal("second", Assert.Single(await store.LoadAsync()).Id);
+                Assert.Equal("second", Assert.Single(await new PersistentProcessRuleJsonStore(() => filePath).LoadAsync()).Id);
+            }
+            finally
+            {
+                DeleteFile(filePath);
+            }
+        }
+
+        [Fact]
+        public async Task ConcurrentSaves_LeaveOneCompleteSnapshot()
+        {
+            var filePath = CreateTemporaryFilePath();
+            var store = new PersistentProcessRuleJsonStore(() => filePath);
+            var expectedIds = Enumerable.Range(0, 8).Select(index => $"rule-{index}").ToHashSet();
+
+            try
+            {
+                await Task.WhenAll(expectedIds.Select(id =>
+                    store.SaveAsync([CreateRule(id, $"{id}.exe", ProcessPriorityClass.High)])));
+
+                var cached = Assert.Single(await store.LoadAsync());
+                var persisted = Assert.Single(await new PersistentProcessRuleJsonStore(() => filePath).LoadAsync());
+                Assert.Contains(cached.Id, expectedIds);
+                Assert.Equal(cached.Id, persisted.Id);
+            }
+            finally
+            {
+                DeleteFile(filePath);
+            }
+        }
+
+        [Fact]
         public async Task LoadAsync_WithCorruptJson_ReturnsEmptyList()
         {
             var filePath = CreateTemporaryFilePath();

--- a/Tests/ThreadPilot.Core.Tests/PersistentRuleAutoApplyServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/PersistentRuleAutoApplyServiceTests.cs
@@ -127,6 +127,50 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
+        public async Task ApplyForProcessStartAsync_WhenNameCannotMatch_DoesNotEnrichProcess()
+        {
+            var process = CreateProcess("editor.exe");
+            process.ExecutablePath = string.Empty;
+            var rule = CreateRule(processName: "game.exe") with { ExecutablePath = @"C:\Games\Game.exe" };
+            var engine = CreateEngine(rule, CreateSuccess(rule, process));
+            var processService = new Mock<IProcessService>(MockBehavior.Strict);
+            var service = CreateService([rule], engine.Object, processService: processService.Object);
+
+            var results = await service.ApplyForProcessStartAsync(process);
+
+            Assert.Empty(results);
+            processService.Verify(
+                service => service.RefreshProcessInfo(It.IsAny<ProcessModel>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task ApplyForProcessStartAsync_WhenPathRuleNameMatches_EnrichesBeforeMatching()
+        {
+            var process = CreateProcess();
+            process.ExecutablePath = string.Empty;
+            var rule = CreateRule() with { ExecutablePath = @"C:\Games\Game.exe" };
+            var engine = CreateEngine(rule, CreateSuccess(rule, process));
+            var processService = new Mock<IProcessService>(MockBehavior.Strict);
+            processService
+                .Setup(service => service.RefreshProcessInfo(process))
+                .Callback(() => process.ExecutablePath = @"C:\Games\Game.exe")
+                .Returns(Task.CompletedTask);
+            var service = CreateService([rule], engine.Object, processService: processService.Object);
+
+            var results = await service.ApplyForProcessStartAsync(process);
+
+            Assert.Single(results);
+            processService.Verify(service => service.RefreshProcessInfo(process), Times.Once);
+            engine.Verify(
+                service => service.ApplyMatchingRulesAsync(
+                    process,
+                    It.IsAny<Predicate<PersistentProcessRule>?>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
         public async Task ApplyForProcessStartAsync_DoesNotReapplySameRuleDuringCooldown()
         {
             var now = DateTimeOffset.UtcNow;
@@ -440,7 +484,8 @@ namespace ThreadPilot.Core.Tests
             ApplicationSettingsModel? settings = null,
             Func<DateTimeOffset>? nowProvider = null,
             IActivityAuditService? audit = null,
-            IPersistentRulePriorityVerificationService? priorityVerifier = null) =>
+            IPersistentRulePriorityVerificationService? priorityVerifier = null,
+            IProcessService? processService = null) =>
             new(
                 new FakePersistentProcessRuleStore(rules),
                 new PersistentProcessRuleMatcher(),
@@ -450,7 +495,8 @@ namespace ThreadPilot.Core.Tests
                 nowProvider ?? (() => DateTimeOffset.UtcNow),
                 TimeSpan.FromSeconds(30),
                 audit,
-                priorityVerifier);
+                priorityVerifier,
+                processService);
 
         private static Mock<IPersistentRulesEngine> CreateEngine(
             PersistentProcessRule rule,

--- a/Tests/ThreadPilot.Core.Tests/ProcessMonitorManagerServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessMonitorManagerServiceTests.cs
@@ -682,6 +682,66 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
+        public async Task ProcessStarted_WithoutRelevantAssociation_DoesNotEnrichOrPersistEventLog()
+        {
+            var processMonitor = new FakeProcessMonitorService();
+            var configuration = new ProcessMonitorConfiguration();
+            var processService = CreateProcessService();
+            var enhancedLogger = CreateEnhancedLogger();
+            var manager = CreateService(
+                processMonitor,
+                CreateAssociationService(configuration),
+                CreatePowerPlanService(),
+                CreateNotificationService(),
+                processService,
+                CreateCoreMaskService(),
+                CreateAffinityApplyService(),
+                enhancedLogger: enhancedLogger);
+
+            await manager.StartAsync();
+            enhancedLogger.Invocations.Clear();
+            processMonitor.RaiseProcessStarted(new ProcessModel { ProcessId = 42, Name = "irrelevant" });
+            await Task.Delay(100);
+
+            processService.Verify(
+                service => service.RefreshProcessInfo(It.IsAny<ProcessModel>()),
+                Times.Never);
+            enhancedLogger.Verify(
+                logger => logger.LogProcessMonitoringEventAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task ProcessStopped_AlwaysClearsPidCaches()
+        {
+            var processMonitor = new FakeProcessMonitorService();
+            var processService = CreateProcessService();
+            var coreMaskService = CreateCoreMaskService();
+            var autoApplyService = CreateAutoApplyService();
+            var manager = CreateService(
+                processMonitor,
+                CreateAssociationService(new ProcessMonitorConfiguration()),
+                CreatePowerPlanService(),
+                CreateNotificationService(),
+                processService,
+                coreMaskService,
+                CreateAffinityApplyService(),
+                autoApplyService);
+
+            await manager.StartAsync();
+            processMonitor.RaiseProcessStopped(new ProcessModel { ProcessId = 73, Name = "short-lived" });
+            await Task.Delay(100);
+
+            autoApplyService.Verify(service => service.MarkProcessExited(73), Times.Once);
+            coreMaskService.Verify(service => service.UnregisterMaskApplication(73), Times.Once);
+            processService.Verify(service => service.UntrackProcess(73), Times.Once);
+        }
+
+        [Fact]
         public async Task Dispose_CompletesOnBlockingSynchronizationContext()
         {
             var processMonitor = new FakeProcessMonitorService
@@ -862,11 +922,7 @@ namespace ThreadPilot.Core.Tests
         {
             public event EventHandler<ProcessEventArgs>? ProcessStarted;
 
-            public event EventHandler<ProcessEventArgs>? ProcessStopped
-            {
-                add { }
-                remove { }
-            }
+            public event EventHandler<ProcessEventArgs>? ProcessStopped;
 
             public event EventHandler<MonitoringStatusEventArgs>? MonitoringStatusChanged
             {
@@ -916,6 +972,9 @@ namespace ThreadPilot.Core.Tests
 
             public void RaiseProcessStarted(ProcessModel process) =>
                 this.ProcessStarted?.Invoke(this, new ProcessEventArgs(process));
+
+            public void RaiseProcessStopped(ProcessModel process) =>
+                this.ProcessStopped?.Invoke(this, new ProcessEventArgs(process));
 
             public void Dispose()
             {

--- a/Tests/ThreadPilot.Core.Tests/ProcessServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessServiceTests.cs
@@ -348,6 +348,26 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
+        public async Task GetProcessesByNameAsync_ReturnsMaterializedModels()
+        {
+            var profilesDirectory = CreateTemporaryDirectory();
+            var service = CreateService(profilesDirectory);
+            using var currentProcess = Process.GetCurrentProcess();
+
+            try
+            {
+                var results = await service.GetProcessesByNameAsync(currentProcess.ProcessName);
+
+                var models = Assert.IsType<List<ProcessModel>>(results);
+                Assert.Contains(models, process => process.ProcessId == currentProcess.Id);
+            }
+            finally
+            {
+                DeleteDirectory(profilesDirectory);
+            }
+        }
+
+        [Fact]
         public void TrackPriorityChange_PreservesOriginalPriority()
         {
             var service = CreateService(CreateTemporaryDirectory());


### PR DESCRIPTION
## Summary

- cache persistent process-rule snapshots in RAM with serialized load/save access
- pre-match process-start events by name before path/full process enrichment
- stop persistent Information logging for irrelevant process starts
- dispose `System.Diagnostics.Process` handles and materialize process enumerations
- clear all PID-scoped runtime caches when any process exits

P0 only. This does not change power-plan refresh, ViewModel initialization, logging/WMI timers, version metadata, or persistent-priority verification/retry behavior from #32.

## Measurements

Release measurements used the same `WinX64-SingleFile` profile as the official workflow and identical one-second sampling scenarios.

| Scenario | Avg CPU before | Avg CPU after | Delta | Handles end | Handles max |
|---|---:|---:|---:|---:|---:|
| visible idle | 27.6748% | 30.0053% | +8.4% | 1705 → 1674 | 1767 → 1740 |
| hidden idle | 0.0878% | 0.0176% | -80.0% | 698 → 691 | 705 → 703 |
| hidden + 80 process churn | 0.2107% | 0.1404% | -33.4% | 691 → 687 | 707 → 703 |

Memory remained effectively flat in the targeted hidden scenarios (+0.4% working set hidden idle, +0.6% under churn). The visible run observed four extra existing `schtasks.exe`/power child commands (31 vs 27), so its CPU delta is noisy and outside P0's background process-start target.

## Validation

- Release build: 0 warnings, 0 errors
- 569/569 tests passed
- official-method single-file publish succeeded
- changed-file formatter verification passed
- NuGet vulnerability audit found no vulnerable packages
