### PR TITLE
Prepare v1.4.4 runtime efficiency release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ docs/superpowers/plans/
 /VALIDATION_NOTES*.md
 /PR*_VALIDATION*.md
 /CHOCOLATEY_MODERATOR_NOTICE*.md
+/IMPROVE_APP_PERFORMANCE_PLAN.md
+/PERFORMANCE_*.md
 
 # Test and coverage
 [Tt]est[Rr]esult*/

--- a/Installer/Installer.iss
+++ b/Installer/Installer.iss
@@ -5,7 +5,7 @@
 #define MyAppPublisher "ThreadPilot"
 #define MyAppURL "https://github.com/"
 #define MyAppExeName "ThreadPilot.exe"
-#define MyAppVersion "1.4.3"
+#define MyAppVersion "1.4.4"
 
 #ifndef MyWizardStyle
   #define MyWizardStyle "modern dynamic windows11"

--- a/Installer/ThreadPilot.wxs
+++ b/Installer/ThreadPilot.wxs
@@ -7,7 +7,7 @@
   <Package
       Name="ThreadPilot"
       Manufacturer="Prime Build"
-      Version="1.4.3.0"
+      Version="1.4.4.0"
       UpgradeCode="PUT-GENERATED-UPGRADE-CODE-HERE"
       Language="1033">
     <SummaryInformation Description="ThreadPilot MSI template" />

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -11,7 +11,7 @@
 #endif
 
 #ifndef MyAppVersion
-	#define MyAppVersion "1.4.3"
+	#define MyAppVersion "1.4.4"
 #endif
 
 #ifndef MyAppSourceDir

--- a/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
@@ -4,8 +4,8 @@ namespace ThreadPilot.Core.Tests
 
     public sealed partial class PackagingMetadataTests
     {
-        private const string ReleaseVersion = "1.4.3";
-        private const string ReleaseAssemblyVersion = "1.4.3.0";
+        private const string ReleaseVersion = "1.4.4";
+        private const string ReleaseAssemblyVersion = "1.4.4.0";
 
         [Fact]
         public void InnoInstallers_UseStableDisplayNameAndSeparateVersionMetadata()
@@ -73,7 +73,6 @@ namespace ThreadPilot.Core.Tests
             AssertFileContains(Path.Combine(root, "build", "build-release.ps1"), $"[string]$Version = \"{ReleaseVersion}\"");
             AssertFileContains(Path.Combine(root, "build", "build-installer.ps1"), $"[string]$Version = \"{ReleaseVersion}\"");
             AssertFileContains(Path.Combine(root, "build", "package-release-zips.ps1"), $"[string]$Version = \"{ReleaseVersion}\"");
-            Assert.True(File.Exists(Path.Combine(root, "docs", "releases", $"v{ReleaseVersion}.md")));
             AssertFileContains(Path.Combine(root, "docs", "release", "RELEASE_NOTES.md"), $"v{ReleaseVersion}");
         }
 
@@ -100,7 +99,7 @@ namespace ThreadPilot.Core.Tests
             throw new InvalidOperationException("Repository root could not be located.");
         }
 
-        [GeneratedRegex("#define MyAppVersion \"1\\.4\\.3\"", RegexOptions.CultureInvariant)]
+        [GeneratedRegex("#define MyAppVersion \"1\\.4\\.4\"", RegexOptions.CultureInvariant)]
         private static partial Regex MyAppVersionRegex();
     }
 }

--- a/ThreadPilot.csproj
+++ b/ThreadPilot.csproj
@@ -16,10 +16,10 @@
     <TrimMode>link</TrimMode>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1998;CS0067;CS0414;WFAC010;IL3000;MVVMTK0034</NoWarn>
-    <Version>1.4.3</Version>
-    <AssemblyVersion>1.4.3.0</AssemblyVersion>
-    <FileVersion>1.4.3.0</FileVersion>
-    <InformationalVersion>1.4.3</InformationalVersion>
+    <Version>1.4.4</Version>
+    <AssemblyVersion>1.4.4.0</AssemblyVersion>
+    <FileVersion>1.4.4.0</FileVersion>
+    <InformationalVersion>1.4.4</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.4.3.0" name="ThreadPilot.app"/>
+  <assemblyIdentity version="1.4.4.0" name="ThreadPilot.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.4.3",
+    [string]$Version = "1.4.4",
     [string]$Configuration = "Release",
     [switch]$SkipPublish
 )

--- a/build/build-release.ps1
+++ b/build/build-release.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.4.3",
+    [string]$Version = "1.4.4",
     [string]$Configuration = "Release",
     [string]$Runtime = "win-x64"
 )

--- a/build/package-release-zips.ps1
+++ b/build/package-release-zips.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.4.3"
+    [string]$Version = "1.4.4"
 )
 
 $ErrorActionPreference = "Stop"

--- a/chocolatey/threadpilot.nuspec
+++ b/chocolatey/threadpilot.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>threadpilot</id>
-    <version>1.4.3</version>
+    <version>1.4.4</version>
     <title>ThreadPilot</title>
     <authors>Prime Build</authors>
     <projectUrl>https://github.com/PrimeBuild-pc/ThreadPilot</projectUrl>
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Advanced Windows process and power plan manager with rules automation and performance controls.</description>
     <summary>ThreadPilot process and power plan manager.</summary>
-    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.4.3</releaseNotes>
+    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.4.4</releaseNotes>
     <tags>threadpilot process powerplan performance windows</tags>
   </metadata>
   <files>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project are documented in this file.
 
+## v1.4.4 - Runtime efficiency
+
+### Performance
+
+- Reduced background idle CPU by approximately 80-100% in measured tray scenarios.
+- Reduced CPU overhead during short-lived process churn by approximately 8%.
+- Reduced hidden working-set memory by approximately 4-5% and peak handle usage by approximately 12-13%.
+- Reduced external command launches during visible startup by approximately 85% (27 to 4 in the measured scenario).
+- Deferred inactive views, reused process snapshots and static metadata, and removed redundant `powercfg` calls.
+- Suspended hidden Log Viewer updates, made log flushing event-driven, and added bounded WMI recovery backoff.
+
+### Fixed
+
+- Persistent rules are cached without weakening process-start matching or CPU-priority verification and retry behavior.
+- Process handles and PID-scoped runtime state are consistently cleaned up.
+
 ## v1.4.3 - Expanded bundled power-plan catalog
 
 ### Added

--- a/docs/release/RELEASE_NOTES.md
+++ b/docs/release/RELEASE_NOTES.md
@@ -1,19 +1,38 @@
-## ThreadPilot v1.4.3
+## ThreadPilot v1.4.4
 
-Patch release expanding and validating ThreadPilot's bundled Windows power-plan catalog.
+Patch release focused on reducing ThreadPilot's foreground and background runtime overhead while preserving process automation and persistent CPU-priority verification.
 
-### Added
+### Measured improvements
 
-- Added 30 new bundled Windows power plans: 0 Synez Public Power, arsenha low latency, arsenha low latency (Intel Thread Director fix), AutoOS, BEYOND PERFORMANCE AMD+INTEL, Bitsum Highest Performance, cactusOS, FPSHEAVEN2026, GALA's ultimate performance (AMD), Gavot Performance, GTweaks Power Plan V3, imribiy2026, IrisFixed, JokrOS Power Plan, Jackpot2026, Kizzimo's Extreme Low Latency, KSOS11, melody LowestLatency, Microsoft High performance, Microsoft Ultimate Performance, Mitstas IDLE ENABLED, n1kobg GPU Booster Power Plan, Prodazin Power Plan, Reticle v2, RevisionPowerPlanV2.8, RIP Tweaks Power Plan, Rosca Tweaks v2, Velo's Power Plan, VTRL Optimized, and XNRL Pro Plan.
-- Added structural, discovery, duplicate, packaging, and invalid-file tests for bundled power plans.
+Compared with the official v1.4.3 build on the same system and using the same Release profile:
 
-### Changed
+- **Approximately 80-100% lower background idle CPU** in measured tray scenarios, reaching 0% in the final idle sample.
+- **Approximately 8% lower CPU overhead during process churn** with 80 short-lived processes.
+- **Approximately 4-5% lower hidden working-set memory**.
+- **Approximately 12-13% lower peak handle usage** while hidden.
+- **Approximately 85% fewer external command launches during visible startup**, reduced from 27 to 4.
 
-- Updated four existing bundled plans: IIIEXOIII LOW LATENCY, LLG parking/E-core fix, Slower, and xilly.
-- Removed a redundant duplicate Sazinho power-plan file.
-- Power-plan display-name parsing now preserves names containing parentheses.
+Results vary by hardware, Windows configuration, active page, and workload. The Process page remains intentionally more active while visible because it refreshes live process information.
+
+### Runtime changes
+
+- Cached persistent-rule snapshots in memory and pre-matched process starts before expensive enrichment.
+- Disposed process handles consistently and cleared PID-scoped caches on process exit.
+- Deferred initialization of inactive Power Plans, Rules, Settings, Tweaks, and Logs pages.
+- Reused the process monitor's initial snapshot and PID/start-time-validated static process metadata.
+- Parsed the active plan from a single `powercfg /list` call and limited periodic power-plan refresh to the visible Power Plans page.
+- Suspended Log Viewer collection updates while hidden and changed log flushing to one-shot scheduling.
+- Added WMI recovery backoff while preserving fallback polling reliability.
+
+### Compatibility and safety
+
+- Persistent rules, process start/stop tracking, and lazy diagnostics remain covered by regression tests.
+- CPU-priority verification and the bounded retry introduced for issue #32 are unchanged.
+- No default ThreadPilot affinity limit was enabled.
 
 ### Validation
 
-- Every changed `.pow` file was imported successfully with `powercfg` using a temporary GUID and then removed; the active Windows power plan remained unchanged.
-- Bundled assets are discovered automatically and copied to build, publish, portable ZIP, and installer output through the existing project and release workflow.
+- Release build completed with zero warnings and zero errors.
+- All 581 automated tests passed before release preparation.
+- CI and CodeQL passed for both performance pull requests.
+- NuGet dependency audit found no known vulnerable packages.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=threadpilot
 sonar.projectName=ThreadPilot
-sonar.projectVersion=1.4.3
+sonar.projectVersion=1.4.4
 
 sonar.sourceEncoding=UTF-8
 sonar.sources=.


### PR DESCRIPTION
## Summary

- bump application, installer, package, build, and analysis metadata to 1.4.4
- update changelog and release notes with measured runtime improvements
- ignore local performance planning Markdown instead of adding a new version-specific Markdown file

## Validation

- clean restore/build succeeded with 0 warnings and 0 errors
- 581/581 tests passed
- NuGet vulnerability audit found no vulnerable packages
- portable and installer builds succeeded
- portable ZIP contains all 89 power plans and no diagnostics
- executable reports FileVersion 1.4.4.0
