### PR TITLE
Add multilingual support

### DIFF
--- a/Helpers/NavigationBehavior.cs
+++ b/Helpers/NavigationBehavior.cs
@@ -43,7 +43,7 @@ namespace ThreadPilot.Helpers
             }
 
             var result = showUnsavedSettingsPromptAsync != null
-                ? await showUnsavedSettingsPromptAsync().ConfigureAwait(false)
+                ? await showUnsavedSettingsPromptAsync()
                 : MessageBox.Show(
                     "You have unsaved changes in Settings.\n\nChoose an action:\n- Yes: Save changes\n- No: Discard changes\n- Cancel: Stay on current tab",
                     "Unsaved Settings",
@@ -53,8 +53,8 @@ namespace ThreadPilot.Helpers
             return result switch
             {
                 MessageBoxResult.Cancel => false,
-                MessageBoxResult.Yes => await settingsViewModel.SaveIfDirtyAsync().ConfigureAwait(false),
-                MessageBoxResult.No => await DiscardPendingChangesAsync(settingsViewModel).ConfigureAwait(false),
+                MessageBoxResult.Yes => await settingsViewModel.SaveIfDirtyAsync(),
+                MessageBoxResult.No => await DiscardPendingChangesAsync(settingsViewModel),
                 _ => true,
             };
         }
@@ -66,7 +66,7 @@ namespace ThreadPilot.Helpers
 
         private static async Task<bool> DiscardPendingChangesAsync(SettingsViewModel settingsViewModel)
         {
-            await settingsViewModel.DiscardPendingChangesAsync().ConfigureAwait(false);
+            await settingsViewModel.DiscardPendingChangesAsync();
             return true;
         }
     }

--- a/Locales/de-DE.xaml
+++ b/Locales/de-DE.xaml
@@ -1,0 +1,665 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- MainWindow / General -->
+    <sys:String x:Key="MainWindow_Title">ThreadPilot – Prozess- und Energieplan-Manager</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningTitle">Administratorrechte empfohlen</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningDescription">ThreadPilot wird mit eingeschränkten Berechtigungen ausgeführt. Einige Funktionen sind möglicherweise nicht verfügbar.</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningRequired">Administratorzugriff ist erforderlich für:</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningPowerPlans">• Ändern der Energieplankonfigurationen</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningAffinity">• Ändern der Affinität und Priorität des Prozesses CPU</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningTweaks">• Anwenden von Optimierungen und Optimierungen auf Systemebene</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningProtected">• Verwalten geschützter Prozesse</sys:String>
+    <sys:String x:Key="MainWindow_ContinueWithoutElevation">Fahren Sie ohne Erhöhung fort</sys:String>
+    <sys:String x:Key="MainWindow_RequestElevation">Höhe anfordern</sys:String>
+
+    <!-- MainWindow Navigation -->
+    <sys:String x:Key="MainWindow_NavProcess">Prozessmanagement</sys:String>
+    <sys:String x:Key="MainWindow_NavMasks">CPU-Masken</sys:String>
+    <sys:String x:Key="MainWindow_NavPower">Energiepläne</sys:String>
+    <sys:String x:Key="MainWindow_NavRules">Regeln</sys:String>
+    <sys:String x:Key="MainWindow_NavDiagnostics">Diagnose</sys:String>
+    <sys:String x:Key="MainWindow_NavActivity">ThreadPilot-Aktivität</sys:String>
+    <sys:String x:Key="MainWindow_NavTweaks">Optimierungen</sys:String>
+    <sys:String x:Key="MainWindow_NavSettings">Einstellungen</sys:String>
+
+    <!-- MainWindow Overlays -->
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestionTitle">Start minimiert</sys:String>
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestionDescription">Aktivieren Sie „Start minimiert“, wenn ThreadPilot bei zukünftigen Windows-Anmeldungen automatisch in der Taskleiste gestartet werden soll.</sys:String>
+    <sys:String x:Key="MainWindow_Recommended">Empfohlen</sys:String>
+    <sys:String x:Key="MainWindow_DontShowAgain">Nicht mehr anzeigen</sys:String>
+    <sys:String x:Key="MainWindow_OpenSettings">Öffnen Sie Einstellungen</sys:String>
+    <sys:String x:Key="MainWindow_PrimaryNavigation">Primäre Navigation</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningOverlay">Warnung zur Rechteerhöhung</sys:String>
+    <sys:String x:Key="MainWindow_PerformanceIntroductionOverlay">Leistungseinführungs-Overlay</sys:String>
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestion">Vorschlag zum minimierten Start</sys:String>
+    <sys:String x:Key="MainWindow_UnsavedSettingsDialog">Dialogfeld „Nicht gespeicherte Einstellungen“.</sys:String>
+    <sys:String x:Key="MainWindow_LoadingOverlay">Overlay zum Laden der Anwendung beim Start</sys:String>
+
+    <!-- LogViewerView -->
+    <sys:String x:Key="LogViewerView_Title">ThreadPilot Aktivität</sys:String>
+    <sys:String x:Key="LogViewerView_Subtitle">Zeigt von ThreadPilot ausgeführte Aktionen an, einschließlich angewendeter Regeln, Affinitätsänderungen, Prioritätsänderungen, Energieplanänderungen, Einstellungsänderungen, Optimierungen, Optimierungen und Meldungen zu sicheren Fehlern.</sys:String>
+    <sys:String x:Key="LogViewerView_Search">Suche:</sys:String>
+    <sys:String x:Key="LogViewerView_CategoryLabel">Kategorie:</sys:String>
+    <sys:String x:Key="LogViewerView_LevelLabel">Ebene:</sys:String>
+    <sys:String x:Key="LogViewerView_From">Von:</sys:String>
+    <sys:String x:Key="LogViewerView_To">An:</sys:String>
+    <sys:String x:Key="LogViewerView_Refresh">Aktualisieren</sys:String>
+    <sys:String x:Key="LogViewerView_ClearDisplay">Anzeige leeren</sys:String>
+    <sys:String x:Key="LogViewerView_ExportActivity">Aktivität exportieren</sys:String>
+    <sys:String x:Key="LogViewerView_CleanupDiagnostics">Diagnosedateien bereinigen</sys:String>
+    <sys:String x:Key="LogViewerView_OpenFolder">Öffnen Sie den Diagnoseordner</sys:String>
+
+    <!-- LogViewerView Grid Headers -->
+    <sys:String x:Key="LogViewerView_HeaderTime">Zeit</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderStatus">Status</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderCategory">Kategorie</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderMessage">Nachricht</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderDetails">Details</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderId">ID</sys:String>
+    <sys:String x:Key="LogViewerView_ContextMenuCopy">Eintrag kopieren</sys:String>
+    <sys:String x:Key="LogViewerView_ContextMenuRefresh">Aktualisieren</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntries">Keine Protokolleinträge zum Anzeigen vorhanden</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntriesTip">Passen Sie Filter an oder aktualisieren Sie Protokolle, um aktuelle ThreadPilot-Aktivitäten zu laden.</sys:String>
+
+    <!-- LogViewerView Details -->
+    <sys:String x:Key="LogViewerView_DetailsTitle">Aktivitätsdetails</sys:String>
+    <sys:String x:Key="LogViewerView_Timestamp">Zeitstempel:</sys:String>
+    <sys:String x:Key="LogViewerView_Status">Status:</sys:String>
+    <sys:String x:Key="LogViewerView_Category">Kategorie:</sys:String>
+    <sys:String x:Key="LogViewerView_Message">Nachricht:</sys:String>
+    <sys:String x:Key="LogViewerView_Details">Einzelheiten:</sys:String>
+    <sys:String x:Key="LogViewerView_CorrelationId">Korrelations-ID:</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntrySelected">Kein Protokolleintrag ausgewählt</sys:String>
+    <sys:String x:Key="LogViewerView_Files">Dateien:</sys:String>
+    <sys:String x:Key="LogViewerView_Size">Größe:</sys:String>
+    <sys:String x:Key="LogViewerView_DebugDiagnostics">Debug-Diagnose</sys:String>
+    <sys:String x:Key="LogViewerView_MaxSize">Maximale Größe (MB):</sys:String>
+    <sys:String x:Key="LogViewerView_Retention">Aufbewahrung (Tage):</sys:String>
+    <sys:String x:Key="LogViewerView_SaveSettings">Einstellungen speichern</sys:String>
+
+    <!-- MasksView -->
+    <sys:String x:Key="MasksView_Title">CPU-Masken</sys:String>
+    <sys:String x:Key="MasksView_Subtitle">Erstellen Sie wiederverwendbare CPU-Affinitätsvoreinstellungen für die Verwendung pro Prozess.</sys:String>
+    <sys:String x:Key="MasksView_EditingClarification">Wenn Sie hier eine Maske auswählen, wird nur die Voreinstellung bearbeitet. Die Affinität von CPU wird erst geändert, wenn Sie sie auf einen Prozess anwenden oder in einer Prozessregel speichern.</sys:String>
+    <sys:String x:Key="MasksView_New">Neu</sys:String>
+    <sys:String x:Key="MasksView_Delete">Löschen</sys:String>
+    <sys:String x:Key="MasksView_Duplicate">Maske duplizieren</sys:String>
+    <sys:String x:Key="MasksView_Info">Maskeninformationen</sys:String>
+    <sys:String x:Key="MasksView_Name">Name:</sys:String>
+    <sys:String x:Key="MasksView_Description">Beschreibung:</sys:String>
+    <sys:String x:Key="MasksView_Enabled">Aktiviert</sys:String>
+    <sys:String x:Key="MasksView_DefaultPreset">Standardvoreinstellung</sys:String>
+    <sys:String x:Key="MasksView_DefaultPresetTip">Vorausgewählt, wenn ThreadPilot eine Fallback-Maske benötigt oder wenn Regeln pro Prozess erstellt werden. Die CPU-Affinität wird nicht automatisch angewendet.</sys:String>
+    <sys:String x:Key="MasksView_DisableTip">Deaktivieren Sie diese Option, um diese Maske vorübergehend auszublenden</sys:String>
+    <sys:String x:Key="MasksView_SelectCpus">CPUs auswählen</sys:String>
+    <sys:String x:Key="MasksView_SelectCpusTip">Schalten Sie CPUs um, um diese Maskenvoreinstellung zu bearbeiten. Änderungen werden automatisch gespeichert und haben keinen Einfluss auf laufende Prozesse. „Alle Kerne“ ist die geschützte Standardvoreinstellung.</sys:String>
+    <sys:String x:Key="MasksView_SavedAutomatically">Maskennamen, Beschreibungen, CPU-Auswahlen und Optionen werden automatisch gespeichert.</sys:String>
+    <sys:String x:Key="MasksView_CreateNewTooltip">Erstellen Sie eine neue CPU-Maske</sys:String>
+    <sys:String x:Key="MasksView_DeleteTooltip">Ausgewählte Maske löschen</sys:String>
+    <sys:String x:Key="MasksView_CpusHeader">CPUs</sys:String>
+    <sys:String x:Key="MasksView_Cpu">CPU</sys:String>
+    <sys:String x:Key="MasksView_Options">Maskenoptionen</sys:String>
+
+    <!-- PerformanceView -->
+    <sys:String x:Key="PerformanceView_OptionalDiagnostics">Optionale Diagnose</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc">Die Diagnose ist optional und dient der Fehlerbehebung. Für In-Game-Overlays und detaillierte Leistungsdiagramme verwenden Sie spezielle Tools.</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc1">Die Diagnose ist optional und dient der Fehlerbehebung.</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc2">Für In-Game-Overlays und detaillierte Leistungsdiagramme verwenden Sie spezielle Tools.</sys:String>
+    <sys:String x:Key="PerformanceView_QuickTips">Schnelle Tipps:</sys:String>
+    <sys:String x:Key="PerformanceView_Tip1">1. Öffnen Sie die Diagnose nur, wenn Sie einen gezielten Schnappschuss zur Fehlerbehebung benötigen.</sys:String>
+    <sys:String x:Key="PerformanceView_Tip2">2. Überprüfen Sie Hotspots nur als Hinweis, bevor Sie Automatisierungsregeln erstellen.</sys:String>
+    <sys:String x:Key="PerformanceView_Tip3">3. Stoppen Sie Live-Metriken, wenn Sie mit der Fehlerbehebung fertig sind.</sys:String>
+    <sys:String x:Key="PerformanceView_Continue">Weiter zur Diagnose</sys:String>
+
+    <sys:String x:Key="PerformanceView_ActiveProcesses">Aktive Prozesse</sys:String>
+    <sys:String x:Key="PerformanceView_TopConsumersDesc">Top-CPU- und Speicherverbraucher mit Regelerstellung mit einem Klick.</sys:String>
+    <sys:String x:Key="PerformanceView_SearchPlaceholder">Suchen Sie Prozesse nach Namen</sys:String>
+    <sys:String x:Key="PerformanceView_RuleBackedOnly">Nur durch Regeln gesichert</sys:String>
+    <sys:String x:Key="PerformanceView_ActionableOnly">Nur umsetzbar</sys:String>
+    <sys:String x:Key="PerformanceView_RuleImpact">Regelauswirkungen</sys:String>
+    <sys:String x:Key="PerformanceView_CreateRuleButton">Regel aus Auswahl erstellen/aktualisieren</sys:String>
+    <sys:String x:Key="PerformanceView_CreateRuleTooltip">Erstellen oder aktualisieren Sie eine Automatisierungsregel für den ausgewählten Hotspot-Prozess</sys:String>
+
+    <sys:String x:Key="PerformanceView_Timeline">Stabilitätszeitleiste</sys:String>
+    <sys:String x:Key="PerformanceView_ClearHistory">Verlauf löschen</sys:String>
+    <sys:String x:Key="PerformanceView_ClearHistoryTooltip">Löschen Sie die angezeigten Metriken und den Zeitachsenverlauf</sys:String>
+    <sys:String x:Key="PerformanceView_CoreSnapshot">Kernübersicht</sys:String>
+    <sys:String x:Key="PerformanceView_CoreSnapshotDesc">Auslastung pro Kern zur schnellen Erkennung von Ungleichgewichten.</sys:String>
+    <sys:String x:Key="PerformanceView_ToggleCore">Kernbereich umschalten</sys:String>
+    <sys:String x:Key="PerformanceView_ToggleProcess">Prozessfenster umschalten</sys:String>
+    <sys:String x:Key="PerformanceView_StartLive">Starten Sie Live-Metriken</sys:String>
+    <sys:String x:Key="PerformanceView_StartLiveTooltip">Starten Sie die Live-Metrikerfassung für dieses Dashboard</sys:String>
+    <sys:String x:Key="PerformanceView_StopLive">Stoppen Sie Live-Metriken</sys:String>
+    <sys:String x:Key="PerformanceView_StopLiveTooltip">Live-Metrikerfassung anhalten; Die Hintergrundautomatisierung ist separat</sys:String>
+    <sys:String x:Key="PerformanceView_Refresh">Aktualisieren</sys:String>
+    <sys:String x:Key="PerformanceView_RefreshTooltip">Aktualisieren Sie den aktuellen Dashboard-Snapshot</sys:String>
+
+    <sys:String x:Key="PerformanceView_GlobalPowerPlan">Globaler Energieplan</sys:String>
+    <sys:String x:Key="PerformanceView_ProcessHotspots">Prozess-Hotspots</sys:String>
+    <sys:String x:Key="PerformanceView_Filter">Filtern</sys:String>
+    <sys:String x:Key="PerformanceView_Memory">Speicher</sys:String>
+    <sys:String x:Key="PerformanceView_Name">Name</sys:String>
+    <sys:String x:Key="PerformanceView_Priority">Priorität</sys:String>
+    <sys:String x:Key="PerformanceView_Window">Fenster</sys:String>
+    <sys:String x:Key="PerformanceView_MemoryUsed">Verwendeter Speicher</sys:String>
+    <sys:String x:Key="PerformanceView_CpuPercent">CPU %</sys:String>
+    <sys:String x:Key="PerformanceView_MemPercent">Speicher %</sys:String>
+    <sys:String x:Key="PerformanceView_Threads">Threads</sys:String>
+    <sys:String x:Key="PerformanceView_Events">Ereignisse</sys:String>
+    <sys:String x:Key="PerformanceView_Severity">Schweregrad</sys:String>
+    <sys:String x:Key="PerformanceView_Detail">Detailliert</sys:String>
+    <sys:String x:Key="PerformanceView_Time">Zeit</sys:String>
+    <sys:String x:Key="PerformanceView_Category">Kategorie</sys:String>
+    <sys:String x:Key="PerformanceView_Process">Prozess</sys:String>
+    <sys:String x:Key="PerformanceView_SelectedHotspot">Ausgewählter Hotspot-Prozess</sys:String>
+    <sys:String x:Key="PerformanceView_Metrics">Metriken</sys:String>
+    <sys:String x:Key="PerformanceView_Processes">Prozesse</sys:String>
+
+    <!-- PowerPlanView -->
+    <sys:String x:Key="PowerPlanView_Title">Energiepläne</sys:String>
+    <sys:String x:Key="PowerPlanView_Subtitle">Verwalten Sie den aktiven Windows-Energieplan und importieren Sie benutzerdefinierte .pow-Profile</sys:String>
+    <sys:String x:Key="PowerPlanView_WindowsPowerPlans">Windows Energiepläne</sys:String>
+    <sys:String x:Key="PowerPlanView_SelectActiveTip">Wählen Sie den Windows-Plan aus, den Sie aktivieren möchten.</sys:String>
+    <sys:String x:Key="PowerPlanView_SetActive">Als aktiven Windows-Plan festlegen</sys:String>
+    <sys:String x:Key="PowerPlanView_SetActiveTooltip">Ändern Sie den aktiven Energieplan Windows in den ausgewählten Plan</sys:String>
+    <sys:String x:Key="PowerPlanView_Refresh">Pläne aktualisieren</sys:String>
+    <sys:String x:Key="PowerPlanView_RefreshTooltip">Aktualisieren Sie die Liste der verfügbaren Energiesparpläne</sys:String>
+    <sys:String x:Key="PowerPlanView_CustomPowerPlans">Benutzerdefinierte Energiepläne</sys:String>
+    <sys:String x:Key="PowerPlanView_LocalPlansTip">Lokale .pow-Dateien können in Windows importiert werden.</sys:String>
+    <sys:String x:Key="PowerPlanView_ImportSelected">Ausgewählte .pow importieren</sys:String>
+    <sys:String x:Key="PowerPlanView_ImportSelectedTooltip">Importieren Sie die ausgewählte benutzerdefinierte .pow-Datei in Windows</sys:String>
+    <sys:String x:Key="PowerPlanView_AddFile">.pow-Datei hinzufügen</sys:String>
+    <sys:String x:Key="PowerPlanView_AddFileTooltip">Fügen Sie der benutzerdefinierten Bibliothek eine neue benutzerdefinierte Energieplandatei hinzu</sys:String>
+    <sys:String x:Key="PowerPlanView_Delete">Löschen</sys:String>
+    <sys:String x:Key="PowerPlanView_Active">Aktiv</sys:String>
+
+    <!-- ProcessPowerPlanAssociationView -->
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Title">Regeln und Automatisierung</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Subtitle">Die Automatisierungsüberwachung überwacht Start-/Stopp-Ereignisse und wendet konfigurierte Energiesparpläne, CPU-Masken und Prioritätsregeln an.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleEditor">Regeleditor</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EditorSubtitle">Erstellen Sie eine Regel aus einer ausführbaren Datei oder einem laufenden Prozess, um den Energieplan, die CPU-Maske und das Prioritätsverhalten zu automatisieren.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ExecutableMatch">Ausführbare Übereinstimmung:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_MatchByPath">Nach Pfad abgleichen</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_MatchByPathTooltip">Ordnen Sie Prozesse nach dem vollständigen Pfad zu, anstatt nur nach dem Namen der ausführbaren Datei</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Browse">Suchen Sie nach ausführbarer Datei</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_BrowseTooltip">Klicken Sie, um eine ausführbare Datei (.exe) von Ihrem Computer auszuwählen</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ExecutableHelp">Wählen Sie eine ausführbare Datei. Die Übereinstimmung nach Pfad ist präziser. Der Abgleich nach Namen gilt für jeden Prozess mit diesem ausführbaren Namen.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseRunningProcess">Verwenden Sie den laufenden Prozess:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseRunningProcessTooltip">Wählen Sie einen aktuell laufenden Prozess aus, um dessen ausführbare Datei zu verwenden</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseSelectedProcess">Ausgewählten Prozess verwenden</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseSelectedProcessTooltip">Verwenden Sie die ausführbare Datei des ausgewählten laufenden Prozesses</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePowerPlan">Rule Power Plan (globaler Switch):</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePowerPlanHelp">Wenn diese Regel übereinstimmt, wechselt Windows den globalen aktiven Energieplan.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleCpuMask">Regel CPU Maske:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleCpuMaskHelp">Optional: Wählen Sie eine CPU-Maske aus, die beim Start dieses Prozesses angewendet werden soll</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePriority">Regelpriorität</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Update">Aktualisieren</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePriorityHelp">Optional: Wählen Sie die Prozesspriorität aus, die beim Start dieses Prozesses angewendet werden soll</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AssociationPriority">Verbandspriorität:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AssociationPriorityHelp">Bei mehreren Übereinstimmungen haben Zuordnungen mit höherer Priorität Vorrang</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AddRule">Regel hinzufügen</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UpdateRule">Ausgewählte Regel aktualisieren</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UpdateRuleTooltip">Aktualisieren Sie die ausgewählte Zuordnung</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ClearSelection">Auswahl löschen</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ClearSelectionTooltip">Löschen Sie die ausgewählte ausführbare Datei</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_CurrentRules">Aktuelle Regeln</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulesDescription">Definieren Sie Regeln pro Prozess. Energiepläne sind global; Masken und Prioritäten gelten für Matching-Prozesse.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Remove">Entfernen</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RemoveTooltip">Entfernen Sie die ausgewählte Zuordnung</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DefaultPowerPlan">Standard-Energieplan (Fallback, wenn keine Regel übereinstimmt)</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DefaultPowerPlanHelp">Energieplan zur Verwendung, wenn keine zugehörigen Prozesse ausgeführt werden:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SetDefault">Legen Sie den Standard-Energieplan fest</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SettingsTitle">Einstellungen für die Automatisierungsüberwachung</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EnableWmi">Ereignisbasierte Automatisierung aktivieren (WMI)</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EnableFallback">Aktivieren Sie die Automatisierungs-Fallback-Abfrage</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PollingInterval">Abfrageintervall (Sekunden):</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ChangeDelay">Verzögerung der Energieplanänderung (ms):</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PreventDuplicates">Verhindern Sie doppelte Energieplanänderungen</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SaveConfig">Konfiguration speichern</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_NoRules">Noch keine Automatisierungsregeln</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Status">Status:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationMonitoring">Automatisierungsüberwachung</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_StartAutomation">Starten Sie die Automatisierungsüberwachung</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_StopAutomation">Stoppen Sie die Automatisierungsüberwachung</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AppliedToMatching">Wird auf jeden passenden Prozess angewendet, wenn die Automatisierungsregel ausgeführt wird.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AppliedOnlyToMatching">Wird nur auf Matching-Prozesse angewendet. Der globale Energieplan Windows wird dadurch nicht geändert.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SelectedExecutable">Ausgewählte ausführbare Datei:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DescriptionLabel">Beschreibung:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationService">Automatisierungsdienst</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulesHeader">Regeln</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Ausführbar</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Energieplan</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_CpuMask">CPU Maske</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Priority">Priorität</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Description">Beschreibung</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ProcessPriority">Prozesspriorität:</sys:String>
+
+    <!-- ProcessView -->
+    <sys:String x:Key="ProcessView_Title">Prozessmanagement</sys:String>
+    <sys:String x:Key="ProcessView_Subtitle">Suchen, filtern und steuern Sie aktive Prozesskonfigurationen</sys:String>
+    <sys:String x:Key="ProcessView_SearchPlaceholder">Suchen Sie Prozesse nach Namen</sys:String>
+    <sys:String x:Key="ProcessView_SearchAutomationName">Prozesssuche</sys:String>
+    <sys:String x:Key="ProcessView_HideSystem">Windows-Systemprozesse ausblenden</sys:String>
+    <sys:String x:Key="ProcessView_HideSystemShort">Systemprozesse ausblenden</sys:String>
+    <sys:String x:Key="ProcessView_HideLowCpu">Prozesse mit sehr geringer CPU-Nutzung ausblenden</sys:String>
+    <sys:String x:Key="ProcessView_HideIdle">Leerlaufprozesse ausblenden</sys:String>
+    <sys:String x:Key="ProcessView_VisibleWindowsOnly">Nur Anwendungen mit sichtbarem windows anzeigen</sys:String>
+    <sys:String x:Key="ProcessView_ActiveAppsOnly">Nur aktive Apps</sys:String>
+    <sys:String x:Key="ProcessView_LockList">Prozessliste sperren</sys:String>
+    <sys:String x:Key="ProcessView_LockListTooltip">Unterbrechen Sie die Aktualisierung der Prozessliste und Sortieraktualisierungen, während Sie mit der aktuellen Liste arbeiten. Die Hintergrundüberwachung und die automatische Anwendung gespeicherter Regeln werden fortgesetzt, während ThreadPilot ausgeführt wird.</sys:String>
+    <sys:String x:Key="ProcessView_SortBy">Sortieren nach:</sys:String>
+    <sys:String x:Key="ProcessView_SortByTooltip">Wählen Sie aus, wie die Prozessliste sortiert werden soll</sys:String>
+
+    <sys:String x:Key="ProcessView_SelectedProcess">Ausgewählter Prozess</sys:String>
+    <sys:String x:Key="ProcessView_NoProcessSelected">Kein Prozess ausgewählt</sys:String>
+    <sys:String x:Key="ProcessView_SelectProcessTip">Wählen Sie einen Prozess aus der Tabelle aus, um Affinitäts-, Prioritäts-, Energieplan- und Regelaktionen zu aktivieren.</sys:String>
+    <sys:String x:Key="ProcessView_PowerPlanPending">Energieplan / Ausstehende Einstellungen</sys:String>
+    <sys:String x:Key="ProcessView_PowerPlanTooltip">Wählen Sie den Energieplan aus, den Sie manuell aktivieren oder per Schnellanwendung einschließen möchten</sys:String>
+    <sys:String x:Key="ProcessView_SetPowerPlan">Legen Sie den Energieplan fest</sys:String>
+    <sys:String x:Key="ProcessView_SetPowerPlanTooltip">Aktivieren Sie den ausgewählten Windows-Energieplan</sys:String>
+
+    <sys:String x:Key="ProcessView_PendingCoreMask">Ausstehende Kernmaske</sys:String>
+    <sys:String x:Key="ProcessView_StageMaskTooltip">Wählen Sie eine Maske aus, um sie bereitzustellen. Dadurch wird die Betriebssystemaffinität erst geändert, wenn auf „Affinität anwenden“ geklickt wird.</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinity">Wenden Sie Affinität an</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinityTooltip">Wenden Sie die ausstehende Kernmaske auf den ausgewählten Prozess an und überprüfen Sie den Affinitätsstatus Windows</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinitySaveRule">Affinität anwenden und als Regel speichern</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinitySaveRuleTooltip">Aktuelle Prozesseinstellungen grundsätzlich speichern. Diese Einstellungen werden automatisch angewendet, wenn dieser Prozess in Zukunft startet.</sys:String>
+
+    <sys:String x:Key="ProcessView_SetCpuPriority">Legen Sie die Priorität CPU fest</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPriorityTooltip">Wenden Sie die ausgewählte Priorität auf den Prozess an</sys:String>
+    <sys:String x:Key="ProcessView_EnforcePriorityRegistry">Priorität durch Registrierung erzwingen</sys:String>
+    <sys:String x:Key="ProcessView_EnforcePriorityRegistryTooltip">Wenden Sie die Priorität über die Registrierung Windows an. Der Prozess muss neu gestartet werden, damit die Änderungen wirksam werden. Diese Einstellung bleibt über Systemneustarts hinweg bestehen.</sys:String>
+    <sys:String x:Key="ProcessView_SetPriority">Priorität festlegen</sys:String>
+    <sys:String x:Key="ProcessView_RealtimeBlockedHelp">Die Echtzeitpriorität wird von ThreadPilot blockiert, da Windows dadurch instabil werden oder nicht mehr reagieren kann.</sys:String>
+    <sys:String x:Key="ProcessView_RealtimeBlocked">Echtzeit (blockiert)</sys:String>
+
+    <sys:String x:Key="ProcessView_DisableIdleServer">Deaktivieren Sie den inaktiven Server</sys:String>
+    <sys:String x:Key="ProcessView_DisableIdleServerTooltip">Verhindert, dass das System während der Ausführung dieses Prozesses in den Ruhezustand wechselt. Nützlich für Spiele und leistungskritische Anwendungen.</sys:String>
+
+    <sys:String x:Key="ProcessView_ProfileRule">Profil / Regel</sys:String>
+    <sys:String x:Key="ProcessView_ProfileNamePlaceholder">Geben Sie einen Profilnamen ein, um Einstellungen zu speichern oder zu laden</sys:String>
+    <sys:String x:Key="ProcessView_SaveProfile">Profil speichern</sys:String>
+    <sys:String x:Key="ProcessView_SaveProfileTooltip">Speichern Sie die aktuelle Affinität und Priorität von CPU als wiederverwendbares Profil</sys:String>
+    <sys:String x:Key="ProcessView_LoadProfile">Profil laden</sys:String>
+    <sys:String x:Key="ProcessView_LoadProfileTooltip">Laden Sie ein zuvor gespeichertes Profil</sys:String>
+    <sys:String x:Key="ProcessView_SaveCurrentRule">Aktuelle Einstellungen als Regel speichern</sys:String>
+
+    <sys:String x:Key="ProcessView_LastAction">Letzte ThreadPilot-Aktion:</sys:String>
+    <sys:String x:Key="ProcessView_Refresh">Aktualisieren</sys:String>
+    <sys:String x:Key="ProcessView_RefreshTooltip">Aktualisieren Sie die Prozessliste</sys:String>
+    <sys:String x:Key="ProcessView_LoadMore">Mehr laden</sys:String>
+    <sys:String x:Key="ProcessView_LoadMoreTooltip">Laden Sie weitere Prozesse</sys:String>
+    <sys:String x:Key="ProcessView_RefreshAutomationName">Prozesse aktualisieren</sys:String>
+    <sys:String x:Key="ProcessView_LoadMoreAutomationName">Laden Sie weitere Prozesse</sys:String>
+    <sys:String x:Key="ProcessView_RunningListAutomationName">Liste der laufenden Prozesse</sys:String>
+    <sys:String x:Key="ProcessView_RunningListAutomationHelp">Virtualisierte Prozesstabelle mit Sortierung und Auswahl</sys:String>
+
+    <sys:String x:Key="ProcessView_ColProcessName">Prozessname</sys:String>
+    <sys:String x:Key="ProcessView_ColWindowTitle">Fenstertitel</sys:String>
+    <sys:String x:Key="ProcessView_ColCpuUsage">CPU-Auslastung</sys:String>
+    <sys:String x:Key="ProcessView_ColMemory">Speicherauslastung</sys:String>
+
+    <sys:String x:Key="ProcessView_AffinityStagedTooltip">Affinität in der Benutzeroberfläche inszeniert. Es wird erst angewendet, wenn auf „Affinität anwenden“ geklickt wird.</sys:String>
+    <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Affinität, die derzeit von Windows für den ausgewählten Prozess gemeldet wird</sys:String>
+    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Schreibgeschützte Vorschau der aktuellen oder ausstehenden CPU-Auswahl</sys:String>
+    <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Öffnen Sie die Registerkarte CPU Masken, um eine neue benutzerdefinierte Maske zu erstellen</sys:String>
+    <sys:String x:Key="ProcessView_HyperThreadingTooltip">Zeigt an, ob Hyper-Threading (Intel) oder SMT (AMD) auf diesem System vorhanden und aktiv ist</sys:String>
+
+    <sys:String x:Key="ProcessView_CopyProcessInfo">Prozessinformationen kopieren</sys:String>
+    <sys:String x:Key="ProcessView_OpenLocation">Öffnen Sie den Speicherort der ausführbaren Datei</sys:String>
+    <sys:String x:Key="ProcessView_ClearCpuSets">CPU-Sätze löschen</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPendingSettings">Ausstehende Einstellungen anwenden</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPendingSettingsTooltip">Wenden Sie die ausstehende Affinität und den ausgewählten Energieplan auf den ausgewählten Prozess an</sys:String>
+    <sys:String x:Key="ProcessView_RulesAppliedOnlyWhenConfigured">Regeln und Änderungen werden von ThreadPilot nur angewendet, wenn sie konfiguriert sind.</sys:String>
+    <sys:String x:Key="ProcessView_CurrentProcessStatus">Aktueller Prozessstatus</sys:String>
+    <sys:String x:Key="ProcessView_AdvancedAffinityPicker">Erweiterte Affinitätsauswahl</sys:String>
+    <sys:String x:Key="ProcessView_RowMaskTooltip">Wählen Sie die ausstehende Maske für Affinitätsaktionen im Zeilenkontextmenü aus</sys:String>
+    <sys:String x:Key="ProcessView_SelectedPowerPlan">Ausgewählter Energieplan</sys:String>
+    <sys:String x:Key="ProcessView_SaveAsRule">Als Regel speichern</sys:String>
+    <sys:String x:Key="ProcessView_NoVisibleWindowTitle">Kein sichtbarer Fenstertitel</sys:String>
+    <sys:String x:Key="ProcessView_BatchLabel">Stapelverarbeitung</sys:String>
+    <sys:String x:Key="ProcessView_TotalSuffix">insgesamt)</sys:String>
+    <sys:String x:Key="ProcessView_PriorityInlineLabel">Priorität</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuUnavailable">CPU: nicht verfügbar</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryUnavailable">Speicher: nicht verfügbar</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuPriorityUnavailable">CPU Priorität: nicht verfügbar</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryPriorityUnavailable">Speicherpriorität nicht verfügbar</sys:String>
+    <sys:String x:Key="ProcessSummary_AffinityUnavailable">Affinität: nicht verfügbar</sys:String>
+    <sys:String x:Key="ProcessSummary_NoSavedRule">Keine gespeicherte Regel</sys:String>
+    <sys:String x:Key="ProcessSummary_NoRecentAction">Keine aktuelle ThreadPilot-Aktion</sys:String>
+    <sys:String x:Key="ProcessSummary_SelectedProcessFormat">Ausgewählter Prozess: {0} (PID {1})</sys:String>
+    <sys:String x:Key="ProcessSummary_StatusProtected">Aktueller Prozessstatus: geschützt oder Zugriff verweigert</sys:String>
+    <sys:String x:Key="ProcessSummary_StatusSelected">Aktueller Prozessstatus: ausgewählt</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuFormat">CPU: {0:N1}%</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryFormat">Speicher: {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuPriorityFormat">CPU Priorität: {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_AffinityLegacyFormat">Affinität: Legacy-Maske 0x{0:X}</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryPriorityFormat">Speicherpriorität: {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_SavedRuleFallback">gespeicherte Regel</sys:String>
+    <sys:String x:Key="ProcessSummary_SavedRuleExistsFormat">Gespeicherte Regel vorhanden: {0}</sys:String>
+
+    <sys:String x:Key="ProcessView_PriorityAboveNormal">Über dem Normalwert</sys:String>
+    <sys:String x:Key="ProcessView_PriorityBelowNormal">Unterhalb des Normalwerts</sys:String>
+    <sys:String x:Key="ProcessView_PriorityHigh">Hoch</sys:String>
+    <sys:String x:Key="ProcessView_PriorityIdle">Leerlauf</sys:String>
+    <sys:String x:Key="ProcessView_PriorityLow">Niedrig</sys:String>
+    <sys:String x:Key="ProcessView_PriorityNormal">Normal</sys:String>
+    <sys:String x:Key="ProcessView_PriorityRealtime">Echtzeit</sys:String>
+    <sys:String x:Key="ProcessView_PriorityBatch">Stapelverarbeitung</sys:String>
+    <sys:String x:Key="ProcessView_PriorityCustom">Benutzerdefiniert</sys:String>
+
+    <sys:String x:Key="ProcessView_HasWindow">Hat Fenster</sys:String>
+    <sys:String x:Key="ProcessView_Window">Fenster</sys:String>
+    <sys:String x:Key="ProcessView_PID">PID</sys:String>
+    <sys:String x:Key="ProcessView_ID">ID</sys:String>
+    <sys:String x:Key="ProcessView_MemoryMb">Speicher (MB)</sys:String>
+    <sys:String x:Key="ProcessView_Affinity">Affinität</sys:String>
+    <sys:String x:Key="ProcessView_Priority">Priorität</sys:String>
+    <sys:String x:Key="ProcessView_Rules">Regeln</sys:String>
+    <sys:String x:Key="ProcessView_Name">Name</sys:String>
+    <sys:String x:Key="ProcessView_SetMemoryPriority">Legen Sie die Speicherpriorität fest</sys:String>
+    <sys:String x:Key="ProcessView_PriorityVeryLow">Sehr niedrig</sys:String>
+    <sys:String x:Key="ProcessView_PriorityMedium">Mittel</sys:String>
+    <sys:String x:Key="ProcessView_RefreshInfo">Prozessinformationen aktualisieren</sys:String>
+
+    <!-- SettingsView -->
+    <sys:String x:Key="SettingsView_Title">Anwendungseinstellungen</sys:String>
+    <sys:String x:Key="SettingsView_Subtitle">Konfigurieren Sie Benachrichtigungen, die Taskleiste und das Anwendungsverhalten</sys:String>
+    <sys:String x:Key="SettingsView_Notifications">Benachrichtigungen</sys:String>
+    <sys:String x:Key="SettingsView_EnableNotifications">Benachrichtigungen aktivieren</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevel">Benachrichtigungsebene</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelAll">Alle</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelWarningsErrors">Nur Warnungen/Fehler</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelSilent">Stumm</sys:String>
+    <sys:String x:Key="SettingsView_EnableBalloon">Sprechblasenbenachrichtigungen aktivieren (Taskleiste)</sys:String>
+    <sys:String x:Key="SettingsView_EnableToast">Toastbenachrichtigungen aktivieren (Windows 10+)</sys:String>
+    <sys:String x:Key="SettingsView_NotificationTypes">Benachrichtigungstypen</sys:String>
+    <sys:String x:Key="SettingsView_NotifyPowerPlan">Änderungen des Energieplans</sys:String>
+    <sys:String x:Key="SettingsView_NotifyProcess">Prozessüberwachungsereignisse</sys:String>
+    <sys:String x:Key="SettingsView_NotifyError">Fehlermeldungen</sys:String>
+    <sys:String x:Key="SettingsView_NotifySuccess">Erfolgsbenachrichtigungen</sys:String>
+    <sys:String x:Key="SettingsView_Duration">Dauer (ms):</sys:String>
+    <sys:String x:Key="SettingsView_TestNotification">Testbenachrichtigung</sys:String>
+
+    <sys:String x:Key="SettingsView_SystemTray">Systemablage</sys:String>
+    <sys:String x:Key="SettingsView_ShowTrayIcon">Taskleistensymbol anzeigen</sys:String>
+    <sys:String x:Key="SettingsView_MinimizeToTray">Auf das Fach minimieren</sys:String>
+    <sys:String x:Key="SettingsView_CloseToTray">In der Nähe des Fachs (anstelle des Ausgangs)</sys:String>
+    <sys:String x:Key="SettingsView_StartMinimized">Minimiert starten</sys:String>
+    <sys:String x:Key="SettingsView_QuickApply">Ausstehende Einstellungen aktivieren, die aus dem Fach übernommen werden</sys:String>
+    <sys:String x:Key="SettingsView_MonitoringControl">Aktivieren Sie die Steuerelemente für die Automatisierungsüberwachung in der Taskleiste</sys:String>
+    <sys:String x:Key="SettingsView_DetailedTooltips">Detaillierte Tooltips anzeigen</sys:String>
+
+    <sys:String x:Key="SettingsView_BasicPreferences">Grundeinstellungen</sys:String>
+    <sys:String x:Key="SettingsView_Autostart">Autostart</sys:String>
+    <sys:String x:Key="SettingsView_StartWithWindows">Beginnen Sie mit Windows</sys:String>
+    <sys:String x:Key="SettingsView_AutostartDescription">ThreadPilot automatisch starten, wenn Windows startet</sys:String>
+    <sys:String x:Key="SettingsView_LowImpactMode">Low-Impact-Modus im Hintergrund</sys:String>
+    <sys:String x:Key="SettingsView_LowImpactDescription">Verringern Sie die Prozesspriorität von ThreadPilot, während es minimiert oder im Fach ausgeblendet ist.</sys:String>
+
+    <sys:String x:Key="SettingsView_Appearance">Aussehen</sys:String>
+    <sys:String x:Key="SettingsView_UseDarkTheme">Verwenden Sie ein dunkles Thema</sys:String>
+    <sys:String x:Key="SettingsView_ThemeDescription">Wendet ein globales Dunkel/Hell-Thema auf alle Registerkarten an</sys:String>
+
+    <sys:String x:Key="SettingsView_Language">Sprache</sys:String>
+    <sys:String x:Key="SettingsView_LanguageZhCn">简体中文 (Simplified Chinese)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageEnUs">English (English)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageItIt">Italiano (Italian)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageFrFr">Français (French)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageDeDe">Deutsch (German)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageEsEs">Español (Spanish)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageRuRu">Русский (Russian)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageDescription">Wendet eine globale Anzeigesprache auf die gesamte Anwendungsoberfläche an.</sys:String>
+
+    <sys:String x:Key="SettingsView_RulesAutomation">Regeln und Automatisierung</sys:String>
+    <sys:String x:Key="SettingsView_RuleAutoApply">Gespeicherte Regel automatisch anwenden</sys:String>
+    <sys:String x:Key="SettingsView_ApplyOnStart">Wenden Sie gespeicherte Regeln an, wenn Matching-Prozesse beginnen</sys:String>
+    <sys:String x:Key="SettingsView_ApplyOnStartDescription">Wendet aktivierte gespeicherte Regeln an, während ThreadPilot ausgeführt wird. Dadurch wird kein Windows-Dienst installiert und es wird keine Registrierungs-/IFEO-Persistenz verwendet.</sys:String>
+    <sys:String x:Key="SettingsView_EnableWmi">Aktivieren Sie WMI-Prozessereignisse</sys:String>
+    <sys:String x:Key="SettingsView_WmiDescription">Verwenden Sie Windows Management Instrumentation für Prozessstart-/-stoppereignisse</sys:String>
+    <sys:String x:Key="SettingsView_EnableFallback">Aktivieren Sie die Fallback-Abfrage</sys:String>
+    <sys:String x:Key="SettingsView_FallbackDescription">Verwenden Sie die Abfrage als Backup, wenn WMI-Prozessereignisse fehlschlagen</sys:String>
+    <sys:String x:Key="SettingsView_PollingInterval">Abfrageintervall (ms):</sys:String>
+    <sys:String x:Key="SettingsView_FallbackPollingInterval">Fallback-Abfrage (ms):</sys:String>
+
+    <sys:String x:Key="SettingsView_Advanced">Fortgeschritten</sys:String>
+    <sys:String x:Key="SettingsView_NotificationHistory">Benachrichtigungsverlauf aktivieren</sys:String>
+    <sys:String x:Key="SettingsView_MaxHistory">Max. Verlaufselemente:</sys:String>
+    <sys:String x:Key="SettingsView_AutoHide">Benachrichtigungen automatisch ausblenden</sys:String>
+    <sys:String x:Key="SettingsView_NotificationSound">Benachrichtigungston aktivieren</sys:String>
+    <sys:String x:Key="SettingsView_DebugLogging">Aktivieren Sie die Debug-Protokollierung</sys:String>
+    <sys:String x:Key="SettingsView_PerformanceCounters">Leistungsindikatoren aktivieren</sys:String>
+
+    <sys:String x:Key="SettingsView_About">Über</sys:String>
+    <sys:String x:Key="SettingsView_Version">Version:</sys:String>
+    <sys:String x:Key="SettingsView_Copyright">Copyright © 2026 PrimeBuild</sys:String>
+    <sys:String x:Key="SettingsView_Translator">Übersetzer: Ylimhs</sys:String>
+    <sys:String x:Key="SettingsView_License">Lizenz: AGPLv3</sys:String>
+    <sys:String x:Key="SettingsView_CheckUpdates">Suchen Sie nach Updates</sys:String>
+    <sys:String x:Key="SettingsView_DownloadInstallUpdate">Laden Sie das Update herunter und installieren Sie es</sys:String>
+    <sys:String x:Key="SettingsView_EnableAutomaticUpdateChecks">Beim Start automatisch prüfen</sys:String>
+    <sys:String x:Key="SettingsView_UpdateIntervalDays">Prüfintervall (Tage):</sys:String>
+    <sys:String x:Key="SettingsView_IncludePrereleaseUpdates">Fügen Sie Vorabversionsaktualisierungen hinzu</sys:String>
+    <sys:String x:Key="SettingsView_LatestVersion">Neueste Version:</sys:String>
+    <sys:String x:Key="SettingsView_LastUpdateCheck">Zuletzt überprüft:</sys:String>
+    <sys:String x:Key="SettingsView_UpdatesDescription">Prüft bei Bedarf mithilfe der offiziellen GitHub-Releases.</sys:String>
+
+    <sys:String x:Key="SettingsView_ResetDefaults">Auf Standardeinstellungen zurücksetzen</sys:String>
+    <sys:String x:Key="SettingsView_ExportConfig">Konfiguration exportieren</sys:String>
+    <sys:String x:Key="SettingsView_ImportConfig">Konfiguration importieren</sys:String>
+    <sys:String x:Key="SettingsView_SaveSettings">Einstellungen speichern</sys:String>
+    <sys:String x:Key="SettingsView_ThreadPilot">ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_StatusThemeChangedFormat">Das Thema wurde in {0} geändert.</sys:String>
+    <sys:String x:Key="Settings_StatusThemeChangeFailedFormat">Das Thema konnte nicht in {0} geändert werden.</sys:String>
+    <sys:String x:Key="Settings_StatusLanguageChangedFormat">Die Sprache wurde in {0} geändert.</sys:String>
+    <sys:String x:Key="Settings_StatusLanguageChangeFailed">Die Sprache konnte nicht geändert werden.</sys:String>
+    <sys:String x:Key="Settings_StatusSaving">Einstellungen speichern...</sys:String>
+    <sys:String x:Key="Settings_StatusSavedWarningsFormat">Mit Warnungen gespeicherte Einstellungen: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusSavedApplied">Einstellungen erfolgreich gespeichert und angewendet.</sys:String>
+    <sys:String x:Key="Settings_StatusErrorSavingFormat">Fehler beim Speichern der Einstellungen: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusResetting">Zurücksetzen auf Standardeinstellungen...</sys:String>
+    <sys:String x:Key="Settings_StatusResetPending">Einstellungen auf Standardwerte zurückgesetzt (noch nicht gespeichert)</sys:String>
+    <sys:String x:Key="Settings_StatusErrorResettingFormat">Fehler beim Zurücksetzen der Einstellungen: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusExporting">Konfigurationspaket wird exportiert...</sys:String>
+    <sys:String x:Key="Settings_StatusExportCanceled">Export abgebrochen</sys:String>
+    <sys:String x:Key="Settings_StatusExportedFormat">Konfiguration exportiert nach: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusErrorExportingFormat">Fehler beim Exportieren der Einstellungen: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusImporting">Konfiguration wird importiert...</sys:String>
+    <sys:String x:Key="Settings_StatusImportCanceled">Import abgebrochen</sys:String>
+    <sys:String x:Key="Settings_StatusImportedApplied">Konfigurationspaket importiert und angewendet</sys:String>
+    <sys:String x:Key="Settings_StatusLegacyImported">Legacy-Einstellungen importiert (Regeln unverändert)</sys:String>
+    <sys:String x:Key="Settings_StatusErrorImportingFormat">Fehler beim Importieren der Einstellungen: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusTestSent">Testbenachrichtigung gesendet</sys:String>
+    <sys:String x:Key="Settings_StatusErrorTestFormat">Fehler beim Senden der Testbenachrichtigung: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusLoading">Einstellungen werden geladen...</sys:String>
+    <sys:String x:Key="Settings_StatusLoaded">Einstellungen geladen</sys:String>
+    <sys:String x:Key="Settings_StatusErrorLoadingFormat">Fehler beim Laden der Einstellungen: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusSynchronized">Einstellungen synchronisiert</sys:String>
+    <sys:String x:Key="Settings_StatusCheckingUpdates">Suche nach Updates...</sys:String>
+    <sys:String x:Key="Settings_StatusLatestUnknown">Die neueste Version kann nicht ermittelt werden.</sys:String>
+    <sys:String x:Key="Settings_StatusNewVersionFormat">Neue Version verfügbar: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusUpToDateFormat">Die Bewerbung ist aktuell. Installierte Version: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateErrorFormat">Fehler beim Überprüfen von Updates: {0}</sys:String>
+    <sys:String x:Key="Settings_UpdateLatestUnknown">Unbekannt</sys:String>
+    <sys:String x:Key="Settings_UpdateNotChecked">Nicht überprüft</sys:String>
+    <sys:String x:Key="Settings_UpdateLastCheckedNever">Niemals</sys:String>
+    <sys:String x:Key="Settings_UpdateConfirmTitle">Installieren Sie das ThreadPilot-Update</sys:String>
+    <sys:String x:Key="Settings_UpdateConfirmMessageFormat">ThreadPilot lädt Version {0} herunter und überprüft sie. Anschließend fordert Windows die Berechtigung zum Starten des Installationsprogramms an. Fortfahren?</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateCanceled">Update abgebrochen.</sys:String>
+    <sys:String x:Key="Settings_StatusDownloadingUpdate">Update wird heruntergeladen und überprüft...</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateInstallerStarted">Update-Installer gestartet.</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateInstallFailedFormat">Update-Installation fehlgeschlagen: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusModified">Die Einstellungen wurden geändert</sys:String>
+    <sys:String x:Key="Settings_StatusMatchSaved">Die Einstellungen stimmen mit der gespeicherten Konfiguration überein</sys:String>
+    <sys:String x:Key="Settings_LanguageSimplifiedChinese">Vereinfachtes Chinesisch</sys:String>
+    <sys:String x:Key="Settings_LanguageEnglish">Englisch</sys:String>
+    <sys:String x:Key="Settings_LanguageItalian">Italienisch</sys:String>
+    <sys:String x:Key="Settings_LanguageFrench">Französisch</sys:String>
+    <sys:String x:Key="Settings_LanguageGerman">Deutsch</sys:String>
+    <sys:String x:Key="Settings_LanguageSpanish">Spanisch</sys:String>
+    <sys:String x:Key="Settings_LanguageRussian">Russisch</sys:String>
+    <sys:String x:Key="Settings_ThemeDark">Dunkel</sys:String>
+    <sys:String x:Key="Settings_ThemeLight">Hell</sys:String>
+    <sys:String x:Key="Settings_DialogExportTitle">ThreadPilot-Konfiguration exportieren</sys:String>
+    <sys:String x:Key="Settings_DialogImportTitle">ThreadPilot-Konfiguration importieren</sys:String>
+    <sys:String x:Key="Settings_WarningAutostartFailed">Der Autostart von Windows konnte nicht aktualisiert werden. Den vorherigen Autostart-Status beibehalten.</sys:String>
+
+    <!-- SettingsWindow -->
+    <sys:String x:Key="SettingsWindow_Title">ThreadPilot Einstellungen</sys:String>
+    <sys:String x:Key="SettingsWindow_UnsavedTitle">Nicht gespeicherte Einstellungen</sys:String>
+    <sys:String x:Key="SettingsWindow_UnsavedDescription">Es gibt nicht gespeicherte Änderungen. Speichern oder verwerfen Sie sie, oder brechen Sie ab, um weiterzuarbeiten.</sys:String>
+    <sys:String x:Key="SettingsWindow_Cancel">Abbrechen</sys:String>
+    <sys:String x:Key="SettingsWindow_Discard">Verwerfen</sys:String>
+    <sys:String x:Key="SettingsWindow_Save">Speichern</sys:String>
+
+    <!-- SystemTweaksView -->
+    <sys:String x:Key="SystemTweaksView_Title">Systemoptimierungen und -optimierungen</sys:String>
+    <sys:String x:Key="SystemTweaksView_Subtitle">Konfigurieren Sie Windows Systemoptimierungen und Leistungsoptimierungen</sys:String>
+    <sys:String x:Key="SystemTweaksView_RefreshAll">Alle aktualisieren</sys:String>
+    <sys:String x:Key="SystemTweaksView_RefreshAllTooltip">Alle Optimierungsstatus aktualisieren</sys:String>
+    <sys:String x:Key="SystemTweaksView_TweakTooltip">Schalten Sie diese Windows-Optimierung um</sys:String>
+    <sys:String x:Key="SystemTweaksView_Status">Status</sys:String>
+
+    <!-- SystemTweaks Names and Descriptions -->
+    <sys:String x:Key="SystemTweak_CoreParking_Name">Core Parking</sys:String>
+    <sys:String x:Key="SystemTweak_CoreParking_Desc">Steuert CPU core parking für die Energieverwaltung</sys:String>
+    <sys:String x:Key="SystemTweak_CStates_Name">C-States</sys:String>
+    <sys:String x:Key="SystemTweak_CStates_Desc">Steuert CPU C-States für die Energieverwaltung</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Name">HPET</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Desc">Hochpräziser Ereigniszeitgeber für die Systemzeitmessung</sys:String>
+    <sys:String x:Key="SystemTweak_SysMain_Name">SysMain-Dienst</sys:String>
+    <sys:String x:Key="SystemTweak_SysMain_Desc">Windows Superfetch/SysMain Dienst für die Speicherverwaltung</sys:String>
+    <sys:String x:Key="SystemTweak_Prefetch_Name">Prefetch</sys:String>
+    <sys:String x:Key="SystemTweak_Prefetch_Desc">Windows Prefetch Funktion für schnelleres Laden der Anwendung</sys:String>
+    <sys:String x:Key="SystemTweak_PowerThrottling_Name">Power Throttling</sys:String>
+    <sys:String x:Key="SystemTweak_PowerThrottling_Desc">Windows Power Throttling für Energieeffizienz</sys:String>
+    <sys:String x:Key="SystemTweak_HighSchedulingCategory_Name">Hohe Planungskategorie</sys:String>
+    <sys:String x:Key="SystemTweak_HighSchedulingCategory_Desc">Hohe Planungspriorität für Gaming-Anwendungen</sys:String>
+    <sys:String x:Key="SystemTweak_MenuShowDelay_Name">Menü Verzögerung anzeigen</sys:String>
+    <sys:String x:Key="SystemTweak_MenuShowDelay_Desc">Verzögerung vor der Anzeige von Kontextmenüs</sys:String>
+
+    <!-- SystemTweaksViewModel Messages -->
+    <sys:String x:Key="SystemTweaks_StatusReady">Bereit</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshing">Erfrischende Systemoptimierungen...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLastRefreshedFormat">Letzte Aktualisierung: {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshFailed">Systemoptimierungen konnten nicht aktualisiert werden</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshFailedShort">Aktualisierung fehlgeschlagen</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusTogglingFormat">Umschalten von {0}...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnabledFormat">{0} erfolgreich aktiviert</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisabledFormat">{0} erfolgreich deaktiviert</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyEnabledFormat">{0} wurde aktiviert</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyDisabledFormat">{0} wurde deaktiviert</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyUpdatedTitle">Systemoptimierung aktualisiert</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusToggleFailedFormat">Fehler beim Umschalten von {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnableFailedFormat">{0} konnte nicht aktiviert werden</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisableFailedFormat">{0} konnte nicht deaktiviert werden</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyFailedTitle">Systemoptimierung fehlgeschlagen</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyFailedFormat">Fehler bei {0} {1}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusErrorTogglingFormat">Fehler beim Umschalten von {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyErrorFormat">Fehler beim Umschalten von {0}: {1}</sys:String>
+    <sys:String x:Key="SystemTweaks_WordEnable">aktivieren</sys:String>
+    <sys:String x:Key="SystemTweaks_WordDisable">deaktivieren</sys:String>
+    <sys:String x:Key="SystemTweaks_WordEnabled">aktiviert</sys:String>
+    <sys:String x:Key="SystemTweaks_WordDisabled">deaktiviert</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnabled">Aktiviert</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisabled">Deaktiviert</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusNotAvailable">Nicht verfügbar</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLoading">Systemoptimierungen werden geladen...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLoadedSuccess">Systemoptimierungen wurden erfolgreich geladen</sys:String>
+
+    <!-- SystemTray Context Menu & Status -->
+    <sys:String x:Key="SystemTray_OpenDashboard">Öffnen Sie das Dashboard</sys:String>
+    <sys:String x:Key="SystemTray_OpenDiagnostics">Öffnen Sie die Diagnose</sys:String>
+    <sys:String x:Key="SystemTray_PauseMonitoring">Automatisierungsüberwachung anhalten</sys:String>
+    <sys:String x:Key="SystemTray_ResumeMonitoring">Fortsetzen der Automatisierungsüberwachung</sys:String>
+    <sys:String x:Key="SystemTray_SystemStatus">Systemstatus</sys:String>
+    <sys:String x:Key="SystemTray_NoProcessSelected">Kein Prozess ausgewählt</sys:String>
+    <sys:String x:Key="SystemTray_SelectedProcessFormat">Ausgewählt: {0}</sys:String>
+    <sys:String x:Key="SystemTray_ApplyPendingToSelected">Ausstehende Einstellungen auf den ausgewählten Prozess anwenden</sys:String>
+    <sys:String x:Key="SystemTray_ApplyPendingToProcessFormat">Ausstehende Einstellungen auf {0} anwenden</sys:String>
+    <sys:String x:Key="SystemTray_PowerPlans">🔋 Energiepläne</sys:String>
+    <sys:String x:Key="SystemTray_Profiles">📋 Profile</sys:String>
+    <sys:String x:Key="SystemTray_Settings">Einstellungen</sys:String>
+    <sys:String x:Key="SystemTray_Exit">Beenden</sys:String>
+    <sys:String x:Key="SystemTray_NoProfilesAvailable">Keine Profile verfügbar</sys:String>
+    <sys:String x:Key="SystemTray_PowerPlanFormat">Energieplan: {0}</sys:String>
+    <sys:String x:Key="SystemTray_StatusWmiError">Automatisierung WMI Fehler</sys:String>
+    <sys:String x:Key="SystemTray_StatusActive">Automatisierung aktiv</sys:String>
+    <sys:String x:Key="SystemTray_StatusDisabled">Automatisierung deaktiviert</sys:String>
+    <sys:String x:Key="SystemTray_Unknown">Unbekannt</sys:String>
+    <sys:String x:Key="SystemTray_CpuRamStatusFormat">💻 CPU: {0:F1}% | RAM: {1:F1}% | {2}</sys:String>
+
+    <!-- ProcessOperationUserMessages -->
+    <sys:String x:Key="ProcessOperationUserMessages_AccessDenied">Windows hat diese Änderung abgelehnt. Der Prozess erfordert möglicherweise Administratorrechte oder ist möglicherweise geschützt.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_AntiCheatProtectedLikely">Der Prozess scheint durch Anti-Cheat- oder Prozessschutz geschützt zu sein. ThreadPilot wird nicht versuchen, es zu umgehen.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_AdminClarification">Der Administratormodus kann bei normalen Berechtigungsproblemen hilfreich sein, kann jedoch Anti-Cheat- oder geschützte Prozessbeschränkungen nicht umgehen.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_LegacyFallbackBlocked">Diese CPU-Auswahl kann durch ältere Affinitäts-APIs in dieser Topologie nicht sicher dargestellt werden. Für diese Auswahl sind CPU Sets erforderlich.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_InvalidTopology">Diese CPU-Auswahl stimmt nicht mit der aktuellen CPU-Topologie überein. Überprüfen Sie die Voreinstellung oder erstellen Sie sie neu.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_ProcessExited">Der Prozess wurde beendet, bevor ThreadPilot die Änderung übernehmen konnte.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_CpuSetsUnavailable">Windows CPU Sätze sind nicht verfügbar oder diese Auswahl wurde abgelehnt. ThreadPilot verwendet nur, wenn möglich, einen sicheren Fallback.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_HighPriorityWarning">Eine hohe Priorität kann die Reaktionsfähigkeit einiger Workloads verbessern, kann jedoch die Reaktionsfähigkeit des Systems verringern.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_RealtimePriorityBlocked">Die Echtzeitpriorität wird von ThreadPilot blockiert, da Windows dadurch instabil werden oder nicht mehr reagieren kann.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentLaunchTimePriorityNotice">Eine dauerhafte Startzeitpriorität wird möglicherweise für normale Prozesse unterstützt, sie umgeht jedoch keine geschützten Prozesse oder Anti-Cheat-Einschränkungen.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentRulesDescription">Wendet gespeicherte Regeln an, wenn ein Abgleichsprozess beginnt. Einige geschützte oder Anti-Cheat-Prozesse lehnen Änderungen möglicherweise ab. Der Administratormodus kann bei normalen Berechtigungsproblemen hilfreich sein, den Schutz jedoch nicht umgehen.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentRulesProtectedProcessWarning">Der Prozess scheint durch Anti-Cheat- oder Prozessschutz geschützt zu sein. ThreadPilot wird nicht versuchen, es zu überschreiben.</sys:String>
+
+    <!-- Notifications -->
+    <sys:String x:Key="Notification_PowerPlanChangedTitle">Energieplan geändert</sys:String>
+    <sys:String x:Key="Notification_PowerPlanChangedFormat">Energieplan wurde von „{0}“ in „{1}“ geändert.</sys:String>
+    <sys:String x:Key="Notification_PowerPlanChangedProcessFormat">Energieplan für Prozess „{1}“ in „{0}“ geändert</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringEnabled">Prozessüberwachung aktiviert</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringDisabled">Prozessüberwachung deaktiviert</sys:String>
+    <sys:String x:Key="Notification_CpuAffinityAppliedTitle">CPU Affinität angewendet</sys:String>
+    <sys:String x:Key="Notification_CpuAffinityAppliedFormat">CPU Affinitätssatz für „{0}“: {1}</sys:String>
+    <sys:String x:Key="Notification_GameBoostActivatedTitle">Game Boost aktiviert</sys:String>
+    <sys:String x:Key="Notification_GameBoostActivatedFormat">Game Boost-Modus für {0} aktiviert</sys:String>
+    <sys:String x:Key="Notification_GameBoostDeactivatedTitle">Game Boost deaktiviert</sys:String>
+    <sys:String x:Key="Notification_GameBoostDeactivatedFormat">Game Boost-Modus nach {0} deaktiviert</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitorErrorTitle">Fehler im Prozessmonitor</sys:String>
+    <sys:String x:Key="Notification_AffinityBlockedTitle">Affinität blockiert</sys:String>
+    <sys:String x:Key="Notification_AffinityAppliedTitle">Affinität angewendet</sys:String>
+    <sys:String x:Key="Notification_AffinityAdjustedTitle">Affinität angepasst</sys:String>
+    <sys:String x:Key="Notification_AffinityFailedTitle">Affinität ist fehlgeschlagen</sys:String>
+    <sys:String x:Key="Notification_AffinityErrorTitle">Affinitätsfehler</sys:String>
+    <sys:String x:Key="Notification_PriorityBlockedTitle">Priorität blockiert</sys:String>
+    <sys:String x:Key="Notification_PriorityWarningTitle">Vorrangige Warnung</sys:String>
+    <sys:String x:Key="Notification_PriorityAppliedTitle">Priorität angewendet</sys:String>
+    <sys:String x:Key="Notification_PriorityAdjustedTitle">Priorität angepasst</sys:String>
+    <sys:String x:Key="Notification_PriorityErrorTitle">Prioritätsfehler</sys:String>
+    <sys:String x:Key="Notification_KeyboardShortcutTitle">Tastaturkürzel</sys:String>
+    <sys:String x:Key="Notification_ToggleMonitoringShortcut">Toggle-Überwachungsverknüpfung aktiviert</sys:String>
+    <sys:String x:Key="Notification_HighPerformanceShortcut">Verknüpfung zum Hochleistungs-Energieplan aktiviert</sys:String>
+    <sys:String x:Key="Notification_RefreshProcessListShortcut">Verknüpfung zum Aktualisieren der Prozessliste aktiviert</sys:String>
+    <sys:String x:Key="Notification_ThreadPilotStartedTitle">ThreadPilot Gestartet</sys:String>
+    <sys:String x:Key="Notification_ThreadPilotStartedMessage">Die Prozessüberwachung und Energieplanverwaltung ist jetzt aktiv</sys:String>
+    <sys:String x:Key="Notification_StartupErrorTitle">Startfehler</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringStartFailed">Der Prozessüberwachungsmanager konnte nicht gestartet werden</sys:String>
+    <sys:String x:Key="Notification_AutomationMonitoringErrorTitle">Fehler bei der Automatisierungsüberwachung</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedTitle">Einstellungen gespeichert</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedMessage">Die Anwendungseinstellungen wurden erfolgreich gespeichert</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedWarningsTitle">Einstellungen mit Warnungen gespeichert</sys:String>
+    <sys:String x:Key="Notification_SettingsErrorTitle">Einstellungsfehler</sys:String>
+    <sys:String x:Key="Notification_SettingsSaveFailed">Einstellungen konnten nicht gespeichert werden</sys:String>
+    <sys:String x:Key="Notification_TestNotificationMessage">Dies ist eine Testbenachrichtigung, um zu überprüfen, ob Ihre Einstellungen korrekt funktionieren.</sys:String>
+
+    <!-- Elevation Service -->
+    <sys:String x:Key="Elevation_RequestPromptText">ThreadPilot erfordert Administratorrechte, um Prozessaffinität und Energiepläne zu verwalten.&#x0a;&#x0a;Möchten Sie die Anwendung mit Administratorrechten neu starten?</sys:String>
+    <sys:String x:Key="Elevation_RequestPromptTitle">Administratorrechte erforderlich</sys:String>
+    <sys:String x:Key="Elevation_FailedText">Neustart mit Administratorrechten fehlgeschlagen. Bitte führen Sie ThreadPilot manuell als Administrator aus.</sys:String>
+    <sys:String x:Key="Elevation_FailedTitle">Erhöhung fehlgeschlagen</sys:String>
+    <sys:String x:Key="Elevation_StatusRunning">Ausführung mit Administratorrechten</sys:String>
+    <sys:String x:Key="Elevation_StatusLimited">Läuft mit eingeschränkten Berechtigungen</sys:String>
+
+    <!-- System Tweaks Errors -->
+    <sys:String x:Key="SystemTweak_Error_QueryCoreParking">Der Wert von Core Parking konnte nicht über powercfg abgefragt werden.</sys:String>
+    <sys:String x:Key="SystemTweak_Error_QueryCStates">Der Wert von C-States konnte nicht über powercfg abgefragt werden.</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PrefetchKeyNotFound">Prefetch Registrierungsschlüssel nicht gefunden</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PowerThrottlingNotAvailable">Power Throttling ist auf diesem System nicht verfügbar</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PriorityControlKeyNotFound">PriorityControl Registrierungsschlüssel nicht gefunden</sys:String>
+    <sys:String x:Key="SystemTweak_Error_DesktopKeyNotFound">Desktop-Registrierungsschlüssel nicht gefunden</sys:String>
+</ResourceDictionary>

--- a/Locales/en-US.xaml
+++ b/Locales/en-US.xaml
@@ -409,6 +409,11 @@
     <sys:String x:Key="SettingsView_Language">Language</sys:String>
     <sys:String x:Key="SettingsView_LanguageZhCn">简体中文 (Simplified Chinese)</sys:String>
     <sys:String x:Key="SettingsView_LanguageEnUs">English (English)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageItIt">Italiano (Italian)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageFrFr">Français (French)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageDeDe">Deutsch (German)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageEsEs">Español (Spanish)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageRuRu">Русский (Russian)</sys:String>
     <sys:String x:Key="SettingsView_LanguageDescription">Applies a global display language across the entire application interface.</sys:String>
     
     <sys:String x:Key="SettingsView_RulesAutomation">Rules &amp; automation</sys:String>
@@ -493,6 +498,11 @@
     <sys:String x:Key="Settings_StatusMatchSaved">Settings match the saved configuration</sys:String>
     <sys:String x:Key="Settings_LanguageSimplifiedChinese">Simplified Chinese</sys:String>
     <sys:String x:Key="Settings_LanguageEnglish">English</sys:String>
+    <sys:String x:Key="Settings_LanguageItalian">Italian</sys:String>
+    <sys:String x:Key="Settings_LanguageFrench">French</sys:String>
+    <sys:String x:Key="Settings_LanguageGerman">German</sys:String>
+    <sys:String x:Key="Settings_LanguageSpanish">Spanish</sys:String>
+    <sys:String x:Key="Settings_LanguageRussian">Russian</sys:String>
     <sys:String x:Key="Settings_ThemeDark">Dark</sys:String>
     <sys:String x:Key="Settings_ThemeLight">Light</sys:String>
     <sys:String x:Key="Settings_DialogExportTitle">Export ThreadPilot Configuration</sys:String>
@@ -502,7 +512,7 @@
     <!-- SettingsWindow -->
     <sys:String x:Key="SettingsWindow_Title">ThreadPilot Settings</sys:String>
     <sys:String x:Key="SettingsWindow_UnsavedTitle">Unsaved Settings</sys:String>
-    <sys:String x:Key="SettingsWindow_UnsavedDescription">You have unsaved changes. Save before closing, discard the changes, or cancel to keep editing.</sys:String>
+    <sys:String x:Key="SettingsWindow_UnsavedDescription">You have unsaved changes. Save them, discard them, or cancel to keep editing.</sys:String>
     <sys:String x:Key="SettingsWindow_Cancel">Cancel</sys:String>
     <sys:String x:Key="SettingsWindow_Discard">Discard</sys:String>
     <sys:String x:Key="SettingsWindow_Save">Save</sys:String>
@@ -520,14 +530,14 @@
     <sys:String x:Key="SystemTweak_CoreParking_Desc">Controls CPU core parking for power management</sys:String>
     <sys:String x:Key="SystemTweak_CStates_Name">C-States</sys:String>
     <sys:String x:Key="SystemTweak_CStates_Desc">Controls CPU C-States for power management</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Name">HPET</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Desc">High Precision Event Timer for system timing</sys:String>
     <sys:String x:Key="SystemTweak_SysMain_Name">SysMain Service</sys:String>
     <sys:String x:Key="SystemTweak_SysMain_Desc">Windows Superfetch/SysMain service for memory management</sys:String>
     <sys:String x:Key="SystemTweak_Prefetch_Name">Prefetch</sys:String>
     <sys:String x:Key="SystemTweak_Prefetch_Desc">Windows Prefetch feature for faster application loading</sys:String>
     <sys:String x:Key="SystemTweak_PowerThrottling_Name">Power Throttling</sys:String>
     <sys:String x:Key="SystemTweak_PowerThrottling_Desc">Windows Power Throttling for energy efficiency</sys:String>
-    <sys:String x:Key="SystemTweak_Hpet_Name">HPET</sys:String>
-    <sys:String x:Key="SystemTweak_Hpet_Desc">High Precision Event Timer for system timing</sys:String>
     <sys:String x:Key="SystemTweak_HighSchedulingCategory_Name">High Scheduling Category</sys:String>
     <sys:String x:Key="SystemTweak_HighSchedulingCategory_Desc">High scheduling priority for gaming applications</sys:String>
     <sys:String x:Key="SystemTweak_MenuShowDelay_Name">Menu Show Delay</sys:String>

--- a/Locales/es-ES.xaml
+++ b/Locales/es-ES.xaml
@@ -1,0 +1,665 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- MainWindow / General -->
+    <sys:String x:Key="MainWindow_Title">ThreadPilot - Administrador de procesos y planes de energía</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningTitle">Privilegios de administrador recomendados</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningDescription">ThreadPilot se está ejecutando con privilegios limitados. Es posible que algunas funciones no estén disponibles.</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningRequired">Se requiere acceso de administrador para:</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningPowerPlans">• Modificar las configuraciones del plan de energía</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningAffinity">• Cambio de proceso CPU afinidad y prioridad</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningTweaks">• Aplicar optimizaciones y ajustes a nivel del sistema</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningProtected">• Gestión de procesos protegidos</sys:String>
+    <sys:String x:Key="MainWindow_ContinueWithoutElevation">Continuar sin elevación</sys:String>
+    <sys:String x:Key="MainWindow_RequestElevation">Solicitar elevación</sys:String>
+
+    <!-- MainWindow Navigation -->
+    <sys:String x:Key="MainWindow_NavProcess">Gestión de procesos</sys:String>
+    <sys:String x:Key="MainWindow_NavMasks">Máscaras de CPU</sys:String>
+    <sys:String x:Key="MainWindow_NavPower">Planes de energía</sys:String>
+    <sys:String x:Key="MainWindow_NavRules">Reglas</sys:String>
+    <sys:String x:Key="MainWindow_NavDiagnostics">Diagnóstico</sys:String>
+    <sys:String x:Key="MainWindow_NavActivity">Actividad de ThreadPilot</sys:String>
+    <sys:String x:Key="MainWindow_NavTweaks">Ajustes</sys:String>
+    <sys:String x:Key="MainWindow_NavSettings">Configuración</sys:String>
+
+    <!-- MainWindow Overlays -->
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestionTitle">Inicio minimizado</sys:String>
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestionDescription">Habilite Inicio minimizado cuando desee que ThreadPilot se inicie silenciosamente en la bandeja en futuros inicios de sesión de Windows.</sys:String>
+    <sys:String x:Key="MainWindow_Recommended">Recomendado</sys:String>
+    <sys:String x:Key="MainWindow_DontShowAgain">No volver a mostrar</sys:String>
+    <sys:String x:Key="MainWindow_OpenSettings">Abrir configuración</sys:String>
+    <sys:String x:Key="MainWindow_PrimaryNavigation">Navegación primaria</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningOverlay">Superposición de advertencia de elevación</sys:String>
+    <sys:String x:Key="MainWindow_PerformanceIntroductionOverlay">Superposición de introducción al rendimiento</sys:String>
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestion">Sugerencia de inicio minimizada</sys:String>
+    <sys:String x:Key="MainWindow_UnsavedSettingsDialog">Cuadro de diálogo de configuración no guardada</sys:String>
+    <sys:String x:Key="MainWindow_LoadingOverlay">Superposición de carga de inicio de la aplicación</sys:String>
+
+    <!-- LogViewerView -->
+    <sys:String x:Key="LogViewerView_Title">ThreadPilot Actividad</sys:String>
+    <sys:String x:Key="LogViewerView_Subtitle">Muestra las acciones realizadas por ThreadPilot, incluidas reglas aplicadas, cambios de afinidad, cambios de prioridad, cambios de plan de energía, cambios de configuración, ajustes, optimizaciones y mensajes de falla segura.</sys:String>
+    <sys:String x:Key="LogViewerView_Search">Buscar:</sys:String>
+    <sys:String x:Key="LogViewerView_CategoryLabel">Categoría:</sys:String>
+    <sys:String x:Key="LogViewerView_LevelLabel">Nivel:</sys:String>
+    <sys:String x:Key="LogViewerView_From">De:</sys:String>
+    <sys:String x:Key="LogViewerView_To">Para:</sys:String>
+    <sys:String x:Key="LogViewerView_Refresh">Actualizar</sys:String>
+    <sys:String x:Key="LogViewerView_ClearDisplay">Borrar pantalla</sys:String>
+    <sys:String x:Key="LogViewerView_ExportActivity">Exportar actividad</sys:String>
+    <sys:String x:Key="LogViewerView_CleanupDiagnostics">Limpiar archivos de diagnóstico</sys:String>
+    <sys:String x:Key="LogViewerView_OpenFolder">Abrir carpeta de diagnóstico</sys:String>
+
+    <!-- LogViewerView Grid Headers -->
+    <sys:String x:Key="LogViewerView_HeaderTime">tiempo</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderStatus">Estado</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderCategory">Categoría</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderMessage">Mensaje</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderDetails">Detalles</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderId">identificación</sys:String>
+    <sys:String x:Key="LogViewerView_ContextMenuCopy">Copiar entrada</sys:String>
+    <sys:String x:Key="LogViewerView_ContextMenuRefresh">Actualizar</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntries">No hay entradas de registro para mostrar</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntriesTip">Ajuste los filtros o actualice los registros para cargar la actividad ThreadPilot reciente.</sys:String>
+
+    <!-- LogViewerView Details -->
+    <sys:String x:Key="LogViewerView_DetailsTitle">Detalles de la actividad</sys:String>
+    <sys:String x:Key="LogViewerView_Timestamp">Marca de tiempo:</sys:String>
+    <sys:String x:Key="LogViewerView_Status">Estado:</sys:String>
+    <sys:String x:Key="LogViewerView_Category">Categoría:</sys:String>
+    <sys:String x:Key="LogViewerView_Message">Mensaje:</sys:String>
+    <sys:String x:Key="LogViewerView_Details">Detalles:</sys:String>
+    <sys:String x:Key="LogViewerView_CorrelationId">ID de correlación:</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntrySelected">No se seleccionó ninguna entrada de registro</sys:String>
+    <sys:String x:Key="LogViewerView_Files">Archivos:</sys:String>
+    <sys:String x:Key="LogViewerView_Size">Tamaño:</sys:String>
+    <sys:String x:Key="LogViewerView_DebugDiagnostics">Diagnóstico de depuración</sys:String>
+    <sys:String x:Key="LogViewerView_MaxSize">Tamaño máximo (MB):</sys:String>
+    <sys:String x:Key="LogViewerView_Retention">Retención (Días):</sys:String>
+    <sys:String x:Key="LogViewerView_SaveSettings">Guardar configuración</sys:String>
+
+    <!-- MasksView -->
+    <sys:String x:Key="MasksView_Title">Máscaras de CPU</sys:String>
+    <sys:String x:Key="MasksView_Subtitle">Cree ajustes preestablecidos de afinidad CPU reutilizables para uso por proceso.</sys:String>
+    <sys:String x:Key="MasksView_EditingClarification">Al seleccionar una máscara aquí solo se edita el ajuste preestablecido. No cambia la afinidad de CPU hasta que la aplica a un proceso o la guarda en una regla de proceso.</sys:String>
+    <sys:String x:Key="MasksView_New">Nuevo</sys:String>
+    <sys:String x:Key="MasksView_Delete">Eliminar</sys:String>
+    <sys:String x:Key="MasksView_Duplicate">Duplicar máscara</sys:String>
+    <sys:String x:Key="MasksView_Info">Información de la máscara</sys:String>
+    <sys:String x:Key="MasksView_Name">Nombre:</sys:String>
+    <sys:String x:Key="MasksView_Description">Descripción:</sys:String>
+    <sys:String x:Key="MasksView_Enabled">Habilitado</sys:String>
+    <sys:String x:Key="MasksView_DefaultPreset">Preajuste predeterminado</sys:String>
+    <sys:String x:Key="MasksView_DefaultPresetTip">Preseleccionado cuando ThreadPilot necesita una máscara alternativa o al crear reglas por proceso. No aplica la afinidad CPU automáticamente.</sys:String>
+    <sys:String x:Key="MasksView_DisableTip">Desactivar para ocultar temporalmente esta máscara</sys:String>
+    <sys:String x:Key="MasksView_SelectCpus">Seleccionar CPU</sys:String>
+    <sys:String x:Key="MasksView_SelectCpusTip">Cambie CPUs para editar este ajuste preestablecido de máscara. Los cambios se guardan automáticamente y no afectan los procesos en ejecución. All Cores es el valor preestablecido predeterminado protegido.</sys:String>
+    <sys:String x:Key="MasksView_SavedAutomatically">Los nombres de máscara, las descripciones, las selecciones CPU y las opciones se guardan automáticamente.</sys:String>
+    <sys:String x:Key="MasksView_CreateNewTooltip">Crea una nueva máscara CPU</sys:String>
+    <sys:String x:Key="MasksView_DeleteTooltip">Eliminar máscara seleccionada</sys:String>
+    <sys:String x:Key="MasksView_CpusHeader">CPUs</sys:String>
+    <sys:String x:Key="MasksView_Cpu">CPU</sys:String>
+    <sys:String x:Key="MasksView_Options">Opciones de máscara</sys:String>
+
+    <!-- PerformanceView -->
+    <sys:String x:Key="PerformanceView_OptionalDiagnostics">Diagnóstico opcional</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc">Los diagnósticos son opcionales y están destinados a la resolución de problemas. Para superposiciones en el juego y gráficos de rendimiento detallados, utilice herramientas dedicadas.</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc1">Los diagnósticos son opcionales y están destinados a la resolución de problemas.</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc2">Para superposiciones en el juego y gráficos de rendimiento detallados, utilice herramientas dedicadas.</sys:String>
+    <sys:String x:Key="PerformanceView_QuickTips">Consejos rápidos:</sys:String>
+    <sys:String x:Key="PerformanceView_Tip1">1. Abra los diagnósticos solo cuando necesite una instantánea de solución de problemas enfocada.</sys:String>
+    <sys:String x:Key="PerformanceView_Tip2">2. Revise los puntos de acceso solo como sugerencia antes de crear reglas de automatización.</sys:String>
+    <sys:String x:Key="PerformanceView_Tip3">3. Detenga las métricas en vivo cuando haya terminado de solucionar el problema.</sys:String>
+    <sys:String x:Key="PerformanceView_Continue">Continuar a Diagnóstico</sys:String>
+
+    <sys:String x:Key="PerformanceView_ActiveProcesses">Procesos activos</sys:String>
+    <sys:String x:Key="PerformanceView_TopConsumersDesc">Principales consumidores de memoria y CPU con creación de reglas con un solo clic.</sys:String>
+    <sys:String x:Key="PerformanceView_SearchPlaceholder">Buscar procesos por nombre</sys:String>
+    <sys:String x:Key="PerformanceView_RuleBackedOnly">Solo respaldado por reglas</sys:String>
+    <sys:String x:Key="PerformanceView_ActionableOnly">Sólo procesable</sys:String>
+    <sys:String x:Key="PerformanceView_RuleImpact">Impacto de la regla</sys:String>
+    <sys:String x:Key="PerformanceView_CreateRuleButton">Crear/actualizar regla a partir de la selección</sys:String>
+    <sys:String x:Key="PerformanceView_CreateRuleTooltip">Cree o actualice una regla de automatización desde el proceso de punto de acceso seleccionado</sys:String>
+
+    <sys:String x:Key="PerformanceView_Timeline">Cronología de estabilidad</sys:String>
+    <sys:String x:Key="PerformanceView_ClearHistory">Borrar historial</sys:String>
+    <sys:String x:Key="PerformanceView_ClearHistoryTooltip">Borrar las métricas mostradas y el historial de la línea de tiempo</sys:String>
+    <sys:String x:Key="PerformanceView_CoreSnapshot">Resumen de núcleos</sys:String>
+    <sys:String x:Key="PerformanceView_CoreSnapshotDesc">Uso por núcleo para detectar rápidamente posibles desequilibrios.</sys:String>
+    <sys:String x:Key="PerformanceView_ToggleCore">Alternar panel principal</sys:String>
+    <sys:String x:Key="PerformanceView_ToggleProcess">Alternar panel de proceso</sys:String>
+    <sys:String x:Key="PerformanceView_StartLive">Iniciar métricas en vivo</sys:String>
+    <sys:String x:Key="PerformanceView_StartLiveTooltip">Iniciar la recopilación de métricas en vivo para este panel</sys:String>
+    <sys:String x:Key="PerformanceView_StopLive">Detener métricas en vivo</sys:String>
+    <sys:String x:Key="PerformanceView_StopLiveTooltip">Pausar la recopilación de métricas en vivo; la automatización en segundo plano es independiente</sys:String>
+    <sys:String x:Key="PerformanceView_Refresh">Actualizar</sys:String>
+    <sys:String x:Key="PerformanceView_RefreshTooltip">Actualizar la instantánea del panel actual</sys:String>
+
+    <sys:String x:Key="PerformanceView_GlobalPowerPlan">Plan de energía global</sys:String>
+    <sys:String x:Key="PerformanceView_ProcessHotspots">Puntos críticos de proceso</sys:String>
+    <sys:String x:Key="PerformanceView_Filter">Filtrar</sys:String>
+    <sys:String x:Key="PerformanceView_Memory">Memoria</sys:String>
+    <sys:String x:Key="PerformanceView_Name">Nombre</sys:String>
+    <sys:String x:Key="PerformanceView_Priority">Prioridad</sys:String>
+    <sys:String x:Key="PerformanceView_Window">ventana</sys:String>
+    <sys:String x:Key="PerformanceView_MemoryUsed">Memoria utilizada</sys:String>
+    <sys:String x:Key="PerformanceView_CpuPercent">CPU%</sys:String>
+    <sys:String x:Key="PerformanceView_MemPercent">% memoria</sys:String>
+    <sys:String x:Key="PerformanceView_Threads">Hilos</sys:String>
+    <sys:String x:Key="PerformanceView_Events">Eventos</sys:String>
+    <sys:String x:Key="PerformanceView_Severity">Gravedad</sys:String>
+    <sys:String x:Key="PerformanceView_Detail">Detalle</sys:String>
+    <sys:String x:Key="PerformanceView_Time">tiempo</sys:String>
+    <sys:String x:Key="PerformanceView_Category">Categoría</sys:String>
+    <sys:String x:Key="PerformanceView_Process">Proceso</sys:String>
+    <sys:String x:Key="PerformanceView_SelectedHotspot">Proceso de punto de acceso seleccionado</sys:String>
+    <sys:String x:Key="PerformanceView_Metrics">Métricas</sys:String>
+    <sys:String x:Key="PerformanceView_Processes">Procesos</sys:String>
+
+    <!-- PowerPlanView -->
+    <sys:String x:Key="PowerPlanView_Title">Planes de energía</sys:String>
+    <sys:String x:Key="PowerPlanView_Subtitle">Administre el plan de energía activo Windows e importe perfiles .pow personalizados</sys:String>
+    <sys:String x:Key="PowerPlanView_WindowsPowerPlans">Windows Planes de energía</sys:String>
+    <sys:String x:Key="PowerPlanView_SelectActiveTip">Seleccione el plan Windows para activarlo.</sys:String>
+    <sys:String x:Key="PowerPlanView_SetActive">Establecer como plan activo Windows</sys:String>
+    <sys:String x:Key="PowerPlanView_SetActiveTooltip">Cambie el plan de energía activo Windows al plan seleccionado</sys:String>
+    <sys:String x:Key="PowerPlanView_Refresh">Actualizar planes</sys:String>
+    <sys:String x:Key="PowerPlanView_RefreshTooltip">Actualizar la lista de planes de energía disponibles</sys:String>
+    <sys:String x:Key="PowerPlanView_CustomPowerPlans">Planes de energía personalizados</sys:String>
+    <sys:String x:Key="PowerPlanView_LocalPlansTip">Archivos .pow locales listos para importar a Windows.</sys:String>
+    <sys:String x:Key="PowerPlanView_ImportSelected">Importar .pow seleccionado</sys:String>
+    <sys:String x:Key="PowerPlanView_ImportSelectedTooltip">Importe el archivo .pow personalizado seleccionado a Windows</sys:String>
+    <sys:String x:Key="PowerPlanView_AddFile">Agregar archivo .pow</sys:String>
+    <sys:String x:Key="PowerPlanView_AddFileTooltip">Agregue un nuevo archivo de plan de energía personalizado a la biblioteca personalizada</sys:String>
+    <sys:String x:Key="PowerPlanView_Delete">Eliminar</sys:String>
+    <sys:String x:Key="PowerPlanView_Active">Activo</sys:String>
+
+    <!-- ProcessPowerPlanAssociationView -->
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Title">Reglas y automatización</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Subtitle">El monitoreo de automatización observa los eventos de inicio/detención del proceso y aplica el plan de energía configurado, la máscara CPU y las reglas de prioridad.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleEditor">Editor de reglas</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EditorSubtitle">Cree una regla a partir de un proceso ejecutable o en ejecución para automatizar el plan de energía, la máscara CPU y el comportamiento prioritario.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ExecutableMatch">Coincidencia ejecutable:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_MatchByPath">Emparejar por ruta</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_MatchByPathTooltip">Haga coincidir los procesos por ruta completa en lugar de solo por el nombre del ejecutable</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Browse">Buscar ejecutable</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_BrowseTooltip">Haga clic para seleccionar un archivo ejecutable (.exe) desde su computadora</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ExecutableHelp">Elija un ejecutable. La coincidencia por ruta es más precisa; la coincidencia por nombre se aplica a cualquier proceso con ese nombre ejecutable.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseRunningProcess">Utilice el proceso en ejecución:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseRunningProcessTooltip">Seleccione un proceso actualmente en ejecución para usar su ejecutable</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseSelectedProcess">Usar el proceso seleccionado</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseSelectedProcessTooltip">Utilice el ejecutable del proceso en ejecución seleccionado</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePowerPlan">Plan de energía de reglas (cambio global):</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePowerPlanHelp">Cuando esta regla coincide, Windows cambia el plan de energía activo global.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleCpuMask">Regla CPU Máscara:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleCpuMaskHelp">Opcional: seleccione una máscara CPU para aplicar cuando comience este proceso</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePriority">Prioridad de regla</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Update">Actualizar</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePriorityHelp">Opcional: seleccione la prioridad del proceso que se aplicará cuando comience este proceso.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AssociationPriority">Prioridad de la asociación:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AssociationPriorityHelp">Las asociaciones de mayor prioridad tienen prioridad cuando hay coincidencias múltiples</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AddRule">Agregar regla</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UpdateRule">Actualizar regla seleccionada</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UpdateRuleTooltip">Actualizar la asociación seleccionada</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ClearSelection">Borrar selección</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ClearSelectionTooltip">Borrar el ejecutable seleccionado</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_CurrentRules">Reglas actuales</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulesDescription">Definir reglas por proceso. Los planes de energía son globales; Las máscaras y prioridades se aplican a los procesos de emparejamiento.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Remove">Quitar</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RemoveTooltip">Eliminar la asociación seleccionada</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DefaultPowerPlan">Plan de energía predeterminado (alternativo cuando ninguna regla coincide)</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DefaultPowerPlanHelp">Plan de energía a utilizar cuando no se estén ejecutando procesos asociados:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SetDefault">Establecer plan de energía predeterminado</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SettingsTitle">Configuración de monitoreo de automatización</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EnableWmi">Habilitar la automatización basada en eventos (WMI)</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EnableFallback">Habilitar el sondeo alternativo de automatización</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PollingInterval">Intervalo de sondeo (segundos):</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ChangeDelay">Retraso en el cambio del plan de energía (ms):</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PreventDuplicates">Evite cambios duplicados en el plan de energía</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SaveConfig">Guardar configuración</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_NoRules">Aún no hay reglas de automatización</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Status">Estado:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationMonitoring">Monitoreo de automatización</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_StartAutomation">Iniciar monitoreo de automatización</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_StopAutomation">Detener el monitoreo de automatización</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AppliedToMatching">Se aplica a cada proceso coincidente cuando se ejecuta la regla de automatización.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AppliedOnlyToMatching">Aplicado únicamente a procesos de casación; no cambia el plan de energía global Windows.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SelectedExecutable">Ejecutable seleccionado:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DescriptionLabel">Descripción:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationService">Servicio de automatización</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulesHeader">Reglas</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">ejecutable</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Plan de energía</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_CpuMask">Máscara de CPU</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Priority">Prioridad</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Description">Descripción</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ProcessPriority">Prioridad del proceso:</sys:String>
+
+    <!-- ProcessView -->
+    <sys:String x:Key="ProcessView_Title">Gestión de procesos</sys:String>
+    <sys:String x:Key="ProcessView_Subtitle">Buscar, filtrar y controlar configuraciones de procesos activos</sys:String>
+    <sys:String x:Key="ProcessView_SearchPlaceholder">Buscar procesos por nombre</sys:String>
+    <sys:String x:Key="ProcessView_SearchAutomationName">Búsqueda de procesos</sys:String>
+    <sys:String x:Key="ProcessView_HideSystem">Ocultar procesos del sistema Windows</sys:String>
+    <sys:String x:Key="ProcessView_HideSystemShort">Ocultar procesos del sistema</sys:String>
+    <sys:String x:Key="ProcessView_HideLowCpu">Ocultar procesos con muy bajo uso de CPU</sys:String>
+    <sys:String x:Key="ProcessView_HideIdle">Ocultar procesos inactivos</sys:String>
+    <sys:String x:Key="ProcessView_VisibleWindowsOnly">Mostrar solo aplicaciones con windows visible</sys:String>
+    <sys:String x:Key="ProcessView_ActiveAppsOnly">Sólo aplicaciones activas</sys:String>
+    <sys:String x:Key="ProcessView_LockList">Lista de procesos de bloqueo</sys:String>
+    <sys:String x:Key="ProcessView_LockListTooltip">Pause el proceso de actualización de la lista y ordene las actualizaciones mientras trabaja con la lista actual. La supervisión en segundo plano y la aplicación automática de reglas guardadas continúan mientras se ejecuta ThreadPilot.</sys:String>
+    <sys:String x:Key="ProcessView_SortBy">Ordenar por:</sys:String>
+    <sys:String x:Key="ProcessView_SortByTooltip">Elija cómo ordenar la lista de procesos</sys:String>
+
+    <sys:String x:Key="ProcessView_SelectedProcess">Proceso seleccionado</sys:String>
+    <sys:String x:Key="ProcessView_NoProcessSelected">Ningún proceso seleccionado</sys:String>
+    <sys:String x:Key="ProcessView_SelectProcessTip">Seleccione un proceso de la tabla para habilitar acciones de afinidad, prioridad, plan de energía y reglas.</sys:String>
+    <sys:String x:Key="ProcessView_PowerPlanPending">Plan de energía/Configuraciones pendientes</sys:String>
+    <sys:String x:Key="ProcessView_PowerPlanTooltip">Elija el plan de energía para activarlo manualmente o incluirlo con aplicación rápida</sys:String>
+    <sys:String x:Key="ProcessView_SetPowerPlan">Establecer plan de energía</sys:String>
+    <sys:String x:Key="ProcessView_SetPowerPlanTooltip">Activar el plan de energía Windows seleccionado</sys:String>
+
+    <sys:String x:Key="ProcessView_PendingCoreMask">Máscara central pendiente</sys:String>
+    <sys:String x:Key="ProcessView_StageMaskTooltip">Selecciona una máscara para ponerla en escena. Esto no cambia la afinidad del sistema operativo hasta que se hace clic en Aplicar afinidad.</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinity">Aplicar afinidad</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinityTooltip">Aplique la máscara central pendiente al proceso seleccionado y verifique el estado de afinidad Windows</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinitySaveRule">Aplicar afinidad y guardar como regla</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinitySaveRuleTooltip">Guarde la configuración del proceso actual como regla. Esta configuración se aplicará automáticamente cuando este proceso comience en el futuro.</sys:String>
+
+    <sys:String x:Key="ProcessView_SetCpuPriority">Establecer prioridad CPU</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPriorityTooltip">Aplicar la prioridad seleccionada al proceso.</sys:String>
+    <sys:String x:Key="ProcessView_EnforcePriorityRegistry">Hacer cumplir la prioridad por registro</sys:String>
+    <sys:String x:Key="ProcessView_EnforcePriorityRegistryTooltip">Aplicar prioridad a través del registro Windows. Se debe reiniciar el proceso para que los cambios surtan efecto. Esta configuración persiste tras los reinicios del sistema.</sys:String>
+    <sys:String x:Key="ProcessView_SetPriority">Establecer prioridad</sys:String>
+    <sys:String x:Key="ProcessView_RealtimeBlockedHelp">La prioridad en tiempo real está bloqueada por ThreadPilot porque puede hacer que Windows sea inestable o no responda.</sys:String>
+    <sys:String x:Key="ProcessView_RealtimeBlocked">Tiempo real (bloqueado)</sys:String>
+
+    <sys:String x:Key="ProcessView_DisableIdleServer">Deshabilitar el servidor inactivo</sys:String>
+    <sys:String x:Key="ProcessView_DisableIdleServerTooltip">Evita que el sistema entre en estado inactivo mientras se ejecuta este proceso. Útil para juegos y aplicaciones críticas para el rendimiento.</sys:String>
+
+    <sys:String x:Key="ProcessView_ProfileRule">Perfil / Regla</sys:String>
+    <sys:String x:Key="ProcessView_ProfileNamePlaceholder">Ingrese un nombre de perfil para guardar o cargar la configuración</sys:String>
+    <sys:String x:Key="ProcessView_SaveProfile">Guardar perfil</sys:String>
+    <sys:String x:Key="ProcessView_SaveProfileTooltip">Guarde la afinidad y prioridad CPU actuales como un perfil reutilizable</sys:String>
+    <sys:String x:Key="ProcessView_LoadProfile">Perfil de carga</sys:String>
+    <sys:String x:Key="ProcessView_LoadProfileTooltip">Cargar un perfil previamente guardado</sys:String>
+    <sys:String x:Key="ProcessView_SaveCurrentRule">Guardar la configuración actual como regla</sys:String>
+
+    <sys:String x:Key="ProcessView_LastAction">Última acción ThreadPilot:</sys:String>
+    <sys:String x:Key="ProcessView_Refresh">Actualizar</sys:String>
+    <sys:String x:Key="ProcessView_RefreshTooltip">Actualizar la lista de procesos</sys:String>
+    <sys:String x:Key="ProcessView_LoadMore">Cargar más</sys:String>
+    <sys:String x:Key="ProcessView_LoadMoreTooltip">Cargar más procesos</sys:String>
+    <sys:String x:Key="ProcessView_RefreshAutomationName">Actualizar procesos</sys:String>
+    <sys:String x:Key="ProcessView_LoadMoreAutomationName">Cargar más procesos</sys:String>
+    <sys:String x:Key="ProcessView_RunningListAutomationName">Lista de procesos en ejecución</sys:String>
+    <sys:String x:Key="ProcessView_RunningListAutomationHelp">Mesa de proceso virtualizada con clasificación y selección.</sys:String>
+
+    <sys:String x:Key="ProcessView_ColProcessName">Nombre del proceso</sys:String>
+    <sys:String x:Key="ProcessView_ColWindowTitle">Título de la ventana</sys:String>
+    <sys:String x:Key="ProcessView_ColCpuUsage">Uso de CPU</sys:String>
+    <sys:String x:Key="ProcessView_ColMemory">Uso de la memoria</sys:String>
+
+    <sys:String x:Key="ProcessView_AffinityStagedTooltip">Afinidad puesta en escena en la interfaz de usuario. No se aplica hasta que se hace clic en Aplicar afinidad.</sys:String>
+    <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Afinidad reportada actualmente por Windows para el proceso seleccionado</sys:String>
+    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Vista previa de solo lectura de la selección CPU actual o pendiente</sys:String>
+    <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Abra la pestaña Máscaras CPU para crear una nueva máscara personalizada</sys:String>
+    <sys:String x:Key="ProcessView_HyperThreadingTooltip">Muestra si Hyper-Threading (Intel) o SMT (AMD) está presente y activo en este sistema.</sys:String>
+
+    <sys:String x:Key="ProcessView_CopyProcessInfo">Copiar información del proceso</sys:String>
+    <sys:String x:Key="ProcessView_OpenLocation">Abrir ubicación ejecutable</sys:String>
+    <sys:String x:Key="ProcessView_ClearCpuSets">Borrar conjuntos CPU</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPendingSettings">Aplicar configuraciones pendientes</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPendingSettingsTooltip">Aplicar la afinidad pendiente y el plan de energía seleccionado al proceso seleccionado</sys:String>
+    <sys:String x:Key="ProcessView_RulesAppliedOnlyWhenConfigured">ThreadPilot aplica las reglas y los cambios solo cuando están configurados.</sys:String>
+    <sys:String x:Key="ProcessView_CurrentProcessStatus">Estado actual del proceso</sys:String>
+    <sys:String x:Key="ProcessView_AdvancedAffinityPicker">Selector de afinidad avanzado</sys:String>
+    <sys:String x:Key="ProcessView_RowMaskTooltip">Seleccione la máscara pendiente para las acciones de afinidad del menú contextual de fila</sys:String>
+    <sys:String x:Key="ProcessView_SelectedPowerPlan">Plan de energía seleccionado</sys:String>
+    <sys:String x:Key="ProcessView_SaveAsRule">Guardar como regla</sys:String>
+    <sys:String x:Key="ProcessView_NoVisibleWindowTitle">No hay título de ventana visible</sys:String>
+    <sys:String x:Key="ProcessView_BatchLabel">Lotes</sys:String>
+    <sys:String x:Key="ProcessView_TotalSuffix">total)</sys:String>
+    <sys:String x:Key="ProcessView_PriorityInlineLabel">Prioridad</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuUnavailable">CPU: no disponible</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryUnavailable">Memoria: no disponible</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuPriorityUnavailable">CPU prioridad: no disponible</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryPriorityUnavailable">Prioridad de memoria no disponible</sys:String>
+    <sys:String x:Key="ProcessSummary_AffinityUnavailable">Afinidad: no disponible</sys:String>
+    <sys:String x:Key="ProcessSummary_NoSavedRule">Ninguna regla guardada</sys:String>
+    <sys:String x:Key="ProcessSummary_NoRecentAction">Ninguna acción ThreadPilot reciente</sys:String>
+    <sys:String x:Key="ProcessSummary_SelectedProcessFormat">Proceso seleccionado: {0} (PID {1})</sys:String>
+    <sys:String x:Key="ProcessSummary_StatusProtected">Estado actual del proceso: protegido o acceso denegado</sys:String>
+    <sys:String x:Key="ProcessSummary_StatusSelected">Estado actual del proceso: seleccionado</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuFormat">CPU: {0:N1}%</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryFormat">Memoria: {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuPriorityFormat">CPU prioridad: {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_AffinityLegacyFormat">Afinidad: máscara heredada 0x{0:X}</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryPriorityFormat">Prioridad de memoria: {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_SavedRuleFallback">regla guardada</sys:String>
+    <sys:String x:Key="ProcessSummary_SavedRuleExistsFormat">La regla guardada existe: {0}</sys:String>
+
+    <sys:String x:Key="ProcessView_PriorityAboveNormal">Por encima de lo normal</sys:String>
+    <sys:String x:Key="ProcessView_PriorityBelowNormal">Por debajo de lo normal</sys:String>
+    <sys:String x:Key="ProcessView_PriorityHigh">Alto</sys:String>
+    <sys:String x:Key="ProcessView_PriorityIdle">inactivo</sys:String>
+    <sys:String x:Key="ProcessView_PriorityLow">Bajo</sys:String>
+    <sys:String x:Key="ProcessView_PriorityNormal">Normal</sys:String>
+    <sys:String x:Key="ProcessView_PriorityRealtime">En tiempo real</sys:String>
+    <sys:String x:Key="ProcessView_PriorityBatch">Lotes</sys:String>
+    <sys:String x:Key="ProcessView_PriorityCustom">personalizado</sys:String>
+
+    <sys:String x:Key="ProcessView_HasWindow">Tiene ventana</sys:String>
+    <sys:String x:Key="ProcessView_Window">ventana</sys:String>
+    <sys:String x:Key="ProcessView_PID">PID</sys:String>
+    <sys:String x:Key="ProcessView_ID">ID</sys:String>
+    <sys:String x:Key="ProcessView_MemoryMb">Memoria (MB)</sys:String>
+    <sys:String x:Key="ProcessView_Affinity">Afinidad</sys:String>
+    <sys:String x:Key="ProcessView_Priority">Prioridad</sys:String>
+    <sys:String x:Key="ProcessView_Rules">Reglas</sys:String>
+    <sys:String x:Key="ProcessView_Name">Nombre</sys:String>
+    <sys:String x:Key="ProcessView_SetMemoryPriority">Establecer prioridad de memoria</sys:String>
+    <sys:String x:Key="ProcessView_PriorityVeryLow">Muy bajo</sys:String>
+    <sys:String x:Key="ProcessView_PriorityMedium">Medio</sys:String>
+    <sys:String x:Key="ProcessView_RefreshInfo">Actualizar información del proceso</sys:String>
+
+    <!-- SettingsView -->
+    <sys:String x:Key="SettingsView_Title">Configuración de la aplicación</sys:String>
+    <sys:String x:Key="SettingsView_Subtitle">Configurar notificaciones, bandeja del sistema y comportamiento de las aplicaciones</sys:String>
+    <sys:String x:Key="SettingsView_Notifications">Notificaciones</sys:String>
+    <sys:String x:Key="SettingsView_EnableNotifications">Habilitar notificaciones</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevel">Nivel de notificación</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelAll">Todos</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelWarningsErrors">Advertencias/Errores solamente</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelSilent">silencioso</sys:String>
+    <sys:String x:Key="SettingsView_EnableBalloon">Habilitar notificaciones de globo (bandeja del sistema)</sys:String>
+    <sys:String x:Key="SettingsView_EnableToast">Habilitar notificaciones del sistema (Windows 10+)</sys:String>
+    <sys:String x:Key="SettingsView_NotificationTypes">Tipos de notificación</sys:String>
+    <sys:String x:Key="SettingsView_NotifyPowerPlan">Cambios en el plan de energía</sys:String>
+    <sys:String x:Key="SettingsView_NotifyProcess">Eventos de monitoreo de procesos</sys:String>
+    <sys:String x:Key="SettingsView_NotifyError">Notificaciones de errores</sys:String>
+    <sys:String x:Key="SettingsView_NotifySuccess">Notificaciones de éxito</sys:String>
+    <sys:String x:Key="SettingsView_Duration">Duración (ms):</sys:String>
+    <sys:String x:Key="SettingsView_TestNotification">Notificación de prueba</sys:String>
+
+    <sys:String x:Key="SettingsView_SystemTray">Bandeja del sistema</sys:String>
+    <sys:String x:Key="SettingsView_ShowTrayIcon">Mostrar icono de bandeja</sys:String>
+    <sys:String x:Key="SettingsView_MinimizeToTray">Minimizar a bandeja</sys:String>
+    <sys:String x:Key="SettingsView_CloseToTray">Cerca de la bandeja (en lugar de salir)</sys:String>
+    <sys:String x:Key="SettingsView_StartMinimized">Empezar minimizado</sys:String>
+    <sys:String x:Key="SettingsView_QuickApply">Habilitar configuración pendiente aplicar desde la bandeja</sys:String>
+    <sys:String x:Key="SettingsView_MonitoringControl">Habilite los controles de monitoreo de automatización desde la bandeja</sys:String>
+    <sys:String x:Key="SettingsView_DetailedTooltips">Mostrar información sobre herramientas detallada</sys:String>
+
+    <sys:String x:Key="SettingsView_BasicPreferences">Preferencias básicas</sys:String>
+    <sys:String x:Key="SettingsView_Autostart">Inicio automático</sys:String>
+    <sys:String x:Key="SettingsView_StartWithWindows">Comience con Windows</sys:String>
+    <sys:String x:Key="SettingsView_AutostartDescription">Iniciar automáticamente ThreadPilot cuando se inicia Windows</sys:String>
+    <sys:String x:Key="SettingsView_LowImpactMode">Modo de bajo impacto en segundo plano.</sys:String>
+    <sys:String x:Key="SettingsView_LowImpactDescription">Reduzca la prioridad del proceso de ThreadPilot mientras está minimizado u oculto en la bandeja.</sys:String>
+
+    <sys:String x:Key="SettingsView_Appearance">Apariencia</sys:String>
+    <sys:String x:Key="SettingsView_UseDarkTheme">Usar tema oscuro</sys:String>
+    <sys:String x:Key="SettingsView_ThemeDescription">Aplica un tema global Oscuro/Claro en todas las pestañas</sys:String>
+
+    <sys:String x:Key="SettingsView_Language">Idioma</sys:String>
+    <sys:String x:Key="SettingsView_LanguageZhCn">简体中文 (Simplified Chinese)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageEnUs">English (English)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageItIt">Italiano (Italian)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageFrFr">Français (French)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageDeDe">Deutsch (German)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageEsEs">Español (Spanish)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageRuRu">Русский (Russian)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageDescription">Aplica un idioma de visualización global en toda la interfaz de la aplicación.</sys:String>
+
+    <sys:String x:Key="SettingsView_RulesAutomation">Reglas y automatización</sys:String>
+    <sys:String x:Key="SettingsView_RuleAutoApply">Aplicación automática de regla guardada</sys:String>
+    <sys:String x:Key="SettingsView_ApplyOnStart">Aplicar reglas guardadas cuando comiencen los procesos coincidentes</sys:String>
+    <sys:String x:Key="SettingsView_ApplyOnStartDescription">Aplica reglas guardadas habilitadas mientras se ejecuta ThreadPilot. Esto no instala un servicio Windows y no utiliza persistencia de registro/IFEO.</sys:String>
+    <sys:String x:Key="SettingsView_EnableWmi">Habilitar eventos de proceso WMI</sys:String>
+    <sys:String x:Key="SettingsView_WmiDescription">Utilice Windows Management Instrumentation para eventos de inicio/detención de procesos</sys:String>
+    <sys:String x:Key="SettingsView_EnableFallback">Habilitar el sondeo alternativo</sys:String>
+    <sys:String x:Key="SettingsView_FallbackDescription">Utilice el sondeo como respaldo cuando fallan los eventos del proceso WMI</sys:String>
+    <sys:String x:Key="SettingsView_PollingInterval">Intervalo de sondeo (ms):</sys:String>
+    <sys:String x:Key="SettingsView_FallbackPollingInterval">Encuesta alternativa (ms):</sys:String>
+
+    <sys:String x:Key="SettingsView_Advanced">Avanzado</sys:String>
+    <sys:String x:Key="SettingsView_NotificationHistory">Habilitar el historial de notificaciones</sys:String>
+    <sys:String x:Key="SettingsView_MaxHistory">Elementos máximos del historial:</sys:String>
+    <sys:String x:Key="SettingsView_AutoHide">Ocultar notificaciones automáticamente</sys:String>
+    <sys:String x:Key="SettingsView_NotificationSound">Habilitar sonido de notificación</sys:String>
+    <sys:String x:Key="SettingsView_DebugLogging">Habilitar el registro de depuración</sys:String>
+    <sys:String x:Key="SettingsView_PerformanceCounters">Habilitar contadores de rendimiento</sys:String>
+
+    <sys:String x:Key="SettingsView_About">Acerca de</sys:String>
+    <sys:String x:Key="SettingsView_Version">Versión:</sys:String>
+    <sys:String x:Key="SettingsView_Copyright">Copyright © 2026 PrimeBuild</sys:String>
+    <sys:String x:Key="SettingsView_Translator">Traductor: Ylimhs</sys:String>
+    <sys:String x:Key="SettingsView_License">Licencia: AGPLv3</sys:String>
+    <sys:String x:Key="SettingsView_CheckUpdates">Buscar actualizaciones</sys:String>
+    <sys:String x:Key="SettingsView_DownloadInstallUpdate">Descargar e instalar la actualización</sys:String>
+    <sys:String x:Key="SettingsView_EnableAutomaticUpdateChecks">Verificar automáticamente al iniciar</sys:String>
+    <sys:String x:Key="SettingsView_UpdateIntervalDays">Intervalo de verificación (días):</sys:String>
+    <sys:String x:Key="SettingsView_IncludePrereleaseUpdates">Incluir actualizaciones preliminares</sys:String>
+    <sys:String x:Key="SettingsView_LatestVersion">Última versión:</sys:String>
+    <sys:String x:Key="SettingsView_LastUpdateCheck">Última comprobación:</sys:String>
+    <sys:String x:Key="SettingsView_UpdatesDescription">Verificaciones bajo demanda utilizando las versiones oficiales GitHub.</sys:String>
+
+    <sys:String x:Key="SettingsView_ResetDefaults">Restablecer los valores predeterminados</sys:String>
+    <sys:String x:Key="SettingsView_ExportConfig">Configuración de exportación</sys:String>
+    <sys:String x:Key="SettingsView_ImportConfig">Importar configuración</sys:String>
+    <sys:String x:Key="SettingsView_SaveSettings">Guardar configuración</sys:String>
+    <sys:String x:Key="SettingsView_ThreadPilot">ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_StatusThemeChangedFormat">El tema cambió a {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusThemeChangeFailedFormat">No se pudo cambiar el tema a {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusLanguageChangedFormat">El idioma cambió a {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusLanguageChangeFailed">No se pudo cambiar el idioma.</sys:String>
+    <sys:String x:Key="Settings_StatusSaving">Guardando configuración...</sys:String>
+    <sys:String x:Key="Settings_StatusSavedWarningsFormat">Configuraciones guardadas con advertencias: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusSavedApplied">La configuración se guardó y se aplicó correctamente.</sys:String>
+    <sys:String x:Key="Settings_StatusErrorSavingFormat">Error al guardar la configuración: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusResetting">Restableciendo los valores predeterminados...</sys:String>
+    <sys:String x:Key="Settings_StatusResetPending">Configuración restablecida a los valores predeterminados (aún no guardada)</sys:String>
+    <sys:String x:Key="Settings_StatusErrorResettingFormat">Error al restablecer la configuración: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusExporting">Exportando paquete de configuración...</sys:String>
+    <sys:String x:Key="Settings_StatusExportCanceled">Exportación cancelada</sys:String>
+    <sys:String x:Key="Settings_StatusExportedFormat">Configuración exportada a: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusErrorExportingFormat">Error al exportar la configuración: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusImporting">Importando configuración...</sys:String>
+    <sys:String x:Key="Settings_StatusImportCanceled">Importación cancelada</sys:String>
+    <sys:String x:Key="Settings_StatusImportedApplied">Paquete de configuración importado y aplicado</sys:String>
+    <sys:String x:Key="Settings_StatusLegacyImported">Configuración heredada importada (reglas sin cambios)</sys:String>
+    <sys:String x:Key="Settings_StatusErrorImportingFormat">Error al importar la configuración: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusTestSent">Notificación de prueba enviada</sys:String>
+    <sys:String x:Key="Settings_StatusErrorTestFormat">Error al enviar la notificación de prueba: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusLoading">Cargando configuración...</sys:String>
+    <sys:String x:Key="Settings_StatusLoaded">Configuraciones cargadas</sys:String>
+    <sys:String x:Key="Settings_StatusErrorLoadingFormat">Error al cargar la configuración: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusSynchronized">Configuraciones sincronizadas</sys:String>
+    <sys:String x:Key="Settings_StatusCheckingUpdates">Buscando actualizaciones...</sys:String>
+    <sys:String x:Key="Settings_StatusLatestUnknown">No se puede determinar la última versión.</sys:String>
+    <sys:String x:Key="Settings_StatusNewVersionFormat">Nueva versión disponible: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusUpToDateFormat">La aplicación está actualizada. Versión instalada: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateErrorFormat">Error al comprobar actualizaciones: {0}</sys:String>
+    <sys:String x:Key="Settings_UpdateLatestUnknown">Desconocido</sys:String>
+    <sys:String x:Key="Settings_UpdateNotChecked">No comprobado</sys:String>
+    <sys:String x:Key="Settings_UpdateLastCheckedNever">nunca</sys:String>
+    <sys:String x:Key="Settings_UpdateConfirmTitle">Instalar la actualización ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_UpdateConfirmMessageFormat">ThreadPilot descargará y verificará la versión {0}, y luego solicitará permiso a Windows para ejecutar el instalador. ¿Continuar?</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateCanceled">Actualización cancelada.</sys:String>
+    <sys:String x:Key="Settings_StatusDownloadingUpdate">Descargando y verificando actualización...</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateInstallerStarted">Se inició el instalador de la actualización.</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateInstallFailedFormat">Error en la instalación de la actualización: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusModified">La configuración ha sido modificada.</sys:String>
+    <sys:String x:Key="Settings_StatusMatchSaved">Los ajustes coinciden con la configuración guardada</sys:String>
+    <sys:String x:Key="Settings_LanguageSimplifiedChinese">Chino simplificado</sys:String>
+    <sys:String x:Key="Settings_LanguageEnglish">Inglés</sys:String>
+    <sys:String x:Key="Settings_LanguageItalian">Italiano</sys:String>
+    <sys:String x:Key="Settings_LanguageFrench">Francés</sys:String>
+    <sys:String x:Key="Settings_LanguageGerman">Alemán</sys:String>
+    <sys:String x:Key="Settings_LanguageSpanish">Español</sys:String>
+    <sys:String x:Key="Settings_LanguageRussian">Ruso</sys:String>
+    <sys:String x:Key="Settings_ThemeDark">oscuro</sys:String>
+    <sys:String x:Key="Settings_ThemeLight">Claro</sys:String>
+    <sys:String x:Key="Settings_DialogExportTitle">Exportar configuración ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_DialogImportTitle">Importar configuración ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_WarningAutostartFailed">No se pudo actualizar el inicio automático Windows. Manteniendo el estado de inicio automático anterior.</sys:String>
+
+    <!-- SettingsWindow -->
+    <sys:String x:Key="SettingsWindow_Title">ThreadPilot Configuración</sys:String>
+    <sys:String x:Key="SettingsWindow_UnsavedTitle">Configuraciones no guardadas</sys:String>
+    <sys:String x:Key="SettingsWindow_UnsavedDescription">Hay cambios sin guardar. Guárdalos, descártalos o cancela para seguir editando.</sys:String>
+    <sys:String x:Key="SettingsWindow_Cancel">Cancelar</sys:String>
+    <sys:String x:Key="SettingsWindow_Discard">Descartar</sys:String>
+    <sys:String x:Key="SettingsWindow_Save">Guardar</sys:String>
+
+    <!-- SystemTweaksView -->
+    <sys:String x:Key="SystemTweaksView_Title">Ajustes y optimizaciones del sistema</sys:String>
+    <sys:String x:Key="SystemTweaksView_Subtitle">Configurar Windows optimizaciones del sistema y ajustes de rendimiento</sys:String>
+    <sys:String x:Key="SystemTweaksView_RefreshAll">Actualizar todo</sys:String>
+    <sys:String x:Key="SystemTweaksView_RefreshAllTooltip">Actualizar todos los estados de ajuste</sys:String>
+    <sys:String x:Key="SystemTweaksView_TweakTooltip">Alternar este ajuste Windows</sys:String>
+    <sys:String x:Key="SystemTweaksView_Status">Estado</sys:String>
+
+    <!-- SystemTweaks Names and Descriptions -->
+    <sys:String x:Key="SystemTweak_CoreParking_Name">Core Parking</sys:String>
+    <sys:String x:Key="SystemTweak_CoreParking_Desc">Controles CPU core parking para administración de energía</sys:String>
+    <sys:String x:Key="SystemTweak_CStates_Name">C-States</sys:String>
+    <sys:String x:Key="SystemTweak_CStates_Desc">Controles CPU C-States para administración de energía</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Name">HPET</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Desc">Temporizador de eventos de alta precisión para la temporización del sistema</sys:String>
+    <sys:String x:Key="SystemTweak_SysMain_Name">SysMain Servicio</sys:String>
+    <sys:String x:Key="SystemTweak_SysMain_Desc">Windows Superfetch/SysMain servicio para gestión de memoria</sys:String>
+    <sys:String x:Key="SystemTweak_Prefetch_Name">Prefetch</sys:String>
+    <sys:String x:Key="SystemTweak_Prefetch_Desc">Función Windows Prefetch para una carga de aplicaciones más rápida</sys:String>
+    <sys:String x:Key="SystemTweak_PowerThrottling_Name">Power Throttling</sys:String>
+    <sys:String x:Key="SystemTweak_PowerThrottling_Desc">Windows Power Throttling para eficiencia energética</sys:String>
+    <sys:String x:Key="SystemTweak_HighSchedulingCategory_Name">Categoría de programación alta</sys:String>
+    <sys:String x:Key="SystemTweak_HighSchedulingCategory_Desc">Alta prioridad de programación para aplicaciones de juegos</sys:String>
+    <sys:String x:Key="SystemTweak_MenuShowDelay_Name">Menú Mostrar retraso</sys:String>
+    <sys:String x:Key="SystemTweak_MenuShowDelay_Desc">Retraso antes de mostrar menús contextuales</sys:String>
+
+    <!-- SystemTweaksViewModel Messages -->
+    <sys:String x:Key="SystemTweaks_StatusReady">Listo</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshing">Actualizaciones en el sistema...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLastRefreshedFormat">Última actualización: {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshFailed">No se pudieron actualizar los ajustes del sistema</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshFailedShort">Error al actualizar</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusTogglingFormat">Alternando {0}...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnabledFormat">{0} habilitado exitosamente</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisabledFormat">{0} deshabilitado exitosamente</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyEnabledFormat">{0} ha sido habilitado</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyDisabledFormat">{0} ha sido deshabilitado</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyUpdatedTitle">Ajuste del sistema actualizado</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusToggleFailedFormat">No se pudo alternar {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnableFailedFormat">No se pudo habilitar {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisableFailedFormat">No se pudo deshabilitar {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyFailedTitle">Error en el ajuste del sistema</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyFailedFormat">No se pudo {0} {1}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusErrorTogglingFormat">Error al alternar {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyErrorFormat">Error al alternar {0}: {1}</sys:String>
+    <sys:String x:Key="SystemTweaks_WordEnable">habilitar</sys:String>
+    <sys:String x:Key="SystemTweaks_WordDisable">desactivar</sys:String>
+    <sys:String x:Key="SystemTweaks_WordEnabled">habilitado</sys:String>
+    <sys:String x:Key="SystemTweaks_WordDisabled">deshabilitado</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnabled">Habilitado</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisabled">Deshabilitado</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusNotAvailable">No disponible</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLoading">Cargando ajustes en el sistema...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLoadedSuccess">Los ajustes del sistema se cargaron correctamente</sys:String>
+
+    <!-- SystemTray Context Menu & Status -->
+    <sys:String x:Key="SystemTray_OpenDashboard">Abrir panel</sys:String>
+    <sys:String x:Key="SystemTray_OpenDiagnostics">Diagnóstico abierto</sys:String>
+    <sys:String x:Key="SystemTray_PauseMonitoring">Pausar la supervisión de la automatización</sys:String>
+    <sys:String x:Key="SystemTray_ResumeMonitoring">Reanudar el seguimiento de la automatización</sys:String>
+    <sys:String x:Key="SystemTray_SystemStatus">Estado del sistema</sys:String>
+    <sys:String x:Key="SystemTray_NoProcessSelected">Ningún proceso seleccionado</sys:String>
+    <sys:String x:Key="SystemTray_SelectedProcessFormat">Seleccionado: {0}</sys:String>
+    <sys:String x:Key="SystemTray_ApplyPendingToSelected">Aplicar configuraciones pendientes al proceso seleccionado</sys:String>
+    <sys:String x:Key="SystemTray_ApplyPendingToProcessFormat">Aplicar configuraciones pendientes a {0}</sys:String>
+    <sys:String x:Key="SystemTray_PowerPlans">🔋 Planes de energía</sys:String>
+    <sys:String x:Key="SystemTray_Profiles">📋 Perfiles</sys:String>
+    <sys:String x:Key="SystemTray_Settings">Configuración</sys:String>
+    <sys:String x:Key="SystemTray_Exit">Salir</sys:String>
+    <sys:String x:Key="SystemTray_NoProfilesAvailable">No hay perfiles disponibles</sys:String>
+    <sys:String x:Key="SystemTray_PowerPlanFormat">Plan de energía: {0}</sys:String>
+    <sys:String x:Key="SystemTray_StatusWmiError">Error de automatización WMI</sys:String>
+    <sys:String x:Key="SystemTray_StatusActive">Automatización activa</sys:String>
+    <sys:String x:Key="SystemTray_StatusDisabled">Automatización deshabilitada</sys:String>
+    <sys:String x:Key="SystemTray_Unknown">Desconocido</sys:String>
+    <sys:String x:Key="SystemTray_CpuRamStatusFormat">💻 CPU: {0:F1}% | RAM: {1:F1}% | {2}</sys:String>
+
+    <!-- ProcessOperationUserMessages -->
+    <sys:String x:Key="ProcessOperationUserMessages_AccessDenied">Windows negó este cambio. El proceso puede requerir derechos de administrador o puede estar protegido.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_AntiCheatProtectedLikely">El proceso aparece protegido por anti-trampas o protección de proceso. ThreadPilot no intentará omitirlo.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_AdminClarification">El modo de administrador puede ayudar con problemas de permisos normales, pero no puede eludir las restricciones de procesos protegidos o anti-trampas.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_LegacyFallbackBlocked">Esta selección CPU no se puede representar de forma segura mediante API de afinidad heredadas en esta topología. CPU Se requieren conjuntos para esta selección.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_InvalidTopology">Esta selección CPU no coincide con la topología CPU actual. Revisa o recrea el ajuste preestablecido.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_ProcessExited">El proceso salió antes de que ThreadPilot pudiera aplicar el cambio.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_CpuSetsUnavailable">Windows CPU Los conjuntos no están disponibles o rechazaron esta selección. ThreadPilot utilizará un respaldo seguro solo cuando sea posible.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_HighPriorityWarning">La prioridad alta puede mejorar la capacidad de respuesta de algunas cargas de trabajo, pero puede reducir la capacidad de respuesta del sistema.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_RealtimePriorityBlocked">La prioridad en tiempo real está bloqueada por ThreadPilot porque puede hacer que Windows sea inestable o no responda.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentLaunchTimePriorityNotice">La prioridad persistente en el tiempo de inicio puede ser compatible con procesos normales, pero no elude los procesos protegidos ni las restricciones anti-trampas.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentRulesDescription">Aplica reglas guardadas cuando comienza un proceso de coincidencia. Algunos procesos protegidos o antitrampas pueden rechazar los cambios. El modo de administrador puede ayudar con problemas de permisos normales, pero no puede eludir la protección.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentRulesProtectedProcessWarning">El proceso aparece protegido por anti-trampas o protección de proceso. ThreadPilot no intentará anularlo.</sys:String>
+
+    <!-- Notifications -->
+    <sys:String x:Key="Notification_PowerPlanChangedTitle">Plan de energía cambiado</sys:String>
+    <sys:String x:Key="Notification_PowerPlanChangedFormat">El plan de energía cambió de '{0}' a '{1}'</sys:String>
+    <sys:String x:Key="Notification_PowerPlanChangedProcessFormat">El plan de energía cambió a '{0}' para el proceso '{1}'</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringEnabled">Monitoreo de procesos habilitado</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringDisabled">Monitoreo de procesos deshabilitado</sys:String>
+    <sys:String x:Key="Notification_CpuAffinityAppliedTitle">CPU Afinidad aplicada</sys:String>
+    <sys:String x:Key="Notification_CpuAffinityAppliedFormat">CPU afinidad establecida para '{0}': {1}</sys:String>
+    <sys:String x:Key="Notification_GameBoostActivatedTitle">Mejora del juego activada</sys:String>
+    <sys:String x:Key="Notification_GameBoostActivatedFormat">Modo Game Boost activado para {0}</sys:String>
+    <sys:String x:Key="Notification_GameBoostDeactivatedTitle">Game Boost desactivado</sys:String>
+    <sys:String x:Key="Notification_GameBoostDeactivatedFormat">Modo Game Boost desactivado después de {0}</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitorErrorTitle">Error del monitor de proceso</sys:String>
+    <sys:String x:Key="Notification_AffinityBlockedTitle">Afinidad bloqueada</sys:String>
+    <sys:String x:Key="Notification_AffinityAppliedTitle">Afinidad aplicada</sys:String>
+    <sys:String x:Key="Notification_AffinityAdjustedTitle">Afinidad ajustada</sys:String>
+    <sys:String x:Key="Notification_AffinityFailedTitle">La afinidad falló</sys:String>
+    <sys:String x:Key="Notification_AffinityErrorTitle">error de afinidad</sys:String>
+    <sys:String x:Key="Notification_PriorityBlockedTitle">Prioridad bloqueada</sys:String>
+    <sys:String x:Key="Notification_PriorityWarningTitle">Advertencia de prioridad</sys:String>
+    <sys:String x:Key="Notification_PriorityAppliedTitle">Prioridad aplicada</sys:String>
+    <sys:String x:Key="Notification_PriorityAdjustedTitle">Prioridad ajustada</sys:String>
+    <sys:String x:Key="Notification_PriorityErrorTitle">error de prioridad</sys:String>
+    <sys:String x:Key="Notification_KeyboardShortcutTitle">Atajo de teclado</sys:String>
+    <sys:String x:Key="Notification_ToggleMonitoringShortcut">Alternar acceso directo de monitoreo activado</sys:String>
+    <sys:String x:Key="Notification_HighPerformanceShortcut">Acceso directo al plan de energía de alto rendimiento activado</sys:String>
+    <sys:String x:Key="Notification_RefreshProcessListShortcut">Actualizar acceso directo a la lista de procesos activado</sys:String>
+    <sys:String x:Key="Notification_ThreadPilotStartedTitle">ThreadPilot Iniciado</sys:String>
+    <sys:String x:Key="Notification_ThreadPilotStartedMessage">El monitoreo de procesos y la gestión del plan de energía ahora están activos</sys:String>
+    <sys:String x:Key="Notification_StartupErrorTitle">Error de inicio</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringStartFailed">No se pudo iniciar el administrador de monitoreo de procesos</sys:String>
+    <sys:String x:Key="Notification_AutomationMonitoringErrorTitle">Error de monitoreo de automatización</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedTitle">Configuración guardada</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedMessage">La configuración de la aplicación se ha guardado correctamente.</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedWarningsTitle">Configuraciones guardadas con advertencias</sys:String>
+    <sys:String x:Key="Notification_SettingsErrorTitle">Error de configuración</sys:String>
+    <sys:String x:Key="Notification_SettingsSaveFailed">No se pudo guardar la configuración</sys:String>
+    <sys:String x:Key="Notification_TestNotificationMessage">Esta es una notificación de prueba para verificar que su configuración esté funcionando correctamente.</sys:String>
+
+    <!-- Elevation Service -->
+    <sys:String x:Key="Elevation_RequestPromptText">ThreadPilot requiere privilegios de administrador para gestionar la afinidad de procesos y los planes de energía.&#x0a;&#x0a;¿Le gustaría reiniciar la aplicación con privilegios de administrador?</sys:String>
+    <sys:String x:Key="Elevation_RequestPromptTitle">Privilegios de administrador requeridos</sys:String>
+    <sys:String x:Key="Elevation_FailedText">No se pudo reiniciar con privilegios de administrador. Ejecute manualmente ThreadPilot como administrador.</sys:String>
+    <sys:String x:Key="Elevation_FailedTitle">Error de elevación</sys:String>
+    <sys:String x:Key="Elevation_StatusRunning">Ejecutar con privilegios de administrador</sys:String>
+    <sys:String x:Key="Elevation_StatusLimited">Ejecutando con privilegios limitados</sys:String>
+
+    <!-- System Tweaks Errors -->
+    <sys:String x:Key="SystemTweak_Error_QueryCoreParking">No se pudo consultar el valor Core Parking a través de powercfg</sys:String>
+    <sys:String x:Key="SystemTweak_Error_QueryCStates">No se pudo consultar el valor C-States a través de powercfg</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PrefetchKeyNotFound">Prefetch clave de registro no encontrada</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PowerThrottlingNotAvailable">Power Throttling no disponible en este sistema</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PriorityControlKeyNotFound">PriorityControl clave de registro no encontrada</sys:String>
+    <sys:String x:Key="SystemTweak_Error_DesktopKeyNotFound">No se encontró la clave de registro del escritorio</sys:String>
+</ResourceDictionary>

--- a/Locales/fr-FR.xaml
+++ b/Locales/fr-FR.xaml
@@ -1,0 +1,665 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- MainWindow / General -->
+    <sys:String x:Key="MainWindow_Title">ThreadPilot - Gestionnaire de processus et de plan d'alimentation</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningTitle">Privilèges d'administrateur recommandés</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningDescription">ThreadPilot s'exécute avec des privilèges limités. Certaines fonctionnalités peuvent ne pas être disponibles.</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningRequired">L'accès administrateur est requis pour :</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningPowerPlans">• Modification des configurations du plan d'alimentation</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningAffinity">• Modification de l'affinité et de la priorité du processus CPU</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningTweaks">• Application d'optimisations et de réglages au niveau du système</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningProtected">• Gestion des processus protégés</sys:String>
+    <sys:String x:Key="MainWindow_ContinueWithoutElevation">Continuer sans élévation</sys:String>
+    <sys:String x:Key="MainWindow_RequestElevation">Demander une élévation</sys:String>
+
+    <!-- MainWindow Navigation -->
+    <sys:String x:Key="MainWindow_NavProcess">Gestion des processus</sys:String>
+    <sys:String x:Key="MainWindow_NavMasks">Masques CPU</sys:String>
+    <sys:String x:Key="MainWindow_NavPower">Plans d'alimentation</sys:String>
+    <sys:String x:Key="MainWindow_NavRules">Règles</sys:String>
+    <sys:String x:Key="MainWindow_NavDiagnostics">Diagnostic</sys:String>
+    <sys:String x:Key="MainWindow_NavActivity">Activité de ThreadPilot</sys:String>
+    <sys:String x:Key="MainWindow_NavTweaks">Optimisations</sys:String>
+    <sys:String x:Key="MainWindow_NavSettings">Paramètres</sys:String>
+
+    <!-- MainWindow Overlays -->
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestionTitle">Démarrage minimisé</sys:String>
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestionDescription">Activez le démarrage réduit lorsque vous souhaitez que ThreadPilot démarre silencieusement dans la barre d'état lors des futures connexions Windows.</sys:String>
+    <sys:String x:Key="MainWindow_Recommended">Recommandé</sys:String>
+    <sys:String x:Key="MainWindow_DontShowAgain">Ne plus montrer</sys:String>
+    <sys:String x:Key="MainWindow_OpenSettings">Ouvrir les paramètres</sys:String>
+    <sys:String x:Key="MainWindow_PrimaryNavigation">Navigation principale</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningOverlay">Avertissement d’élévation de privilèges</sys:String>
+    <sys:String x:Key="MainWindow_PerformanceIntroductionOverlay">Superposition d'introduction aux performances</sys:String>
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestion">Suggestion réduite au démarrage</sys:String>
+    <sys:String x:Key="MainWindow_UnsavedSettingsDialog">Boîte de dialogue Paramètres non enregistrés</sys:String>
+    <sys:String x:Key="MainWindow_LoadingOverlay">Superposition de chargement au démarrage de l'application</sys:String>
+
+    <!-- LogViewerView -->
+    <sys:String x:Key="LogViewerView_Title">ThreadPilot Activité</sys:String>
+    <sys:String x:Key="LogViewerView_Subtitle">Affiche les actions effectuées par ThreadPilot, y compris les règles appliquées, les changements d'affinité, les changements de priorité, les changements de plan d'alimentation, les changements de paramètres, les ajustements, les optimisations et les messages d'échec sûrs.</sys:String>
+    <sys:String x:Key="LogViewerView_Search">Rechercher :</sys:String>
+    <sys:String x:Key="LogViewerView_CategoryLabel">Catégorie :</sys:String>
+    <sys:String x:Key="LogViewerView_LevelLabel">Niveau :</sys:String>
+    <sys:String x:Key="LogViewerView_From">De :</sys:String>
+    <sys:String x:Key="LogViewerView_To">Pour :</sys:String>
+    <sys:String x:Key="LogViewerView_Refresh">Actualiser</sys:String>
+    <sys:String x:Key="LogViewerView_ClearDisplay">Effacer l’affichage</sys:String>
+    <sys:String x:Key="LogViewerView_ExportActivity">Exporter l’activité</sys:String>
+    <sys:String x:Key="LogViewerView_CleanupDiagnostics">Nettoyer les fichiers de diagnostic</sys:String>
+    <sys:String x:Key="LogViewerView_OpenFolder">Ouvrir le dossier de diagnostic</sys:String>
+
+    <!-- LogViewerView Grid Headers -->
+    <sys:String x:Key="LogViewerView_HeaderTime">Temps</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderStatus">Statut</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderCategory">Catégorie</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderMessage">Message</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderDetails">Détails</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderId">ID</sys:String>
+    <sys:String x:Key="LogViewerView_ContextMenuCopy">Copier l'entrée</sys:String>
+    <sys:String x:Key="LogViewerView_ContextMenuRefresh">Actualiser</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntries">Aucune entrée de journal à afficher</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntriesTip">Ajustez les filtres ou actualisez les journaux pour charger l’activité ThreadPilot récente.</sys:String>
+
+    <!-- LogViewerView Details -->
+    <sys:String x:Key="LogViewerView_DetailsTitle">Détails de l'activité</sys:String>
+    <sys:String x:Key="LogViewerView_Timestamp">Horodatage :</sys:String>
+    <sys:String x:Key="LogViewerView_Status">Statut :</sys:String>
+    <sys:String x:Key="LogViewerView_Category">Catégorie :</sys:String>
+    <sys:String x:Key="LogViewerView_Message">Message :</sys:String>
+    <sys:String x:Key="LogViewerView_Details">Détails :</sys:String>
+    <sys:String x:Key="LogViewerView_CorrelationId">ID de corrélation :</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntrySelected">Aucune entrée de journal sélectionnée</sys:String>
+    <sys:String x:Key="LogViewerView_Files">Fichiers :</sys:String>
+    <sys:String x:Key="LogViewerView_Size">Taille :</sys:String>
+    <sys:String x:Key="LogViewerView_DebugDiagnostics">Diagnostics de débogage</sys:String>
+    <sys:String x:Key="LogViewerView_MaxSize">Taille maximale (MB) :</sys:String>
+    <sys:String x:Key="LogViewerView_Retention">Rétention (jours) :</sys:String>
+    <sys:String x:Key="LogViewerView_SaveSettings">Enregistrer les paramètres</sys:String>
+
+    <!-- MasksView -->
+    <sys:String x:Key="MasksView_Title">Masques CPU</sys:String>
+    <sys:String x:Key="MasksView_Subtitle">Créez des préréglages d'affinité CPU réutilisables pour une utilisation par processus.</sys:String>
+    <sys:String x:Key="MasksView_EditingClarification">La sélection d'un masque ici modifie uniquement le préréglage. Cela ne modifie pas l'affinité CPU jusqu'à ce que vous l'appliquiez à un processus ou que vous l'enregistriez dans une règle de processus.</sys:String>
+    <sys:String x:Key="MasksView_New">Nouveau</sys:String>
+    <sys:String x:Key="MasksView_Delete">Supprimer</sys:String>
+    <sys:String x:Key="MasksView_Duplicate">Dupliquer le masque</sys:String>
+    <sys:String x:Key="MasksView_Info">Informations sur le masque</sys:String>
+    <sys:String x:Key="MasksView_Name">Nom :</sys:String>
+    <sys:String x:Key="MasksView_Description">Descriptif :</sys:String>
+    <sys:String x:Key="MasksView_Enabled">Activé</sys:String>
+    <sys:String x:Key="MasksView_DefaultPreset">Préréglage par défaut</sys:String>
+    <sys:String x:Key="MasksView_DefaultPresetTip">Présélectionné lorsque ThreadPilot a besoin d'un masque de secours ou lors de la création de règles par processus. Il n’applique pas automatiquement l’affinité CPU.</sys:String>
+    <sys:String x:Key="MasksView_DisableTip">Désactiver pour masquer temporairement ce masque</sys:String>
+    <sys:String x:Key="MasksView_SelectCpus">Sélectionner les CPU</sys:String>
+    <sys:String x:Key="MasksView_SelectCpusTip">Activez CPUs pour modifier ce préréglage de masque. Les modifications sont enregistrées automatiquement et n'affectent pas les processus en cours. All Cores est le préréglage par défaut protégé.</sys:String>
+    <sys:String x:Key="MasksView_SavedAutomatically">Les noms de masques, les descriptions, les sélections CPU et les options sont enregistrés automatiquement.</sys:String>
+    <sys:String x:Key="MasksView_CreateNewTooltip">Créer un nouveau masque CPU</sys:String>
+    <sys:String x:Key="MasksView_DeleteTooltip">Supprimer le masque sélectionné</sys:String>
+    <sys:String x:Key="MasksView_CpusHeader">CPUs</sys:String>
+    <sys:String x:Key="MasksView_Cpu">CPU</sys:String>
+    <sys:String x:Key="MasksView_Options">Options de masque</sys:String>
+
+    <!-- PerformanceView -->
+    <sys:String x:Key="PerformanceView_OptionalDiagnostics">Diagnostics en option</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc">Les diagnostics sont facultatifs et destinés au dépannage. Pour les superpositions dans le jeu et les graphiques de performances détaillés, utilisez des outils dédiés.</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc1">Les diagnostics sont facultatifs et destinés au dépannage.</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc2">Pour les superpositions dans le jeu et les graphiques de performances détaillés, utilisez des outils dédiés.</sys:String>
+    <sys:String x:Key="PerformanceView_QuickTips">Conseils rapides :</sys:String>
+    <sys:String x:Key="PerformanceView_Tip1">1. Ouvrez les diagnostics uniquement lorsque vous avez besoin d'un instantané de dépannage ciblé.</sys:String>
+    <sys:String x:Key="PerformanceView_Tip2">2. Examinez les hotspots uniquement à titre indicatif avant de créer des règles d'automatisation.</sys:String>
+    <sys:String x:Key="PerformanceView_Tip3">3. Arrêtez les métriques en direct lorsque vous avez terminé le dépannage.</sys:String>
+    <sys:String x:Key="PerformanceView_Continue">Continuer vers Diagnostics</sys:String>
+
+    <sys:String x:Key="PerformanceView_ActiveProcesses">Processus actifs</sys:String>
+    <sys:String x:Key="PerformanceView_TopConsumersDesc">Principaux consommateurs de CPU et de mémoire avec création de règles en un clic.</sys:String>
+    <sys:String x:Key="PerformanceView_SearchPlaceholder">Rechercher des processus par nom</sys:String>
+    <sys:String x:Key="PerformanceView_RuleBackedOnly">Basé sur des règles uniquement</sys:String>
+    <sys:String x:Key="PerformanceView_ActionableOnly">Actionnable uniquement</sys:String>
+    <sys:String x:Key="PerformanceView_RuleImpact">Impact des règles</sys:String>
+    <sys:String x:Key="PerformanceView_CreateRuleButton">Créer/mettre à jour une règle à partir de la sélection</sys:String>
+    <sys:String x:Key="PerformanceView_CreateRuleTooltip">Créer ou mettre à jour une règle d'automatisation à partir du processus hotspot sélectionné</sys:String>
+
+    <sys:String x:Key="PerformanceView_Timeline">Chronologie de la stabilité</sys:String>
+    <sys:String x:Key="PerformanceView_ClearHistory">Effacer l'historique</sys:String>
+    <sys:String x:Key="PerformanceView_ClearHistoryTooltip">Effacer les métriques affichées et l'historique de la chronologie</sys:String>
+    <sys:String x:Key="PerformanceView_CoreSnapshot">Aperçu des cœurs</sys:String>
+    <sys:String x:Key="PerformanceView_CoreSnapshotDesc">Utilisation par cœur pour repérer rapidement les déséquilibres.</sys:String>
+    <sys:String x:Key="PerformanceView_ToggleCore">Basculer le panneau principal</sys:String>
+    <sys:String x:Key="PerformanceView_ToggleProcess">Basculer le panneau de processus</sys:String>
+    <sys:String x:Key="PerformanceView_StartLive">Démarrer les métriques en direct</sys:String>
+    <sys:String x:Key="PerformanceView_StartLiveTooltip">Démarrer la collecte de métriques en direct pour ce tableau de bord</sys:String>
+    <sys:String x:Key="PerformanceView_StopLive">Arrêter les métriques en direct</sys:String>
+    <sys:String x:Key="PerformanceView_StopLiveTooltip">Suspendre la collecte de métriques en direct ; l'automatisation en arrière-plan est séparée</sys:String>
+    <sys:String x:Key="PerformanceView_Refresh">Actualiser</sys:String>
+    <sys:String x:Key="PerformanceView_RefreshTooltip">Actualiser l'instantané actuel du tableau de bord</sys:String>
+
+    <sys:String x:Key="PerformanceView_GlobalPowerPlan">Plan d'alimentation mondial</sys:String>
+    <sys:String x:Key="PerformanceView_ProcessHotspots">Points chauds de traitement</sys:String>
+    <sys:String x:Key="PerformanceView_Filter">Filtrer</sys:String>
+    <sys:String x:Key="PerformanceView_Memory">Mémoire</sys:String>
+    <sys:String x:Key="PerformanceView_Name">Nom</sys:String>
+    <sys:String x:Key="PerformanceView_Priority">Priorité</sys:String>
+    <sys:String x:Key="PerformanceView_Window">Fenêtre</sys:String>
+    <sys:String x:Key="PerformanceView_MemoryUsed">Mémoire utilisée</sys:String>
+    <sys:String x:Key="PerformanceView_CpuPercent">CPU %</sys:String>
+    <sys:String x:Key="PerformanceView_MemPercent">% mémoire</sys:String>
+    <sys:String x:Key="PerformanceView_Threads">Threads</sys:String>
+    <sys:String x:Key="PerformanceView_Events">Événements</sys:String>
+    <sys:String x:Key="PerformanceView_Severity">Gravité</sys:String>
+    <sys:String x:Key="PerformanceView_Detail">Détail</sys:String>
+    <sys:String x:Key="PerformanceView_Time">Temps</sys:String>
+    <sys:String x:Key="PerformanceView_Category">Catégorie</sys:String>
+    <sys:String x:Key="PerformanceView_Process">Processus</sys:String>
+    <sys:String x:Key="PerformanceView_SelectedHotspot">Processus de point chaud sélectionné</sys:String>
+    <sys:String x:Key="PerformanceView_Metrics">Métriques</sys:String>
+    <sys:String x:Key="PerformanceView_Processes">Processus</sys:String>
+
+    <!-- PowerPlanView -->
+    <sys:String x:Key="PowerPlanView_Title">Plans d'alimentation</sys:String>
+    <sys:String x:Key="PowerPlanView_Subtitle">Gérez le plan d'alimentation Windows actif et importez des profils .pow personnalisés</sys:String>
+    <sys:String x:Key="PowerPlanView_WindowsPowerPlans">Windows Plans d'alimentation</sys:String>
+    <sys:String x:Key="PowerPlanView_SelectActiveTip">Sélectionnez le plan Windows à rendre actif.</sys:String>
+    <sys:String x:Key="PowerPlanView_SetActive">Définir comme plan Windows actif</sys:String>
+    <sys:String x:Key="PowerPlanView_SetActiveTooltip">Remplacez le plan d'alimentation Windows actif par le plan sélectionné</sys:String>
+    <sys:String x:Key="PowerPlanView_Refresh">Actualiser les plans</sys:String>
+    <sys:String x:Key="PowerPlanView_RefreshTooltip">Actualiser la liste des plans d'alimentation disponibles</sys:String>
+    <sys:String x:Key="PowerPlanView_CustomPowerPlans">Plans d'alimentation personnalisés</sys:String>
+    <sys:String x:Key="PowerPlanView_LocalPlansTip">Fichiers .pow locaux prêts à être importés dans Windows.</sys:String>
+    <sys:String x:Key="PowerPlanView_ImportSelected">Importer le fichier .pow sélectionné</sys:String>
+    <sys:String x:Key="PowerPlanView_ImportSelectedTooltip">Importez le fichier .pow personnalisé sélectionné dans Windows</sys:String>
+    <sys:String x:Key="PowerPlanView_AddFile">Ajouter un fichier .pow</sys:String>
+    <sys:String x:Key="PowerPlanView_AddFileTooltip">Ajouter un nouveau fichier de plan d'alimentation personnalisé à la bibliothèque personnalisée</sys:String>
+    <sys:String x:Key="PowerPlanView_Delete">Supprimer</sys:String>
+    <sys:String x:Key="PowerPlanView_Active">Actif</sys:String>
+
+    <!-- ProcessPowerPlanAssociationView -->
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Title">Règles et automatisation</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Subtitle">La surveillance de l'automatisation surveille les événements de démarrage/arrêt du processus et applique le plan d'alimentation configuré, le masque CPU et les règles de priorité.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleEditor">Éditeur de règles</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EditorSubtitle">Créez une règle à partir d'un processus exécutable ou en cours d'exécution pour automatiser le plan d'alimentation, le masque CPU et le comportement de priorité.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ExecutableMatch">Correspondance exécutable :</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_MatchByPath">Correspondance par chemin</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_MatchByPathTooltip">Faire correspondre les processus par chemin complet au lieu de simplement le nom de l'exécutable</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Browse">Rechercher un exécutable</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_BrowseTooltip">Cliquez pour sélectionner un fichier exécutable (.exe) sur votre ordinateur</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ExecutableHelp">Choisissez un exécutable. La correspondance par chemin est plus précise ; la correspondance par nom s'applique à tout processus portant ce nom d'exécutable.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseRunningProcess">Utiliser le processus en cours :</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseRunningProcessTooltip">Sélectionnez un processus en cours d'exécution pour utiliser son exécutable</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseSelectedProcess">Utiliser le processus sélectionné</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseSelectedProcessTooltip">Utiliser l'exécutable du processus en cours d'exécution sélectionné</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePowerPlan">Plan d'alimentation de règle (commutateur global) :</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePowerPlanHelp">Lorsque cette règle correspond, Windows change le plan d’alimentation actif global.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleCpuMask">Règle CPU Masque :</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleCpuMaskHelp">Facultatif : Sélectionnez un masque CPU à appliquer au démarrage de ce processus.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePriority">Priorité des règles</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Update">Mise à jour</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePriorityHelp">Facultatif : Sélectionnez la priorité du processus à appliquer au démarrage de ce processus.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AssociationPriority">Priorité de l'association :</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AssociationPriorityHelp">Les associations de priorité plus élevée sont prioritaires en cas de correspondance multiple</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AddRule">Ajouter une règle</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UpdateRule">Mettre à jour la règle sélectionnée</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UpdateRuleTooltip">Mettre à jour l'association sélectionnée</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ClearSelection">Effacer la sélection</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ClearSelectionTooltip">Effacer l'exécutable sélectionné</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_CurrentRules">Règles actuelles</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulesDescription">Définissez des règles par processus. Les plans d’alimentation sont mondiaux ; les masques et les priorités s'appliquent aux processus de correspondance.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Remove">Supprimer</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RemoveTooltip">Supprimer l'association sélectionnée</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DefaultPowerPlan">Plan d'alimentation par défaut (repli lorsqu'aucune règle ne correspond)</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DefaultPowerPlanHelp">Plan d'alimentation à utiliser lorsqu'aucun processus associé n'est en cours d'exécution :</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SetDefault">Définir le plan d'alimentation par défaut</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SettingsTitle">Paramètres de surveillance de l'automatisation</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EnableWmi">Activer l'automatisation basée sur les événements (WMI)</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EnableFallback">Activer l'interrogation de secours automatisée</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PollingInterval">Intervalle d'interrogation (secondes) :</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ChangeDelay">Délai de changement de mode d'alimentation (ms) :</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PreventDuplicates">Empêcher les modifications du plan d'alimentation en double</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SaveConfig">Enregistrer la configuration</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_NoRules">Aucune règle d'automatisation pour l'instant</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Status">Statut :</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationMonitoring">Surveillance de l'automatisation</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_StartAutomation">Démarrer la surveillance de l'automatisation</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_StopAutomation">Arrêter la surveillance de l'automatisation</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AppliedToMatching">Appliqué à chaque processus de correspondance lors de l'exécution de la règle d'automatisation.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AppliedOnlyToMatching">Appliqué uniquement aux processus de correspondance ; cela ne modifie pas le plan d’alimentation global Windows.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SelectedExecutable">Exécutable sélectionné :</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DescriptionLabel">Descriptif :</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationService">Service d'automatisation</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulesHeader">Règles</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Exécutable</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Plan d'alimentation</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_CpuMask">CPU Masque</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Priority">Priorité</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Description">Descriptif</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ProcessPriority">Priorité du processus :</sys:String>
+
+    <!-- ProcessView -->
+    <sys:String x:Key="ProcessView_Title">Gestion des processus</sys:String>
+    <sys:String x:Key="ProcessView_Subtitle">Rechercher, filtrer et contrôler les configurations de processus actifs</sys:String>
+    <sys:String x:Key="ProcessView_SearchPlaceholder">Rechercher des processus par nom</sys:String>
+    <sys:String x:Key="ProcessView_SearchAutomationName">Recherche de processus</sys:String>
+    <sys:String x:Key="ProcessView_HideSystem">Masquer les processus système Windows</sys:String>
+    <sys:String x:Key="ProcessView_HideSystemShort">Masquer les processus système</sys:String>
+    <sys:String x:Key="ProcessView_HideLowCpu">Masquer les processus avec une très faible utilisation de CPU</sys:String>
+    <sys:String x:Key="ProcessView_HideIdle">Masquer les processus inactifs</sys:String>
+    <sys:String x:Key="ProcessView_VisibleWindowsOnly">Afficher uniquement les applications avec windows visible</sys:String>
+    <sys:String x:Key="ProcessView_ActiveAppsOnly">Applications actives uniquement</sys:String>
+    <sys:String x:Key="ProcessView_LockList">Liste des processus de verrouillage</sys:String>
+    <sys:String x:Key="ProcessView_LockListTooltip">Suspendez le processus d'actualisation de la liste et de tri des mises à jour pendant que vous travaillez avec la liste actuelle. La surveillance en arrière-plan et l'application automatique des règles enregistrées se poursuivent pendant l'exécution de ThreadPilot.</sys:String>
+    <sys:String x:Key="ProcessView_SortBy">Trier par :</sys:String>
+    <sys:String x:Key="ProcessView_SortByTooltip">Choisissez comment trier la liste des processus</sys:String>
+
+    <sys:String x:Key="ProcessView_SelectedProcess">Processus sélectionné</sys:String>
+    <sys:String x:Key="ProcessView_NoProcessSelected">Aucun processus sélectionné</sys:String>
+    <sys:String x:Key="ProcessView_SelectProcessTip">Sélectionnez un processus dans le tableau pour activer les actions d'affinité, de priorité, de plan d'alimentation et de règle.</sys:String>
+    <sys:String x:Key="ProcessView_PowerPlanPending">Plan d'alimentation/Paramètres en attente</sys:String>
+    <sys:String x:Key="ProcessView_PowerPlanTooltip">Choisissez le plan d'alimentation à activer manuellement ou à inclure avec une application rapide</sys:String>
+    <sys:String x:Key="ProcessView_SetPowerPlan">Définir le plan d'alimentation</sys:String>
+    <sys:String x:Key="ProcessView_SetPowerPlanTooltip">Activer le plan d'alimentation Windows sélectionné</sys:String>
+
+    <sys:String x:Key="ProcessView_PendingCoreMask">Masque de base en attente</sys:String>
+    <sys:String x:Key="ProcessView_StageMaskTooltip">Sélectionnez un masque pour le mettre en scène. Cela ne modifie pas l'affinité du système d'exploitation jusqu'à ce que vous cliquiez sur Appliquer l'affinité.</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinity">Appliquer l'affinité</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinityTooltip">Appliquez le masque principal en attente au processus sélectionné et vérifiez l'état d'affinité Windows</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinitySaveRule">Appliquer l'affinité et enregistrer en tant que règle</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinitySaveRuleTooltip">En règle générale, enregistrez les paramètres de processus actuels. Ces paramètres seront automatiquement appliqués lorsque ce processus démarrera à l’avenir.</sys:String>
+
+    <sys:String x:Key="ProcessView_SetCpuPriority">Définir la priorité CPU</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPriorityTooltip">Appliquer la priorité sélectionnée au processus</sys:String>
+    <sys:String x:Key="ProcessView_EnforcePriorityRegistry">Appliquer la priorité par le registre</sys:String>
+    <sys:String x:Key="ProcessView_EnforcePriorityRegistryTooltip">Appliquez la priorité via le registre Windows. Le processus doit être redémarré pour que les modifications prennent effet. Ce paramètre persiste lors des redémarrages du système.</sys:String>
+    <sys:String x:Key="ProcessView_SetPriority">Définir la priorité</sys:String>
+    <sys:String x:Key="ProcessView_RealtimeBlockedHelp">La priorité en temps réel est bloquée par ThreadPilot car elle peut rendre Windows instable ou ne pas répondre.</sys:String>
+    <sys:String x:Key="ProcessView_RealtimeBlocked">Temps réel (bloqué)</sys:String>
+
+    <sys:String x:Key="ProcessView_DisableIdleServer">Désactiver le serveur inactif</sys:String>
+    <sys:String x:Key="ProcessView_DisableIdleServerTooltip">Empêche le système d'entrer en état d'inactivité pendant l'exécution de ce processus. Utile pour les jeux et les applications critiques en termes de performances.</sys:String>
+
+    <sys:String x:Key="ProcessView_ProfileRule">Profil / Règle</sys:String>
+    <sys:String x:Key="ProcessView_ProfileNamePlaceholder">Entrez un nom de profil pour enregistrer ou charger les paramètres</sys:String>
+    <sys:String x:Key="ProcessView_SaveProfile">Enregistrer le profil</sys:String>
+    <sys:String x:Key="ProcessView_SaveProfileTooltip">Enregistrer l'affinité et la priorité CPU actuelles en tant que profil réutilisable</sys:String>
+    <sys:String x:Key="ProcessView_LoadProfile">Charger le profil</sys:String>
+    <sys:String x:Key="ProcessView_LoadProfileTooltip">Charger un profil précédemment enregistré</sys:String>
+    <sys:String x:Key="ProcessView_SaveCurrentRule">Enregistrer les paramètres actuels en tant que règle</sys:String>
+
+    <sys:String x:Key="ProcessView_LastAction">Dernière action ThreadPilot :</sys:String>
+    <sys:String x:Key="ProcessView_Refresh">Actualiser</sys:String>
+    <sys:String x:Key="ProcessView_RefreshTooltip">Actualiser la liste des processus</sys:String>
+    <sys:String x:Key="ProcessView_LoadMore">Charger plus</sys:String>
+    <sys:String x:Key="ProcessView_LoadMoreTooltip">Charger plus de processus</sys:String>
+    <sys:String x:Key="ProcessView_RefreshAutomationName">Actualiser les processus</sys:String>
+    <sys:String x:Key="ProcessView_LoadMoreAutomationName">Charger plus de processus</sys:String>
+    <sys:String x:Key="ProcessView_RunningListAutomationName">Liste des processus en cours d'exécution</sys:String>
+    <sys:String x:Key="ProcessView_RunningListAutomationHelp">Table de processus virtualisée avec tri et sélection</sys:String>
+
+    <sys:String x:Key="ProcessView_ColProcessName">Nom du processus</sys:String>
+    <sys:String x:Key="ProcessView_ColWindowTitle">Titre de la fenêtre</sys:String>
+    <sys:String x:Key="ProcessView_ColCpuUsage">CPU Utilisation</sys:String>
+    <sys:String x:Key="ProcessView_ColMemory">Utilisation de la mémoire</sys:String>
+
+    <sys:String x:Key="ProcessView_AffinityStagedTooltip">Affinité mise en scène dans l'interface utilisateur. Il n’est pas appliqué tant que vous n’avez pas cliqué sur Appliquer l’affinité.</sys:String>
+    <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Affinité actuellement signalée par Windows pour le processus sélectionné</sys:String>
+    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Aperçu en lecture seule de la sélection CPU actuelle ou en attente</sys:String>
+    <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Ouvrez l'onglet CPU Masques pour créer un nouveau masque personnalisé.</sys:String>
+    <sys:String x:Key="ProcessView_HyperThreadingTooltip">Indique si Hyper-Threading (Intel) ou SMT (AMD) est présent et actif sur ce système</sys:String>
+
+    <sys:String x:Key="ProcessView_CopyProcessInfo">Copier les informations sur le processus</sys:String>
+    <sys:String x:Key="ProcessView_OpenLocation">Emplacement de l'exécutable ouvert</sys:String>
+    <sys:String x:Key="ProcessView_ClearCpuSets">Effacer les ensembles CPU</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPendingSettings">Appliquer les paramètres en attente</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPendingSettingsTooltip">Appliquer l'affinité en attente et le plan d'alimentation sélectionné au processus sélectionné</sys:String>
+    <sys:String x:Key="ProcessView_RulesAppliedOnlyWhenConfigured">Les règles et les modifications sont appliquées par ThreadPilot uniquement lorsqu'elles sont configurées.</sys:String>
+    <sys:String x:Key="ProcessView_CurrentProcessStatus">Statut actuel du processus</sys:String>
+    <sys:String x:Key="ProcessView_AdvancedAffinityPicker">Sélecteur d'affinité avancé</sys:String>
+    <sys:String x:Key="ProcessView_RowMaskTooltip">Sélectionnez le masque en attente pour les actions d'affinité du menu contextuel des lignes</sys:String>
+    <sys:String x:Key="ProcessView_SelectedPowerPlan">Plan d'alimentation sélectionné</sys:String>
+    <sys:String x:Key="ProcessView_SaveAsRule">Enregistrer comme règle</sys:String>
+    <sys:String x:Key="ProcessView_NoVisibleWindowTitle">Aucun titre de fenêtre visible</sys:String>
+    <sys:String x:Key="ProcessView_BatchLabel">Traitement par lots</sys:String>
+    <sys:String x:Key="ProcessView_TotalSuffix">total)</sys:String>
+    <sys:String x:Key="ProcessView_PriorityInlineLabel">Priorité</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuUnavailable">CPU : indisponible</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryUnavailable">Mémoire : indisponible</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuPriorityUnavailable">Priorité CPU : indisponible</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryPriorityUnavailable">Priorité mémoire indisponible</sys:String>
+    <sys:String x:Key="ProcessSummary_AffinityUnavailable">Affinité : indisponible</sys:String>
+    <sys:String x:Key="ProcessSummary_NoSavedRule">Aucune règle enregistrée</sys:String>
+    <sys:String x:Key="ProcessSummary_NoRecentAction">Aucune action ThreadPilot récente</sys:String>
+    <sys:String x:Key="ProcessSummary_SelectedProcessFormat">Processus sélectionné : {0} (PID {1})</sys:String>
+    <sys:String x:Key="ProcessSummary_StatusProtected">Statut actuel du processus : protégé ou accès refusé</sys:String>
+    <sys:String x:Key="ProcessSummary_StatusSelected">Statut actuel du processus : sélectionné</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuFormat">CPU : {0:N1} %</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryFormat">Mémoire : {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuPriorityFormat">Priorité CPU : {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_AffinityLegacyFormat">Affinité : masque hérité 0x{0:X}</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryPriorityFormat">Priorité mémoire : {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_SavedRuleFallback">règle enregistrée</sys:String>
+    <sys:String x:Key="ProcessSummary_SavedRuleExistsFormat">La règle enregistrée existe : {0}</sys:String>
+
+    <sys:String x:Key="ProcessView_PriorityAboveNormal">Au-dessus de la normale</sys:String>
+    <sys:String x:Key="ProcessView_PriorityBelowNormal">En dessous de la normale</sys:String>
+    <sys:String x:Key="ProcessView_PriorityHigh">Élevé</sys:String>
+    <sys:String x:Key="ProcessView_PriorityIdle">Inactif</sys:String>
+    <sys:String x:Key="ProcessView_PriorityLow">Faible</sys:String>
+    <sys:String x:Key="ProcessView_PriorityNormal">Normale</sys:String>
+    <sys:String x:Key="ProcessView_PriorityRealtime">Temps réel</sys:String>
+    <sys:String x:Key="ProcessView_PriorityBatch">Traitement par lots</sys:String>
+    <sys:String x:Key="ProcessView_PriorityCustom">Personnalisé</sys:String>
+
+    <sys:String x:Key="ProcessView_HasWindow">A une fenêtre</sys:String>
+    <sys:String x:Key="ProcessView_Window">Fenêtre</sys:String>
+    <sys:String x:Key="ProcessView_PID">PID</sys:String>
+    <sys:String x:Key="ProcessView_ID">ID</sys:String>
+    <sys:String x:Key="ProcessView_MemoryMb">Mémoire (MB)</sys:String>
+    <sys:String x:Key="ProcessView_Affinity">Affinité</sys:String>
+    <sys:String x:Key="ProcessView_Priority">Priorité</sys:String>
+    <sys:String x:Key="ProcessView_Rules">Règles</sys:String>
+    <sys:String x:Key="ProcessView_Name">Nom</sys:String>
+    <sys:String x:Key="ProcessView_SetMemoryPriority">Définir la priorité de la mémoire</sys:String>
+    <sys:String x:Key="ProcessView_PriorityVeryLow">Très faible</sys:String>
+    <sys:String x:Key="ProcessView_PriorityMedium">Moyen</sys:String>
+    <sys:String x:Key="ProcessView_RefreshInfo">Actualiser les informations sur le processus</sys:String>
+
+    <!-- SettingsView -->
+    <sys:String x:Key="SettingsView_Title">Paramètres des applications</sys:String>
+    <sys:String x:Key="SettingsView_Subtitle">Configurer les notifications, la barre d'état système et le comportement des applications</sys:String>
+    <sys:String x:Key="SettingsView_Notifications">Notifications</sys:String>
+    <sys:String x:Key="SettingsView_EnableNotifications">Activer les notifications</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevel">Niveau de notification</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelAll">Tout</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelWarningsErrors">Avertissements/Erreurs uniquement</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelSilent">Silencieux</sys:String>
+    <sys:String x:Key="SettingsView_EnableBalloon">Activer les notifications par bulles (barre d'état système)</sys:String>
+    <sys:String x:Key="SettingsView_EnableToast">Activer les notifications toast (Windows 10+)</sys:String>
+    <sys:String x:Key="SettingsView_NotificationTypes">Types de notifications</sys:String>
+    <sys:String x:Key="SettingsView_NotifyPowerPlan">Modifications du plan d'alimentation</sys:String>
+    <sys:String x:Key="SettingsView_NotifyProcess">Événements de surveillance des processus</sys:String>
+    <sys:String x:Key="SettingsView_NotifyError">Notifications d'erreur</sys:String>
+    <sys:String x:Key="SettingsView_NotifySuccess">Notifications de réussite</sys:String>
+    <sys:String x:Key="SettingsView_Duration">Durée (ms) :</sys:String>
+    <sys:String x:Key="SettingsView_TestNotification">Avis de test</sys:String>
+
+    <sys:String x:Key="SettingsView_SystemTray">Barre d'état système</sys:String>
+    <sys:String x:Key="SettingsView_ShowTrayIcon">Afficher l'icône de la barre d'état</sys:String>
+    <sys:String x:Key="SettingsView_MinimizeToTray">Réduire dans le bac</sys:String>
+    <sys:String x:Key="SettingsView_CloseToTray">Près du plateau (au lieu de la sortie)</sys:String>
+    <sys:String x:Key="SettingsView_StartMinimized">Démarrer réduit</sys:String>
+    <sys:String x:Key="SettingsView_QuickApply">Activer l'application des paramètres en attente à partir du bac</sys:String>
+    <sys:String x:Key="SettingsView_MonitoringControl">Activer les contrôles de surveillance de l'automatisation à partir du bac</sys:String>
+    <sys:String x:Key="SettingsView_DetailedTooltips">Afficher des info-bulles détaillées</sys:String>
+
+    <sys:String x:Key="SettingsView_BasicPreferences">Préférences de base</sys:String>
+    <sys:String x:Key="SettingsView_Autostart">Démarrage automatique</sys:String>
+    <sys:String x:Key="SettingsView_StartWithWindows">Commencez par Windows</sys:String>
+    <sys:String x:Key="SettingsView_AutostartDescription">Démarrer automatiquement ThreadPilot au démarrage de Windows</sys:String>
+    <sys:String x:Key="SettingsView_LowImpactMode">Mode faible impact en arrière-plan</sys:String>
+    <sys:String x:Key="SettingsView_LowImpactDescription">Réduisez la priorité du processus de ThreadPilot lorsqu'il est réduit ou masqué dans la barre d'état.</sys:String>
+
+    <sys:String x:Key="SettingsView_Appearance">Apparence</sys:String>
+    <sys:String x:Key="SettingsView_UseDarkTheme">Utiliser un thème sombre</sys:String>
+    <sys:String x:Key="SettingsView_ThemeDescription">Applique un thème global Dark/Light sur tous les onglets</sys:String>
+
+    <sys:String x:Key="SettingsView_Language">Langue</sys:String>
+    <sys:String x:Key="SettingsView_LanguageZhCn">简体中文 (Simplified Chinese)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageEnUs">English (English)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageItIt">Italiano (Italian)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageFrFr">Français (French)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageDeDe">Deutsch (German)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageEsEs">Español (Spanish)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageRuRu">Русский (Russian)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageDescription">Applique une langue d’affichage globale sur toute l’interface de l’application.</sys:String>
+
+    <sys:String x:Key="SettingsView_RulesAutomation">Règles et automatisation</sys:String>
+    <sys:String x:Key="SettingsView_RuleAutoApply">Application automatique des règles enregistrées</sys:String>
+    <sys:String x:Key="SettingsView_ApplyOnStart">Appliquer les règles enregistrées au démarrage des processus de correspondance</sys:String>
+    <sys:String x:Key="SettingsView_ApplyOnStartDescription">Applique les règles enregistrées activées pendant l'exécution de ThreadPilot. Cela n'installe pas de service Windows et n'utilise pas la persistance du registre/IFEO.</sys:String>
+    <sys:String x:Key="SettingsView_EnableWmi">Activer les événements de processus WMI</sys:String>
+    <sys:String x:Key="SettingsView_WmiDescription">Utiliser Windows Management Instrumentation pour les événements de démarrage/arrêt de processus</sys:String>
+    <sys:String x:Key="SettingsView_EnableFallback">Activer l'interrogation de secours</sys:String>
+    <sys:String x:Key="SettingsView_FallbackDescription">Utiliser l'interrogation comme sauvegarde lorsque les événements de processus WMI échouent</sys:String>
+    <sys:String x:Key="SettingsView_PollingInterval">Intervalle d'interrogation (ms) :</sys:String>
+    <sys:String x:Key="SettingsView_FallbackPollingInterval">Interrogation de secours (ms) :</sys:String>
+
+    <sys:String x:Key="SettingsView_Advanced">Avancé</sys:String>
+    <sys:String x:Key="SettingsView_NotificationHistory">Activer l'historique des notifications</sys:String>
+    <sys:String x:Key="SettingsView_MaxHistory">Nombre maximum d'éléments d'historique :</sys:String>
+    <sys:String x:Key="SettingsView_AutoHide">Masquer automatiquement les notifications</sys:String>
+    <sys:String x:Key="SettingsView_NotificationSound">Activer le son des notifications</sys:String>
+    <sys:String x:Key="SettingsView_DebugLogging">Activer la journalisation du débogage</sys:String>
+    <sys:String x:Key="SettingsView_PerformanceCounters">Activer les compteurs de performances</sys:String>
+
+    <sys:String x:Key="SettingsView_About">À propos</sys:String>
+    <sys:String x:Key="SettingsView_Version">Version :</sys:String>
+    <sys:String x:Key="SettingsView_Copyright">Copyright © 2026 PrimeBuild</sys:String>
+    <sys:String x:Key="SettingsView_Translator">Traducteur : Ylimhs</sys:String>
+    <sys:String x:Key="SettingsView_License">Licence : AGPLv3</sys:String>
+    <sys:String x:Key="SettingsView_CheckUpdates">Vérifier les mises à jour</sys:String>
+    <sys:String x:Key="SettingsView_DownloadInstallUpdate">Téléchargez et installez la mise à jour</sys:String>
+    <sys:String x:Key="SettingsView_EnableAutomaticUpdateChecks">Vérifier automatiquement au démarrage</sys:String>
+    <sys:String x:Key="SettingsView_UpdateIntervalDays">Intervalle de vérification (jours) :</sys:String>
+    <sys:String x:Key="SettingsView_IncludePrereleaseUpdates">Inclure les mises à jour préliminaires</sys:String>
+    <sys:String x:Key="SettingsView_LatestVersion">Dernière version :</sys:String>
+    <sys:String x:Key="SettingsView_LastUpdateCheck">Dernière vérification :</sys:String>
+    <sys:String x:Key="SettingsView_UpdatesDescription">Vérifications sur demande à l'aide des versions officielles GitHub.</sys:String>
+
+    <sys:String x:Key="SettingsView_ResetDefaults">Réinitialiser aux valeurs par défaut</sys:String>
+    <sys:String x:Key="SettingsView_ExportConfig">Exporter la configuration</sys:String>
+    <sys:String x:Key="SettingsView_ImportConfig">Importer la configuration</sys:String>
+    <sys:String x:Key="SettingsView_SaveSettings">Enregistrer les paramètres</sys:String>
+    <sys:String x:Key="SettingsView_ThreadPilot">ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_StatusThemeChangedFormat">Le thème a été remplacé par {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusThemeChangeFailedFormat">Échec du changement de thème en {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusLanguageChangedFormat">La langue a été modifiée en {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusLanguageChangeFailed">Échec du changement de langue.</sys:String>
+    <sys:String x:Key="Settings_StatusSaving">Enregistrement des paramètres...</sys:String>
+    <sys:String x:Key="Settings_StatusSavedWarningsFormat">Paramètres enregistrés avec avertissements : {0}</sys:String>
+    <sys:String x:Key="Settings_StatusSavedApplied">Paramètres enregistrés et appliqués avec succès.</sys:String>
+    <sys:String x:Key="Settings_StatusErrorSavingFormat">Erreur lors de l'enregistrement des paramètres : {0}</sys:String>
+    <sys:String x:Key="Settings_StatusResetting">Réinitialisation aux valeurs par défaut...</sys:String>
+    <sys:String x:Key="Settings_StatusResetPending">Paramètres réinitialisés aux valeurs par défaut (pas encore enregistrés)</sys:String>
+    <sys:String x:Key="Settings_StatusErrorResettingFormat">Erreur lors de la réinitialisation des paramètres : {0}</sys:String>
+    <sys:String x:Key="Settings_StatusExporting">Exportation du bundle de configuration...</sys:String>
+    <sys:String x:Key="Settings_StatusExportCanceled">Exportation annulée</sys:String>
+    <sys:String x:Key="Settings_StatusExportedFormat">Configuration exportée vers : {0}</sys:String>
+    <sys:String x:Key="Settings_StatusErrorExportingFormat">Erreur lors de l'exportation des paramètres : {0}</sys:String>
+    <sys:String x:Key="Settings_StatusImporting">Importation de la configuration...</sys:String>
+    <sys:String x:Key="Settings_StatusImportCanceled">Importation annulée</sys:String>
+    <sys:String x:Key="Settings_StatusImportedApplied">Ensemble de configuration importé et appliqué</sys:String>
+    <sys:String x:Key="Settings_StatusLegacyImported">Paramètres hérités importés (règles inchangées)</sys:String>
+    <sys:String x:Key="Settings_StatusErrorImportingFormat">Erreur lors de l'importation des paramètres : {0}</sys:String>
+    <sys:String x:Key="Settings_StatusTestSent">Notification de test envoyée</sys:String>
+    <sys:String x:Key="Settings_StatusErrorTestFormat">Erreur lors de l'envoi de la notification de test : {0}</sys:String>
+    <sys:String x:Key="Settings_StatusLoading">Chargement des paramètres...</sys:String>
+    <sys:String x:Key="Settings_StatusLoaded">Paramètres chargés</sys:String>
+    <sys:String x:Key="Settings_StatusErrorLoadingFormat">Erreur de chargement des paramètres : {0}</sys:String>
+    <sys:String x:Key="Settings_StatusSynchronized">Paramètres synchronisés</sys:String>
+    <sys:String x:Key="Settings_StatusCheckingUpdates">Vérification des mises à jour...</sys:String>
+    <sys:String x:Key="Settings_StatusLatestUnknown">Impossible de déterminer la dernière version.</sys:String>
+    <sys:String x:Key="Settings_StatusNewVersionFormat">Nouvelle version disponible : {0}</sys:String>
+    <sys:String x:Key="Settings_StatusUpToDateFormat">L'application est à jour. Version installée : {0}</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateErrorFormat">Erreur lors de la vérification des mises à jour : {0}</sys:String>
+    <sys:String x:Key="Settings_UpdateLatestUnknown">Inconnu</sys:String>
+    <sys:String x:Key="Settings_UpdateNotChecked">Non vérifié</sys:String>
+    <sys:String x:Key="Settings_UpdateLastCheckedNever">Jamais</sys:String>
+    <sys:String x:Key="Settings_UpdateConfirmTitle">Installer la mise à jour ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_UpdateConfirmMessageFormat">ThreadPilot téléchargera et vérifiera la version {0}, puis demandera à Windows l'autorisation d'exécuter le programme d'installation. Continuer ?</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateCanceled">Mise à jour annulée.</sys:String>
+    <sys:String x:Key="Settings_StatusDownloadingUpdate">Téléchargement et vérification de la mise à jour...</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateInstallerStarted">Le programme d'installation de la mise à jour a démarré.</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateInstallFailedFormat">Échec de l'installation de la mise à jour : {0}</sys:String>
+    <sys:String x:Key="Settings_StatusModified">Les paramètres ont été modifiés</sys:String>
+    <sys:String x:Key="Settings_StatusMatchSaved">Les paramètres correspondent à la configuration enregistrée</sys:String>
+    <sys:String x:Key="Settings_LanguageSimplifiedChinese">Chinois simplifié</sys:String>
+    <sys:String x:Key="Settings_LanguageEnglish">Anglais</sys:String>
+    <sys:String x:Key="Settings_LanguageItalian">Italien</sys:String>
+    <sys:String x:Key="Settings_LanguageFrench">Français</sys:String>
+    <sys:String x:Key="Settings_LanguageGerman">Allemand</sys:String>
+    <sys:String x:Key="Settings_LanguageSpanish">Espagnol</sys:String>
+    <sys:String x:Key="Settings_LanguageRussian">Russe</sys:String>
+    <sys:String x:Key="Settings_ThemeDark">Sombre</sys:String>
+    <sys:String x:Key="Settings_ThemeLight">Clair</sys:String>
+    <sys:String x:Key="Settings_DialogExportTitle">Exporter la configuration ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_DialogImportTitle">Importer la configuration ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_WarningAutostartFailed">Échec de la mise à jour du démarrage automatique Windows. Conserver l'état de démarrage automatique précédent.</sys:String>
+
+    <!-- SettingsWindow -->
+    <sys:String x:Key="SettingsWindow_Title">ThreadPilot Paramètres</sys:String>
+    <sys:String x:Key="SettingsWindow_UnsavedTitle">Paramètres non enregistrés</sys:String>
+    <sys:String x:Key="SettingsWindow_UnsavedDescription">Certaines modifications ne sont pas enregistrées. Enregistrez-les, ignorez-les ou annulez pour continuer à les modifier.</sys:String>
+    <sys:String x:Key="SettingsWindow_Cancel">Annuler</sys:String>
+    <sys:String x:Key="SettingsWindow_Discard">Jeter</sys:String>
+    <sys:String x:Key="SettingsWindow_Save">Enregistrer</sys:String>
+
+    <!-- SystemTweaksView -->
+    <sys:String x:Key="SystemTweaksView_Title">Ajustements et optimisations du système</sys:String>
+    <sys:String x:Key="SystemTweaksView_Subtitle">Configurer les optimisations du système Windows et les ajustements de performances</sys:String>
+    <sys:String x:Key="SystemTweaksView_RefreshAll">Actualiser tout</sys:String>
+    <sys:String x:Key="SystemTweaksView_RefreshAllTooltip">Actualiser tous les états de réglage</sys:String>
+    <sys:String x:Key="SystemTweaksView_TweakTooltip">Activez ce réglage Windows</sys:String>
+    <sys:String x:Key="SystemTweaksView_Status">Statut</sys:String>
+
+    <!-- SystemTweaks Names and Descriptions -->
+    <sys:String x:Key="SystemTweak_CoreParking_Name">Core Parking</sys:String>
+    <sys:String x:Key="SystemTweak_CoreParking_Desc">Contrôle CPU core parking pour la gestion de l'alimentation</sys:String>
+    <sys:String x:Key="SystemTweak_CStates_Name">C-States</sys:String>
+    <sys:String x:Key="SystemTweak_CStates_Desc">Contrôle CPU C-States pour la gestion de l'alimentation</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Name">HPET</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Desc">Minuteur d'événements haute précision pour la synchronisation du système</sys:String>
+    <sys:String x:Key="SystemTweak_SysMain_Name">Service SysMain</sys:String>
+    <sys:String x:Key="SystemTweak_SysMain_Desc">Service Windows Superfetch/SysMain pour la gestion de la mémoire</sys:String>
+    <sys:String x:Key="SystemTweak_Prefetch_Name">Prefetch</sys:String>
+    <sys:String x:Key="SystemTweak_Prefetch_Desc">Fonctionnalité Windows Prefetch pour un chargement plus rapide des applications</sys:String>
+    <sys:String x:Key="SystemTweak_PowerThrottling_Name">Power Throttling</sys:String>
+    <sys:String x:Key="SystemTweak_PowerThrottling_Desc">Windows Power Throttling pour l'efficacité énergétique</sys:String>
+    <sys:String x:Key="SystemTweak_HighSchedulingCategory_Name">Catégorie de planification élevée</sys:String>
+    <sys:String x:Key="SystemTweak_HighSchedulingCategory_Desc">Priorité de planification élevée pour les applications de jeux</sys:String>
+    <sys:String x:Key="SystemTweak_MenuShowDelay_Name">Menu Afficher le délai</sys:String>
+    <sys:String x:Key="SystemTweak_MenuShowDelay_Desc">Délai avant l'affichage des menus contextuels</sys:String>
+
+    <!-- SystemTweaksViewModel Messages -->
+    <sys:String x:Key="SystemTweaks_StatusReady">Prêt</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshing">Modifications rafraîchissantes du système...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLastRefreshedFormat">Dernière actualisation : {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshFailed">Échec de l'actualisation des réglages du système</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshFailedShort">Échec de l'actualisation</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusTogglingFormat">Basculer {0}...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnabledFormat">{0} activé avec succès</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisabledFormat">{0} désactivé avec succès</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyEnabledFormat">{0} a été activé</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyDisabledFormat">{0} a été désactivé</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyUpdatedTitle">Ajustement du système mis à jour</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusToggleFailedFormat">Échec de l'activation de {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnableFailedFormat">Échec de l'activation de {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisableFailedFormat">Échec de la désactivation de {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyFailedTitle">Échec de la modification du système</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyFailedFormat">Échec de {0} {1}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusErrorTogglingFormat">Erreur lors du basculement de {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyErrorFormat">Erreur lors du basculement de {0} : {1}</sys:String>
+    <sys:String x:Key="SystemTweaks_WordEnable">activer</sys:String>
+    <sys:String x:Key="SystemTweaks_WordDisable">désactiver</sys:String>
+    <sys:String x:Key="SystemTweaks_WordEnabled">activé</sys:String>
+    <sys:String x:Key="SystemTweaks_WordDisabled">désactivé</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnabled">Activé</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisabled">Désactivé</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusNotAvailable">Non disponible</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLoading">Chargement des modifications du système...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLoadedSuccess">Les réglages du système ont été chargés avec succès</sys:String>
+
+    <!-- SystemTray Context Menu & Status -->
+    <sys:String x:Key="SystemTray_OpenDashboard">Ouvrir le tableau de bord</sys:String>
+    <sys:String x:Key="SystemTray_OpenDiagnostics">Ouvrir le diagnostic</sys:String>
+    <sys:String x:Key="SystemTray_PauseMonitoring">Suspendre la surveillance de l'automatisation</sys:String>
+    <sys:String x:Key="SystemTray_ResumeMonitoring">Reprendre la surveillance de l'automatisation</sys:String>
+    <sys:String x:Key="SystemTray_SystemStatus">État du système</sys:String>
+    <sys:String x:Key="SystemTray_NoProcessSelected">Aucun processus sélectionné</sys:String>
+    <sys:String x:Key="SystemTray_SelectedProcessFormat">Sélectionné : {0}</sys:String>
+    <sys:String x:Key="SystemTray_ApplyPendingToSelected">Appliquer les paramètres en attente au processus sélectionné</sys:String>
+    <sys:String x:Key="SystemTray_ApplyPendingToProcessFormat">Appliquer les paramètres en attente à {0}</sys:String>
+    <sys:String x:Key="SystemTray_PowerPlans">🔋 Plans d'alimentation</sys:String>
+    <sys:String x:Key="SystemTray_Profiles">📋 Profils</sys:String>
+    <sys:String x:Key="SystemTray_Settings">Paramètres</sys:String>
+    <sys:String x:Key="SystemTray_Exit">Quitter</sys:String>
+    <sys:String x:Key="SystemTray_NoProfilesAvailable">Aucun profil disponible</sys:String>
+    <sys:String x:Key="SystemTray_PowerPlanFormat">Plan d'alimentation : {0}</sys:String>
+    <sys:String x:Key="SystemTray_StatusWmiError">Erreur d'automatisation WMI</sys:String>
+    <sys:String x:Key="SystemTray_StatusActive">Automatisation active</sys:String>
+    <sys:String x:Key="SystemTray_StatusDisabled">Automatisation désactivée</sys:String>
+    <sys:String x:Key="SystemTray_Unknown">Inconnu</sys:String>
+    <sys:String x:Key="SystemTray_CpuRamStatusFormat">💻 CPU : {0:F1}% | RAM : {1:F1}% | {2}</sys:String>
+
+    <!-- ProcessOperationUserMessages -->
+    <sys:String x:Key="ProcessOperationUserMessages_AccessDenied">Windows a refusé cette modification. Le processus peut nécessiter des droits d'administrateur ou peut être protégé.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_AntiCheatProtectedLikely">Le processus semble protégé par un anti-triche ou une protection de processus. ThreadPilot n'essaiera pas de le contourner.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_AdminClarification">Le mode Administrateur peut aider à résoudre les problèmes d'autorisation normaux, mais ne peut pas contourner les restrictions anti-triche ou de processus protégés.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_LegacyFallbackBlocked">Cette sélection CPU ne peut pas être représentée en toute sécurité par les API d'affinité héritées sur cette topologie. CPU Des ensembles sont requis pour cette sélection.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_InvalidTopology">Cette sélection CPU ne correspond pas à la topologie CPU actuelle. Vérifiez ou recréez le préréglage.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_ProcessExited">Le processus s'est terminé avant que ThreadPilot puisse appliquer la modification.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_CpuSetsUnavailable">Windows CPU Les ensembles ne sont pas disponibles ou ont rejeté cette sélection. ThreadPilot utilisera une solution de secours sécurisée uniquement lorsque cela est possible.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_HighPriorityWarning">Une priorité élevée peut améliorer la réactivité de certaines charges de travail, mais peut réduire la réactivité du système.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_RealtimePriorityBlocked">La priorité en temps réel est bloquée par ThreadPilot car elle peut rendre Windows instable ou ne pas répondre.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentLaunchTimePriorityNotice">La priorité persistante au moment du lancement peut être prise en charge pour les processus normaux, mais elle ne contourne pas les processus protégés ou les restrictions anti-triche.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentRulesDescription">Applique les règles enregistrées lorsqu'un processus de correspondance démarre. Certains processus protégés ou anti-triche peuvent rejeter les modifications. Le mode Administrateur peut résoudre les problèmes d'autorisation normaux, mais ne peut pas contourner la protection.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentRulesProtectedProcessWarning">Le processus semble protégé par un anti-triche ou une protection de processus. ThreadPilot n'essaiera pas de le remplacer.</sys:String>
+
+    <!-- Notifications -->
+    <sys:String x:Key="Notification_PowerPlanChangedTitle">Plan d'alimentation modifié</sys:String>
+    <sys:String x:Key="Notification_PowerPlanChangedFormat">Le plan d'alimentation est passé de « {0} » à « {1} »</sys:String>
+    <sys:String x:Key="Notification_PowerPlanChangedProcessFormat">Le plan d'alimentation a été modifié en « {0} » pour le processus « {1} »</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringEnabled">Surveillance des processus activée</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringDisabled">Surveillance du processus désactivée</sys:String>
+    <sys:String x:Key="Notification_CpuAffinityAppliedTitle">CPU Affinité appliquée</sys:String>
+    <sys:String x:Key="Notification_CpuAffinityAppliedFormat">Ensemble d'affinité CPU pour '{0}' : {1}</sys:String>
+    <sys:String x:Key="Notification_GameBoostActivatedTitle">Boost de jeu activé</sys:String>
+    <sys:String x:Key="Notification_GameBoostActivatedFormat">Mode Game Boost activé pour {0}</sys:String>
+    <sys:String x:Key="Notification_GameBoostDeactivatedTitle">Boost de jeu désactivé</sys:String>
+    <sys:String x:Key="Notification_GameBoostDeactivatedFormat">Mode Game Boost désactivé après {0}</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitorErrorTitle">Erreur du moniteur de processus</sys:String>
+    <sys:String x:Key="Notification_AffinityBlockedTitle">Affinité bloquée</sys:String>
+    <sys:String x:Key="Notification_AffinityAppliedTitle">Affinité appliquée</sys:String>
+    <sys:String x:Key="Notification_AffinityAdjustedTitle">Affinité ajustée</sys:String>
+    <sys:String x:Key="Notification_AffinityFailedTitle">L'affinité a échoué</sys:String>
+    <sys:String x:Key="Notification_AffinityErrorTitle">Erreur d'affinité</sys:String>
+    <sys:String x:Key="Notification_PriorityBlockedTitle">Priorité bloquée</sys:String>
+    <sys:String x:Key="Notification_PriorityWarningTitle">Avertissement prioritaire</sys:String>
+    <sys:String x:Key="Notification_PriorityAppliedTitle">Priorité appliquée</sys:String>
+    <sys:String x:Key="Notification_PriorityAdjustedTitle">Priorité ajustée</sys:String>
+    <sys:String x:Key="Notification_PriorityErrorTitle">Erreur de priorité</sys:String>
+    <sys:String x:Key="Notification_KeyboardShortcutTitle">Raccourci clavier</sys:String>
+    <sys:String x:Key="Notification_ToggleMonitoringShortcut">Basculer le raccourci de surveillance activé</sys:String>
+    <sys:String x:Key="Notification_HighPerformanceShortcut">Raccourci du mode d'alimentation hautes performances activé</sys:String>
+    <sys:String x:Key="Notification_RefreshProcessListShortcut">Raccourci d'actualisation de la liste des processus activé</sys:String>
+    <sys:String x:Key="Notification_ThreadPilotStartedTitle">ThreadPilot Démarré</sys:String>
+    <sys:String x:Key="Notification_ThreadPilotStartedMessage">La surveillance des processus et la gestion du plan d'alimentation sont désormais actives</sys:String>
+    <sys:String x:Key="Notification_StartupErrorTitle">Erreur de démarrage</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringStartFailed">Échec du démarrage du gestionnaire de surveillance des processus</sys:String>
+    <sys:String x:Key="Notification_AutomationMonitoringErrorTitle">Erreur de surveillance de l'automatisation</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedTitle">Paramètres enregistrés</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedMessage">Les paramètres de l'application ont été enregistrés avec succès</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedWarningsTitle">Paramètres enregistrés avec les avertissements</sys:String>
+    <sys:String x:Key="Notification_SettingsErrorTitle">Erreur de paramètres</sys:String>
+    <sys:String x:Key="Notification_SettingsSaveFailed">Échec de l'enregistrement des paramètres</sys:String>
+    <sys:String x:Key="Notification_TestNotificationMessage">Il s'agit d'une notification de test pour vérifier que vos paramètres fonctionnent correctement.</sys:String>
+
+    <!-- Elevation Service -->
+    <sys:String x:Key="Elevation_RequestPromptText">ThreadPilot nécessite des privilèges d'administrateur pour gérer l'affinité des processus et les plans d'alimentation.&#x0a;&#x0a;Souhaitez-vous redémarrer l'application avec les privilèges d'administrateur ?</sys:String>
+    <sys:String x:Key="Elevation_RequestPromptTitle">Privilèges d'administrateur requis</sys:String>
+    <sys:String x:Key="Elevation_FailedText">Échec du redémarrage avec les privilèges d'administrateur. Veuillez exécuter manuellement ThreadPilot en tant qu'administrateur.</sys:String>
+    <sys:String x:Key="Elevation_FailedTitle">Échec de l'élévation</sys:String>
+    <sys:String x:Key="Elevation_StatusRunning">Exécution avec les privilèges d'administrateur</sys:String>
+    <sys:String x:Key="Elevation_StatusLimited">Fonctionner avec des privilèges limités</sys:String>
+
+    <!-- System Tweaks Errors -->
+    <sys:String x:Key="SystemTweak_Error_QueryCoreParking">Impossible d'interroger la valeur Core Parking via powercfg</sys:String>
+    <sys:String x:Key="SystemTweak_Error_QueryCStates">Impossible d'interroger la valeur C-States via powercfg</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PrefetchKeyNotFound">Clé de registre Prefetch introuvable</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PowerThrottlingNotAvailable">Power Throttling non disponible sur ce système</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PriorityControlKeyNotFound">Clé de registre PriorityControl introuvable</sys:String>
+    <sys:String x:Key="SystemTweak_Error_DesktopKeyNotFound">Clé de registre de bureau introuvable</sys:String>
+</ResourceDictionary>

--- a/Locales/it-IT.xaml
+++ b/Locales/it-IT.xaml
@@ -1,0 +1,665 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- MainWindow / General -->
+    <sys:String x:Key="MainWindow_Title">ThreadPilot - Gestore processi e piano di alimentazione</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningTitle">Privilegi di amministratore consigliati</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningDescription">ThreadPilot è in esecuzione con privilegi limitati. Alcune funzionalità potrebbero non essere disponibili.</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningRequired">È richiesto l'accesso come amministratore per:</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningPowerPlans">• Modifica delle configurazioni del piano di alimentazione</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningAffinity">• Modifica dell'affinità e della priorità del processo CPU</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningTweaks">• Applicazione di ottimizzazioni e modifiche a livello di sistema</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningProtected">• Gestire i processi protetti</sys:String>
+    <sys:String x:Key="MainWindow_ContinueWithoutElevation">Continua senza elevazione</sys:String>
+    <sys:String x:Key="MainWindow_RequestElevation">Richiedi elevazione</sys:String>
+
+    <!-- MainWindow Navigation -->
+    <sys:String x:Key="MainWindow_NavProcess">Gestione dei processi</sys:String>
+    <sys:String x:Key="MainWindow_NavMasks">Maschere CPU</sys:String>
+    <sys:String x:Key="MainWindow_NavPower">Piani di alimentazione</sys:String>
+    <sys:String x:Key="MainWindow_NavRules">Regole</sys:String>
+    <sys:String x:Key="MainWindow_NavDiagnostics">Diagnostica</sys:String>
+    <sys:String x:Key="MainWindow_NavActivity">Attività di ThreadPilot</sys:String>
+    <sys:String x:Key="MainWindow_NavTweaks">Ottimizzazioni</sys:String>
+    <sys:String x:Key="MainWindow_NavSettings">Impostazioni</sys:String>
+
+    <!-- MainWindow Overlays -->
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestionTitle">Avvio ridotto a icona</sys:String>
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestionDescription">Abilita Avvio ridotto a icona quando desideri che ThreadPilot venga avviato in modalità silenziosa nella barra delle applicazioni agli accessi futuri di Windows.</sys:String>
+    <sys:String x:Key="MainWindow_Recommended">Consigliato</sys:String>
+    <sys:String x:Key="MainWindow_DontShowAgain">Non mostrare più</sys:String>
+    <sys:String x:Key="MainWindow_OpenSettings">Apri Impostazioni</sys:String>
+    <sys:String x:Key="MainWindow_PrimaryNavigation">Navigazione primaria</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningOverlay">Avviso di elevazione dei privilegi</sys:String>
+    <sys:String x:Key="MainWindow_PerformanceIntroductionOverlay">Sovrapposizione di introduzione alle prestazioni</sys:String>
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestion">Suggerimento ridotto al minimo per l'avvio</sys:String>
+    <sys:String x:Key="MainWindow_UnsavedSettingsDialog">Finestra di dialogo delle impostazioni non salvate</sys:String>
+    <sys:String x:Key="MainWindow_LoadingOverlay">Overlay di caricamento all'avvio dell'applicazione</sys:String>
+
+    <!-- LogViewerView -->
+    <sys:String x:Key="LogViewerView_Title">ThreadPilot Attività</sys:String>
+    <sys:String x:Key="LogViewerView_Subtitle">Mostra le azioni eseguite da ThreadPilot, incluse regole applicate, modifiche di affinità, modifiche di priorità, modifiche del piano di alimentazione, modifiche delle impostazioni, modifiche, ottimizzazioni e messaggi di errore sicuro.</sys:String>
+    <sys:String x:Key="LogViewerView_Search">Cerca:</sys:String>
+    <sys:String x:Key="LogViewerView_CategoryLabel">Categoria:</sys:String>
+    <sys:String x:Key="LogViewerView_LevelLabel">Livello:</sys:String>
+    <sys:String x:Key="LogViewerView_From">Da:</sys:String>
+    <sys:String x:Key="LogViewerView_To">A:</sys:String>
+    <sys:String x:Key="LogViewerView_Refresh">Aggiorna</sys:String>
+    <sys:String x:Key="LogViewerView_ClearDisplay">Cancella visualizzazione</sys:String>
+    <sys:String x:Key="LogViewerView_ExportActivity">Esporta attività</sys:String>
+    <sys:String x:Key="LogViewerView_CleanupDiagnostics">Elimina file diagnostici</sys:String>
+    <sys:String x:Key="LogViewerView_OpenFolder">Apri la cartella diagnostica</sys:String>
+
+    <!-- LogViewerView Grid Headers -->
+    <sys:String x:Key="LogViewerView_HeaderTime">Tempo</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderStatus">Stato</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderCategory">Categoria</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderMessage">Messaggio</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderDetails">Dettagli</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderId">ID</sys:String>
+    <sys:String x:Key="LogViewerView_ContextMenuCopy">Copia voce</sys:String>
+    <sys:String x:Key="LogViewerView_ContextMenuRefresh">Aggiorna</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntries">Nessuna voce di registro da visualizzare</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntriesTip">Modifica i filtri o aggiorna i log per caricare l'attività ThreadPilot recente.</sys:String>
+
+    <!-- LogViewerView Details -->
+    <sys:String x:Key="LogViewerView_DetailsTitle">Dettagli attività</sys:String>
+    <sys:String x:Key="LogViewerView_Timestamp">Timestamp:</sys:String>
+    <sys:String x:Key="LogViewerView_Status">Stato:</sys:String>
+    <sys:String x:Key="LogViewerView_Category">Categoria:</sys:String>
+    <sys:String x:Key="LogViewerView_Message">Messaggio:</sys:String>
+    <sys:String x:Key="LogViewerView_Details">Dettagli:</sys:String>
+    <sys:String x:Key="LogViewerView_CorrelationId">ID di correlazione:</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntrySelected">Nessuna voce di registro selezionata</sys:String>
+    <sys:String x:Key="LogViewerView_Files">File:</sys:String>
+    <sys:String x:Key="LogViewerView_Size">Dimensioni:</sys:String>
+    <sys:String x:Key="LogViewerView_DebugDiagnostics">Diagnostica di debug</sys:String>
+    <sys:String x:Key="LogViewerView_MaxSize">Dimensione massima (MB):</sys:String>
+    <sys:String x:Key="LogViewerView_Retention">Conservazione (giorni):</sys:String>
+    <sys:String x:Key="LogViewerView_SaveSettings">Salva impostazioni</sys:String>
+
+    <!-- MasksView -->
+    <sys:String x:Key="MasksView_Title">Maschere CPU</sys:String>
+    <sys:String x:Key="MasksView_Subtitle">Crea preimpostazioni di affinità CPU riutilizzabili per l'utilizzo in ciascun processo.</sys:String>
+    <sys:String x:Key="MasksView_EditingClarification">Selezionando una maschera qui si modifica solo la preimpostazione. Non modifica l'affinità CPU finché non lo applichi a un processo o lo salvi in ​​una regola di processo.</sys:String>
+    <sys:String x:Key="MasksView_New">Nuovo</sys:String>
+    <sys:String x:Key="MasksView_Delete">Elimina</sys:String>
+    <sys:String x:Key="MasksView_Duplicate">Duplica maschera</sys:String>
+    <sys:String x:Key="MasksView_Info">Informazioni sulla maschera</sys:String>
+    <sys:String x:Key="MasksView_Name">Nome:</sys:String>
+    <sys:String x:Key="MasksView_Description">Descrizione:</sys:String>
+    <sys:String x:Key="MasksView_Enabled">Abilitato</sys:String>
+    <sys:String x:Key="MasksView_DefaultPreset">Preimpostazione predefinita</sys:String>
+    <sys:String x:Key="MasksView_DefaultPresetTip">Preselezionato quando ThreadPilot necessita di una maschera di fallback o quando si creano regole per processo. Non applica automaticamente l'affinità CPU.</sys:String>
+    <sys:String x:Key="MasksView_DisableTip">Disabilita per nascondere temporaneamente questa maschera</sys:String>
+    <sys:String x:Key="MasksView_SelectCpus">Seleziona CPU</sys:String>
+    <sys:String x:Key="MasksView_SelectCpusTip">Attiva/disattiva CPUs per modificare questa maschera preimpostata. Le modifiche vengono salvate automaticamente e non influiscono sui processi in esecuzione. Tutti i core è l'impostazione predefinita protetta.</sys:String>
+    <sys:String x:Key="MasksView_SavedAutomatically">I nomi delle maschere, le descrizioni, le selezioni CPU e le opzioni vengono salvate automaticamente.</sys:String>
+    <sys:String x:Key="MasksView_CreateNewTooltip">Crea una nuova maschera CPU</sys:String>
+    <sys:String x:Key="MasksView_DeleteTooltip">Elimina la maschera selezionata</sys:String>
+    <sys:String x:Key="MasksView_CpusHeader">CPUs</sys:String>
+    <sys:String x:Key="MasksView_Cpu">CPU</sys:String>
+    <sys:String x:Key="MasksView_Options">Opzioni maschera</sys:String>
+
+    <!-- PerformanceView -->
+    <sys:String x:Key="PerformanceView_OptionalDiagnostics">Diagnostica opzionale</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc">La diagnostica è facoltativa e destinata alla risoluzione dei problemi. Per sovrapposizioni di gioco e grafici dettagliati delle prestazioni, utilizza strumenti dedicati.</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc1">La diagnostica è facoltativa e destinata alla risoluzione dei problemi.</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc2">Per sovrapposizioni di gioco e grafici dettagliati delle prestazioni, utilizza strumenti dedicati.</sys:String>
+    <sys:String x:Key="PerformanceView_QuickTips">Suggerimenti rapidi:</sys:String>
+    <sys:String x:Key="PerformanceView_Tip1">1. Aprire la diagnostica solo quando è necessaria un'istantanea mirata per la risoluzione dei problemi.</sys:String>
+    <sys:String x:Key="PerformanceView_Tip2">2. Esamina gli hotspot solo come suggerimento prima di creare regole di automazione.</sys:String>
+    <sys:String x:Key="PerformanceView_Tip3">3. Interrompi le metriche in tempo reale una volta terminata la risoluzione dei problemi.</sys:String>
+    <sys:String x:Key="PerformanceView_Continue">Continuare con Diagnostica</sys:String>
+
+    <sys:String x:Key="PerformanceView_ActiveProcesses">Processi attivi</sys:String>
+    <sys:String x:Key="PerformanceView_TopConsumersDesc">Principali CPU e consumatori di memoria con la creazione di regole con un clic.</sys:String>
+    <sys:String x:Key="PerformanceView_SearchPlaceholder">Cerca processi per nome</sys:String>
+    <sys:String x:Key="PerformanceView_RuleBackedOnly">Solo supportato da regole</sys:String>
+    <sys:String x:Key="PerformanceView_ActionableOnly">Solo utilizzabile</sys:String>
+    <sys:String x:Key="PerformanceView_RuleImpact">Impatto delle regole</sys:String>
+    <sys:String x:Key="PerformanceView_CreateRuleButton">Crea/Aggiorna regola dalla selezione</sys:String>
+    <sys:String x:Key="PerformanceView_CreateRuleTooltip">Crea o aggiorna una regola di automazione dal processo hotspot selezionato</sys:String>
+
+    <sys:String x:Key="PerformanceView_Timeline">Cronologia della stabilità</sys:String>
+    <sys:String x:Key="PerformanceView_ClearHistory">Cancella cronologia</sys:String>
+    <sys:String x:Key="PerformanceView_ClearHistoryTooltip">Cancella le metriche visualizzate e la cronologia della sequenza temporale</sys:String>
+    <sys:String x:Key="PerformanceView_CoreSnapshot">Istantanea dei core</sys:String>
+    <sys:String x:Key="PerformanceView_CoreSnapshotDesc">Utilizzo per core per individuare rapidamente eventuali squilibri.</sys:String>
+    <sys:String x:Key="PerformanceView_ToggleCore">Attiva/disattiva il pannello principale</sys:String>
+    <sys:String x:Key="PerformanceView_ToggleProcess">Attiva/disattiva il pannello Processi</sys:String>
+    <sys:String x:Key="PerformanceView_StartLive">Avvia metriche in tempo reale</sys:String>
+    <sys:String x:Key="PerformanceView_StartLiveTooltip">Avvia la raccolta di metriche in tempo reale per questa dashboard</sys:String>
+    <sys:String x:Key="PerformanceView_StopLive">Interrompi le metriche in tempo reale</sys:String>
+    <sys:String x:Key="PerformanceView_StopLiveTooltip">Mettere in pausa la raccolta delle metriche in tempo reale; l'automazione in background è separata</sys:String>
+    <sys:String x:Key="PerformanceView_Refresh">Aggiorna</sys:String>
+    <sys:String x:Key="PerformanceView_RefreshTooltip">Aggiorna l'istantanea della dashboard corrente</sys:String>
+
+    <sys:String x:Key="PerformanceView_GlobalPowerPlan">Piano di alimentazione globale</sys:String>
+    <sys:String x:Key="PerformanceView_ProcessHotspots">Hotspot di processo</sys:String>
+    <sys:String x:Key="PerformanceView_Filter">Filtra</sys:String>
+    <sys:String x:Key="PerformanceView_Memory">Memoria</sys:String>
+    <sys:String x:Key="PerformanceView_Name">Nome</sys:String>
+    <sys:String x:Key="PerformanceView_Priority">Priorità</sys:String>
+    <sys:String x:Key="PerformanceView_Window">Finestra</sys:String>
+    <sys:String x:Key="PerformanceView_MemoryUsed">Memoria utilizzata</sys:String>
+    <sys:String x:Key="PerformanceView_CpuPercent">CPU %</sys:String>
+    <sys:String x:Key="PerformanceView_MemPercent">Mem%</sys:String>
+    <sys:String x:Key="PerformanceView_Threads">Thread</sys:String>
+    <sys:String x:Key="PerformanceView_Events">Eventi</sys:String>
+    <sys:String x:Key="PerformanceView_Severity">Gravità</sys:String>
+    <sys:String x:Key="PerformanceView_Detail">Dettaglio</sys:String>
+    <sys:String x:Key="PerformanceView_Time">Tempo</sys:String>
+    <sys:String x:Key="PerformanceView_Category">Categoria</sys:String>
+    <sys:String x:Key="PerformanceView_Process">Processo</sys:String>
+    <sys:String x:Key="PerformanceView_SelectedHotspot">Processo hotspot selezionato</sys:String>
+    <sys:String x:Key="PerformanceView_Metrics">Metriche</sys:String>
+    <sys:String x:Key="PerformanceView_Processes">Processi</sys:String>
+
+    <!-- PowerPlanView -->
+    <sys:String x:Key="PowerPlanView_Title">Piani di alimentazione</sys:String>
+    <sys:String x:Key="PowerPlanView_Subtitle">Gestisci il piano di alimentazione Windows attivo e importa profili .pow personalizzati</sys:String>
+    <sys:String x:Key="PowerPlanView_WindowsPowerPlans">Windows Piani di alimentazione</sys:String>
+    <sys:String x:Key="PowerPlanView_SelectActiveTip">Seleziona il piano Windows da rendere attivo.</sys:String>
+    <sys:String x:Key="PowerPlanView_SetActive">Imposta come piano Windows attivo</sys:String>
+    <sys:String x:Key="PowerPlanView_SetActiveTooltip">Modificare il piano di alimentazione attivo Windows con il piano selezionato</sys:String>
+    <sys:String x:Key="PowerPlanView_Refresh">Aggiorna i piani</sys:String>
+    <sys:String x:Key="PowerPlanView_RefreshTooltip">Aggiorna l'elenco delle combinazioni di risparmio energia disponibili</sys:String>
+    <sys:String x:Key="PowerPlanView_CustomPowerPlans">Piani di alimentazione personalizzati</sys:String>
+    <sys:String x:Key="PowerPlanView_LocalPlansTip">File .pow locali pronti per essere importati in Windows.</sys:String>
+    <sys:String x:Key="PowerPlanView_ImportSelected">Importa file .pow selezionati</sys:String>
+    <sys:String x:Key="PowerPlanView_ImportSelectedTooltip">Importa il file .pow personalizzato selezionato in Windows</sys:String>
+    <sys:String x:Key="PowerPlanView_AddFile">Aggiungi il file .pow</sys:String>
+    <sys:String x:Key="PowerPlanView_AddFileTooltip">Aggiungi un nuovo file di combinazione di risparmio energia personalizzato alla libreria personalizzata</sys:String>
+    <sys:String x:Key="PowerPlanView_Delete">Elimina</sys:String>
+    <sys:String x:Key="PowerPlanView_Active">Attivo</sys:String>
+
+    <!-- ProcessPowerPlanAssociationView -->
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Title">Regole e automazione</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Subtitle">Il monitoraggio dell'automazione controlla gli eventi di avvio/arresto del processo e applica il piano di risparmio energia configurato, la maschera CPU e le regole di priorità.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleEditor">Editor delle regole</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EditorSubtitle">Crea una regola da un processo eseguibile o in esecuzione per automatizzare il piano di risparmio energia, la maschera CPU e il comportamento prioritario.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ExecutableMatch">Corrispondenza eseguibile:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_MatchByPath">Corrispondenza per percorso</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_MatchByPathTooltip">Abbina i processi in base al percorso completo anziché solo al nome dell'eseguibile</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Browse">Cerca Eseguibile</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_BrowseTooltip">Fare clic per selezionare un file eseguibile (.exe) dal computer</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ExecutableHelp">Scegli un eseguibile. La corrispondenza per percorso è più precisa; la corrispondenza per nome si applica a qualsiasi processo con quel nome eseguibile.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseRunningProcess">Usa processo in esecuzione:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseRunningProcessTooltip">Seleziona un processo attualmente in esecuzione per utilizzare il suo eseguibile</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseSelectedProcess">Utilizza il processo selezionato</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseSelectedProcessTooltip">Utilizza l'eseguibile del processo in esecuzione selezionato</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePowerPlan">Piano di alimentazione delle regole (passaggio globale):</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePowerPlanHelp">Quando questa regola corrisponde, Windows cambia il piano di alimentazione attivo globale.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleCpuMask">Regola CPU Maschera:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleCpuMaskHelp">Facoltativo: selezionare una maschera CPU da applicare all'avvio del processo</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePriority">Priorità regola</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Update">Aggiorna</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePriorityHelp">Facoltativo: selezionare la priorità del processo da applicare all'avvio di questo processo</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AssociationPriority">Priorità dell'associazione:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AssociationPriorityHelp">Le associazioni con priorità più alta hanno la precedenza in caso di corrispondenze multiple</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AddRule">Aggiungi regola</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UpdateRule">Aggiorna regola selezionata</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UpdateRuleTooltip">Aggiorna l'associazione selezionata</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ClearSelection">Cancella selezione</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ClearSelectionTooltip">Cancella l'eseguibile selezionato</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_CurrentRules">Regole attuali</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulesDescription">Definisci regole per processo. I piani di alimentazione sono globali; maschere e priorità si applicano ai processi corrispondenti.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Remove">Rimuovi</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RemoveTooltip">Rimuovi l'associazione selezionata</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DefaultPowerPlan">Piano di alimentazione predefinito (fallback quando nessuna regola corrisponde)</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DefaultPowerPlanHelp">Piano di risparmio energia da utilizzare quando non sono in esecuzione processi associati:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SetDefault">Imposta il piano di alimentazione predefinito</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SettingsTitle">Impostazioni di monitoraggio dell'automazione</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EnableWmi">Abilita automazione basata su eventi (WMI)</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EnableFallback">Abilita il polling di fallback dell'automazione</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PollingInterval">Intervallo di polling (secondi):</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ChangeDelay">Ritardo modifica piano di alimentazione (ms):</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PreventDuplicates">Previeni modifiche duplicate del piano di alimentazione</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SaveConfig">Salva configurazione</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_NoRules">Nessuna regola di automazione ancora</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Status">Stato:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationMonitoring">Monitoraggio dell'automazione</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_StartAutomation">Avvia il monitoraggio dell'automazione</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_StopAutomation">Arresta il monitoraggio dell'automazione</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AppliedToMatching">Applicato a ciascun processo corrispondente quando viene eseguita la regola di automazione.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AppliedOnlyToMatching">Applicato solo ai processi di corrispondenza; non modifica il piano di alimentazione globale Windows.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SelectedExecutable">Eseguibile selezionato:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DescriptionLabel">Descrizione:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationService">Servizio di automazione</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulesHeader">Regole</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Eseguibile</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Piano di alimentazione</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_CpuMask">CPU Maschera</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Priority">Priorità</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Description">Descrizione</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ProcessPriority">Priorità del processo:</sys:String>
+
+    <!-- ProcessView -->
+    <sys:String x:Key="ProcessView_Title">Gestione dei processi</sys:String>
+    <sys:String x:Key="ProcessView_Subtitle">Cerca, filtra e controlla le configurazioni dei processi attivi</sys:String>
+    <sys:String x:Key="ProcessView_SearchPlaceholder">Cerca processi per nome</sys:String>
+    <sys:String x:Key="ProcessView_SearchAutomationName">Ricerca di processi</sys:String>
+    <sys:String x:Key="ProcessView_HideSystem">Nascondi i processi di sistema Windows</sys:String>
+    <sys:String x:Key="ProcessView_HideSystemShort">Nascondi processi di sistema</sys:String>
+    <sys:String x:Key="ProcessView_HideLowCpu">Nascondi processi con un utilizzo di CPU molto basso</sys:String>
+    <sys:String x:Key="ProcessView_HideIdle">Nascondi processi inattivi</sys:String>
+    <sys:String x:Key="ProcessView_VisibleWindowsOnly">Mostra solo le applicazioni con windows visibile</sys:String>
+    <sys:String x:Key="ProcessView_ActiveAppsOnly">Solo app attive</sys:String>
+    <sys:String x:Key="ProcessView_LockList">Blocca l'elenco dei processi</sys:String>
+    <sys:String x:Key="ProcessView_LockListTooltip">Metti in pausa l'aggiornamento dell'elenco dei processi e l'ordinamento degli aggiornamenti mentre lavori con l'elenco corrente. Il monitoraggio in background e l'applicazione automatica delle regole salvate continuano mentre ThreadPilot è in esecuzione.</sys:String>
+    <sys:String x:Key="ProcessView_SortBy">Ordina per:</sys:String>
+    <sys:String x:Key="ProcessView_SortByTooltip">Scegli come ordinare l'elenco dei processi</sys:String>
+
+    <sys:String x:Key="ProcessView_SelectedProcess">Processo selezionato</sys:String>
+    <sys:String x:Key="ProcessView_NoProcessSelected">Nessun processo selezionato</sys:String>
+    <sys:String x:Key="ProcessView_SelectProcessTip">Seleziona un processo dalla tabella per abilitare le azioni di affinità, priorità, piano di risparmio energia e regole.</sys:String>
+    <sys:String x:Key="ProcessView_PowerPlanPending">Piano di alimentazione/Impostazioni in sospeso</sys:String>
+    <sys:String x:Key="ProcessView_PowerPlanTooltip">Scegli il piano di risparmio energia da attivare manualmente o da includere con l'applicazione rapida</sys:String>
+    <sys:String x:Key="ProcessView_SetPowerPlan">Imposta il piano di risparmio energia</sys:String>
+    <sys:String x:Key="ProcessView_SetPowerPlanTooltip">Attiva il piano di risparmio energia Windows selezionato</sys:String>
+
+    <sys:String x:Key="ProcessView_PendingCoreMask">Maschera centrale in sospeso</sys:String>
+    <sys:String x:Key="ProcessView_StageMaskTooltip">Seleziona una maschera per metterla in scena. Ciò non modifica l'affinità del sistema operativo finché non si fa clic su Applica affinità.</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinity">Applica affinità</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinityTooltip">Applica la maschera core in sospeso al processo selezionato e verifica lo stato di affinità Windows</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinitySaveRule">Applica affinità e Salva come regola</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinitySaveRuleTooltip">Salva le impostazioni del processo corrente come regola. Queste impostazioni verranno applicate automaticamente all'avvio di questo processo in futuro.</sys:String>
+
+    <sys:String x:Key="ProcessView_SetCpuPriority">Imposta la priorità CPU</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPriorityTooltip">Applica la priorità selezionata al processo</sys:String>
+    <sys:String x:Key="ProcessView_EnforcePriorityRegistry">Applicare la priorità tramite il registro</sys:String>
+    <sys:String x:Key="ProcessView_EnforcePriorityRegistryTooltip">Applica la priorità tramite il registro Windows. Il processo deve essere riavviato affinché le modifiche abbiano effetto. Questa impostazione persiste durante i riavvii del sistema.</sys:String>
+    <sys:String x:Key="ProcessView_SetPriority">Imposta la priorità</sys:String>
+    <sys:String x:Key="ProcessView_RealtimeBlockedHelp">La priorità in tempo reale è bloccata da ThreadPilot perché può rendere Windows instabile o non rispondere.</sys:String>
+    <sys:String x:Key="ProcessView_RealtimeBlocked">In tempo reale (bloccato)</sys:String>
+
+    <sys:String x:Key="ProcessView_DisableIdleServer">Disabilita server inattivo</sys:String>
+    <sys:String x:Key="ProcessView_DisableIdleServerTooltip">Impedisce al sistema di entrare nello stato inattivo mentre questo processo è in esecuzione. Utile per giochi e applicazioni critiche per le prestazioni.</sys:String>
+
+    <sys:String x:Key="ProcessView_ProfileRule">Profilo/Regola</sys:String>
+    <sys:String x:Key="ProcessView_ProfileNamePlaceholder">Inserisci un nome di profilo per salvare o caricare le impostazioni</sys:String>
+    <sys:String x:Key="ProcessView_SaveProfile">Salva profilo</sys:String>
+    <sys:String x:Key="ProcessView_SaveProfileTooltip">Salva l'affinità e la priorità CPU correnti come profilo riutilizzabile</sys:String>
+    <sys:String x:Key="ProcessView_LoadProfile">Carica profilo</sys:String>
+    <sys:String x:Key="ProcessView_LoadProfileTooltip">Carica un profilo salvato in precedenza</sys:String>
+    <sys:String x:Key="ProcessView_SaveCurrentRule">Salva le impostazioni correnti come regola</sys:String>
+
+    <sys:String x:Key="ProcessView_LastAction">Ultima azione ThreadPilot:</sys:String>
+    <sys:String x:Key="ProcessView_Refresh">Aggiorna</sys:String>
+    <sys:String x:Key="ProcessView_RefreshTooltip">Aggiorna l'elenco dei processi</sys:String>
+    <sys:String x:Key="ProcessView_LoadMore">Carica altro</sys:String>
+    <sys:String x:Key="ProcessView_LoadMoreTooltip">Carica più processi</sys:String>
+    <sys:String x:Key="ProcessView_RefreshAutomationName">Aggiorna i processi</sys:String>
+    <sys:String x:Key="ProcessView_LoadMoreAutomationName">Carica più processi</sys:String>
+    <sys:String x:Key="ProcessView_RunningListAutomationName">Elenco dei processi in esecuzione</sys:String>
+    <sys:String x:Key="ProcessView_RunningListAutomationHelp">Tabella dei processi virtualizzata con ordinamento e selezione</sys:String>
+
+    <sys:String x:Key="ProcessView_ColProcessName">Nome del processo</sys:String>
+    <sys:String x:Key="ProcessView_ColWindowTitle">Titolo della finestra</sys:String>
+    <sys:String x:Key="ProcessView_ColCpuUsage">Utilizzo CPU</sys:String>
+    <sys:String x:Key="ProcessView_ColMemory">Utilizzo della memoria</sys:String>
+
+    <sys:String x:Key="ProcessView_AffinityStagedTooltip">Affinità organizzata nell'interfaccia utente. Non viene applicato finché non si fa clic su Applica affinità.</sys:String>
+    <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Affinità attualmente segnalata da Windows per il processo selezionato</sys:String>
+    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Anteprima di sola lettura della selezione CPU corrente o in sospeso</sys:String>
+    <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Apri la scheda CPU Maschere per creare una nuova maschera personalizzata</sys:String>
+    <sys:String x:Key="ProcessView_HyperThreadingTooltip">Mostra se Hyper-Threading (Intel) o SMT (AMD) è presente e attivo su questo sistema</sys:String>
+
+    <sys:String x:Key="ProcessView_CopyProcessInfo">Copia informazioni sul processo</sys:String>
+    <sys:String x:Key="ProcessView_OpenLocation">Apri la posizione dell'eseguibile</sys:String>
+    <sys:String x:Key="ProcessView_ClearCpuSets">Cancella CPU Imposta</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPendingSettings">Applica le impostazioni in sospeso</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPendingSettingsTooltip">Applica l'affinità in sospeso e la combinazione per il risparmio di energia selezionata al processo selezionato</sys:String>
+    <sys:String x:Key="ProcessView_RulesAppliedOnlyWhenConfigured">Le regole e le modifiche vengono applicate da ThreadPilot solo se configurate.</sys:String>
+    <sys:String x:Key="ProcessView_CurrentProcessStatus">Stato attuale del processo</sys:String>
+    <sys:String x:Key="ProcessView_AdvancedAffinityPicker">Selettore di affinità avanzato</sys:String>
+    <sys:String x:Key="ProcessView_RowMaskTooltip">Seleziona la maschera in sospeso per le azioni di affinità del menu contestuale delle righe</sys:String>
+    <sys:String x:Key="ProcessView_SelectedPowerPlan">Piano di alimentazione selezionato</sys:String>
+    <sys:String x:Key="ProcessView_SaveAsRule">Salva come regola</sys:String>
+    <sys:String x:Key="ProcessView_NoVisibleWindowTitle">Nessun titolo della finestra visibile</sys:String>
+    <sys:String x:Key="ProcessView_BatchLabel">Batch</sys:String>
+    <sys:String x:Key="ProcessView_TotalSuffix">totale)</sys:String>
+    <sys:String x:Key="ProcessView_PriorityInlineLabel">Priorità</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuUnavailable">CPU: non disponibile</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryUnavailable">Memoria: non disponibile</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuPriorityUnavailable">CPU priorità: non disponibile</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryPriorityUnavailable">Priorità memoria non disponibile</sys:String>
+    <sys:String x:Key="ProcessSummary_AffinityUnavailable">Affinità: non disponibile</sys:String>
+    <sys:String x:Key="ProcessSummary_NoSavedRule">Nessuna regola salvata</sys:String>
+    <sys:String x:Key="ProcessSummary_NoRecentAction">Nessuna azione ThreadPilot recente</sys:String>
+    <sys:String x:Key="ProcessSummary_SelectedProcessFormat">Processo selezionato: {0} (PID {1})</sys:String>
+    <sys:String x:Key="ProcessSummary_StatusProtected">Stato attuale del processo: protetto o accesso negato</sys:String>
+    <sys:String x:Key="ProcessSummary_StatusSelected">Stato attuale del processo: selezionato</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuFormat">CPU: {0:N1}%</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryFormat">Memoria: {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuPriorityFormat">CPU priorità: {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_AffinityLegacyFormat">Affinità: maschera legacy 0x{0:X}</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryPriorityFormat">Priorità memoria: {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_SavedRuleFallback">regola salvata</sys:String>
+    <sys:String x:Key="ProcessSummary_SavedRuleExistsFormat">La regola salvata esiste: {0}</sys:String>
+
+    <sys:String x:Key="ProcessView_PriorityAboveNormal">Sopra il normale</sys:String>
+    <sys:String x:Key="ProcessView_PriorityBelowNormal">Sotto la norma</sys:String>
+    <sys:String x:Key="ProcessView_PriorityHigh">Alto</sys:String>
+    <sys:String x:Key="ProcessView_PriorityIdle">Inattivo</sys:String>
+    <sys:String x:Key="ProcessView_PriorityLow">Basso</sys:String>
+    <sys:String x:Key="ProcessView_PriorityNormal">Normale</sys:String>
+    <sys:String x:Key="ProcessView_PriorityRealtime">In tempo reale</sys:String>
+    <sys:String x:Key="ProcessView_PriorityBatch">Batch</sys:String>
+    <sys:String x:Key="ProcessView_PriorityCustom">Personalizzato</sys:String>
+
+    <sys:String x:Key="ProcessView_HasWindow">Ha finestra</sys:String>
+    <sys:String x:Key="ProcessView_Window">Finestra</sys:String>
+    <sys:String x:Key="ProcessView_PID">PID</sys:String>
+    <sys:String x:Key="ProcessView_ID">ID</sys:String>
+    <sys:String x:Key="ProcessView_MemoryMb">Memoria (MB)</sys:String>
+    <sys:String x:Key="ProcessView_Affinity">Affinità</sys:String>
+    <sys:String x:Key="ProcessView_Priority">Priorità</sys:String>
+    <sys:String x:Key="ProcessView_Rules">Regole</sys:String>
+    <sys:String x:Key="ProcessView_Name">Nome</sys:String>
+    <sys:String x:Key="ProcessView_SetMemoryPriority">Imposta la priorità della memoria</sys:String>
+    <sys:String x:Key="ProcessView_PriorityVeryLow">Molto basso</sys:String>
+    <sys:String x:Key="ProcessView_PriorityMedium">Medio</sys:String>
+    <sys:String x:Key="ProcessView_RefreshInfo">Aggiorna informazioni sul processo</sys:String>
+
+    <!-- SettingsView -->
+    <sys:String x:Key="SettingsView_Title">Impostazioni dell'applicazione</sys:String>
+    <sys:String x:Key="SettingsView_Subtitle">Configura notifiche, barra delle applicazioni e comportamento dell'applicazione</sys:String>
+    <sys:String x:Key="SettingsView_Notifications">Notifiche</sys:String>
+    <sys:String x:Key="SettingsView_EnableNotifications">Abilita notifiche</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevel">Livello di notifica</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelAll">Tutto</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelWarningsErrors">Solo avvisi/errori</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelSilent">Silenzioso</sys:String>
+    <sys:String x:Key="SettingsView_EnableBalloon">Abilita notifiche tramite fumetto (barra delle applicazioni)</sys:String>
+    <sys:String x:Key="SettingsView_EnableToast">Abilita notifiche toast (Windows 10+)</sys:String>
+    <sys:String x:Key="SettingsView_NotificationTypes">Tipi di notifica</sys:String>
+    <sys:String x:Key="SettingsView_NotifyPowerPlan">Modifiche al piano di alimentazione</sys:String>
+    <sys:String x:Key="SettingsView_NotifyProcess">Eventi di monitoraggio dei processi</sys:String>
+    <sys:String x:Key="SettingsView_NotifyError">Notifiche di errore</sys:String>
+    <sys:String x:Key="SettingsView_NotifySuccess">Notifiche di successo</sys:String>
+    <sys:String x:Key="SettingsView_Duration">Durata (ms):</sys:String>
+    <sys:String x:Key="SettingsView_TestNotification">Notifica di prova</sys:String>
+
+    <sys:String x:Key="SettingsView_SystemTray">Vassoio di sistema</sys:String>
+    <sys:String x:Key="SettingsView_ShowTrayIcon">Mostra l'icona nella barra delle applicazioni</sys:String>
+    <sys:String x:Key="SettingsView_MinimizeToTray">Ridurre a icona nel vassoio</sys:String>
+    <sys:String x:Key="SettingsView_CloseToTray">Vicino al vassoio (invece che all'uscita)</sys:String>
+    <sys:String x:Key="SettingsView_StartMinimized">Inizia minimizzato</sys:String>
+    <sys:String x:Key="SettingsView_QuickApply">Abilita le impostazioni in sospeso applicate dal vassoio</sys:String>
+    <sys:String x:Key="SettingsView_MonitoringControl">Abilita i controlli di monitoraggio dell'automazione dal vassoio</sys:String>
+    <sys:String x:Key="SettingsView_DetailedTooltips">Mostra descrizioni comandi dettagliate</sys:String>
+
+    <sys:String x:Key="SettingsView_BasicPreferences">Preferenze di base</sys:String>
+    <sys:String x:Key="SettingsView_Autostart">Avvio automatico</sys:String>
+    <sys:String x:Key="SettingsView_StartWithWindows">Inizia con Windows</sys:String>
+    <sys:String x:Key="SettingsView_AutostartDescription">Avvia automaticamente ThreadPilot all'avvio di Windows</sys:String>
+    <sys:String x:Key="SettingsView_LowImpactMode">Modalità a basso impatto in background</sys:String>
+    <sys:String x:Key="SettingsView_LowImpactDescription">Diminuisce la priorità del processo di ThreadPilot mentre è ridotto a icona o nascosto nel vassoio.</sys:String>
+
+    <sys:String x:Key="SettingsView_Appearance">Aspetto</sys:String>
+    <sys:String x:Key="SettingsView_UseDarkTheme">Utilizza il tema scuro</sys:String>
+    <sys:String x:Key="SettingsView_ThemeDescription">Applica un tema globale Scuro/Chiaro a tutte le schede</sys:String>
+
+    <sys:String x:Key="SettingsView_Language">Lingua</sys:String>
+    <sys:String x:Key="SettingsView_LanguageZhCn">简体中文 (Simplified Chinese)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageEnUs">English (English)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageItIt">Italiano (Italian)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageFrFr">Français (French)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageDeDe">Deutsch (German)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageEsEs">Español (Spanish)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageRuRu">Русский (Russian)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageDescription">Applica una lingua di visualizzazione globale nell'intera interfaccia dell'applicazione.</sys:String>
+
+    <sys:String x:Key="SettingsView_RulesAutomation">Regole e automazione</sys:String>
+    <sys:String x:Key="SettingsView_RuleAutoApply">Applicazione automatica della regola salvata</sys:String>
+    <sys:String x:Key="SettingsView_ApplyOnStart">Applica le regole salvate all'avvio dei processi di corrispondenza</sys:String>
+    <sys:String x:Key="SettingsView_ApplyOnStartDescription">Applica le regole salvate abilitate mentre ThreadPilot è in esecuzione. Ciò non installa un servizio Windows e non utilizza la persistenza del registro/IFEO.</sys:String>
+    <sys:String x:Key="SettingsView_EnableWmi">Abilita eventi di processo WMI</sys:String>
+    <sys:String x:Key="SettingsView_WmiDescription">Utilizzare Windows Strumentazione di gestione per gli eventi di avvio/arresto del processo</sys:String>
+    <sys:String x:Key="SettingsView_EnableFallback">Abilita il polling di fallback</sys:String>
+    <sys:String x:Key="SettingsView_FallbackDescription">Utilizza il polling come backup quando gli eventi del processo WMI falliscono</sys:String>
+    <sys:String x:Key="SettingsView_PollingInterval">Intervallo di interrogazione (ms):</sys:String>
+    <sys:String x:Key="SettingsView_FallbackPollingInterval">Polling di fallback (ms):</sys:String>
+
+    <sys:String x:Key="SettingsView_Advanced">Avanzato</sys:String>
+    <sys:String x:Key="SettingsView_NotificationHistory">Abilita la cronologia delle notifiche</sys:String>
+    <sys:String x:Key="SettingsView_MaxHistory">Elementi massimi della cronologia:</sys:String>
+    <sys:String x:Key="SettingsView_AutoHide">Notifiche nascoste automaticamente</sys:String>
+    <sys:String x:Key="SettingsView_NotificationSound">Abilita il suono delle notifiche</sys:String>
+    <sys:String x:Key="SettingsView_DebugLogging">Abilita la registrazione del debug</sys:String>
+    <sys:String x:Key="SettingsView_PerformanceCounters">Abilita i contatori delle prestazioni</sys:String>
+
+    <sys:String x:Key="SettingsView_About">Informazioni</sys:String>
+    <sys:String x:Key="SettingsView_Version">Versione:</sys:String>
+    <sys:String x:Key="SettingsView_Copyright">Copyright © 2026 PrimeBuild</sys:String>
+    <sys:String x:Key="SettingsView_Translator">Traduttore: Ylimhs</sys:String>
+    <sys:String x:Key="SettingsView_License">Licenza: AGPLv3</sys:String>
+    <sys:String x:Key="SettingsView_CheckUpdates">Controlla gli aggiornamenti</sys:String>
+    <sys:String x:Key="SettingsView_DownloadInstallUpdate">Scarica e installa l'aggiornamento</sys:String>
+    <sys:String x:Key="SettingsView_EnableAutomaticUpdateChecks">Controlla automaticamente all'avvio</sys:String>
+    <sys:String x:Key="SettingsView_UpdateIntervalDays">Intervallo di controllo (giorni):</sys:String>
+    <sys:String x:Key="SettingsView_IncludePrereleaseUpdates">Includere aggiornamenti preliminari</sys:String>
+    <sys:String x:Key="SettingsView_LatestVersion">Ultima versione:</sys:String>
+    <sys:String x:Key="SettingsView_LastUpdateCheck">Ultimo controllo:</sys:String>
+    <sys:String x:Key="SettingsView_UpdatesDescription">Verifiche su richiesta utilizzando le Release ufficiali GitHub.</sys:String>
+
+    <sys:String x:Key="SettingsView_ResetDefaults">Ripristina le impostazioni predefinite</sys:String>
+    <sys:String x:Key="SettingsView_ExportConfig">Esporta configurazione</sys:String>
+    <sys:String x:Key="SettingsView_ImportConfig">Importa configurazione</sys:String>
+    <sys:String x:Key="SettingsView_SaveSettings">Salva impostazioni</sys:String>
+    <sys:String x:Key="SettingsView_ThreadPilot">ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_StatusThemeChangedFormat">Tema cambiato in {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusThemeChangeFailedFormat">Impossibile modificare il tema in {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusLanguageChangedFormat">Lingua modificata in {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusLanguageChangeFailed">Impossibile cambiare lingua.</sys:String>
+    <sys:String x:Key="Settings_StatusSaving">Salvataggio delle impostazioni...</sys:String>
+    <sys:String x:Key="Settings_StatusSavedWarningsFormat">Impostazioni salvate con avvisi: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusSavedApplied">Impostazioni salvate e applicate correttamente.</sys:String>
+    <sys:String x:Key="Settings_StatusErrorSavingFormat">Errore durante il salvataggio delle impostazioni: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusResetting">Ripristino delle impostazioni predefinite...</sys:String>
+    <sys:String x:Key="Settings_StatusResetPending">Impostazioni ripristinate ai valori predefiniti (non ancora salvate)</sys:String>
+    <sys:String x:Key="Settings_StatusErrorResettingFormat">Errore durante la reimpostazione delle impostazioni: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusExporting">Esportazione del pacchetto di configurazione...</sys:String>
+    <sys:String x:Key="Settings_StatusExportCanceled">Esportazione annullata</sys:String>
+    <sys:String x:Key="Settings_StatusExportedFormat">Configurazione esportata in: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusErrorExportingFormat">Errore durante l'esportazione delle impostazioni: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusImporting">Importazione della configurazione...</sys:String>
+    <sys:String x:Key="Settings_StatusImportCanceled">Importazione annullata</sys:String>
+    <sys:String x:Key="Settings_StatusImportedApplied">Pacchetto di configurazione importato e applicato</sys:String>
+    <sys:String x:Key="Settings_StatusLegacyImported">Impostazioni legacy importate (regole invariate)</sys:String>
+    <sys:String x:Key="Settings_StatusErrorImportingFormat">Errore durante l'importazione delle impostazioni: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusTestSent">Notifica di prova inviata</sys:String>
+    <sys:String x:Key="Settings_StatusErrorTestFormat">Errore durante l'invio della notifica di prova: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusLoading">Caricamento impostazioni...</sys:String>
+    <sys:String x:Key="Settings_StatusLoaded">Impostazioni caricate</sys:String>
+    <sys:String x:Key="Settings_StatusErrorLoadingFormat">Errore durante il caricamento delle impostazioni: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusSynchronized">Impostazioni sincronizzate</sys:String>
+    <sys:String x:Key="Settings_StatusCheckingUpdates">Controllo aggiornamenti...</sys:String>
+    <sys:String x:Key="Settings_StatusLatestUnknown">Impossibile determinare la versione più recente.</sys:String>
+    <sys:String x:Key="Settings_StatusNewVersionFormat">Nuova versione disponibile: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusUpToDateFormat">L'applicazione è aggiornata. Versione installata: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateErrorFormat">Errore durante il controllo degli aggiornamenti: {0}</sys:String>
+    <sys:String x:Key="Settings_UpdateLatestUnknown">Sconosciuto</sys:String>
+    <sys:String x:Key="Settings_UpdateNotChecked">Non controllato</sys:String>
+    <sys:String x:Key="Settings_UpdateLastCheckedNever">Mai</sys:String>
+    <sys:String x:Key="Settings_UpdateConfirmTitle">Installa l'aggiornamento ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_UpdateConfirmMessageFormat">ThreadPilot scaricherà e verificherà la versione {0}, quindi chiederà a Windows l'autorizzazione per eseguire il programma di installazione. Continuare?</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateCanceled">Aggiornamento annullato.</sys:String>
+    <sys:String x:Key="Settings_StatusDownloadingUpdate">Download e verifica dell'aggiornamento in corso...</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateInstallerStarted">Avviato il programma di installazione dell'aggiornamento.</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateInstallFailedFormat">Installazione dell'aggiornamento non riuscita: {0}</sys:String>
+    <sys:String x:Key="Settings_StatusModified">Le impostazioni sono state modificate</sys:String>
+    <sys:String x:Key="Settings_StatusMatchSaved">Le impostazioni corrispondono alla configurazione salvata</sys:String>
+    <sys:String x:Key="Settings_LanguageSimplifiedChinese">Cinese semplificato</sys:String>
+    <sys:String x:Key="Settings_LanguageEnglish">Inglese</sys:String>
+    <sys:String x:Key="Settings_LanguageItalian">Italiano</sys:String>
+    <sys:String x:Key="Settings_LanguageFrench">Francese</sys:String>
+    <sys:String x:Key="Settings_LanguageGerman">Tedesco</sys:String>
+    <sys:String x:Key="Settings_LanguageSpanish">Spagnolo</sys:String>
+    <sys:String x:Key="Settings_LanguageRussian">Russo</sys:String>
+    <sys:String x:Key="Settings_ThemeDark">Scuro</sys:String>
+    <sys:String x:Key="Settings_ThemeLight">Chiaro</sys:String>
+    <sys:String x:Key="Settings_DialogExportTitle">Esporta ThreadPilot Configurazione</sys:String>
+    <sys:String x:Key="Settings_DialogImportTitle">Importa ThreadPilot Configurazione</sys:String>
+    <sys:String x:Key="Settings_WarningAutostartFailed">Impossibile aggiornare l'avvio automatico Windows. Mantenimento dello stato di avvio automatico precedente.</sys:String>
+
+    <!-- SettingsWindow -->
+    <sys:String x:Key="SettingsWindow_Title">ThreadPilot Impostazioni</sys:String>
+    <sys:String x:Key="SettingsWindow_UnsavedTitle">Impostazioni non salvate</sys:String>
+    <sys:String x:Key="SettingsWindow_UnsavedDescription">Sono presenti modifiche non salvate. Salvale, scartale oppure annulla per continuare a modificarle.</sys:String>
+    <sys:String x:Key="SettingsWindow_Cancel">Annulla</sys:String>
+    <sys:String x:Key="SettingsWindow_Discard">Scartare</sys:String>
+    <sys:String x:Key="SettingsWindow_Save">Salva</sys:String>
+
+    <!-- SystemTweaksView -->
+    <sys:String x:Key="SystemTweaksView_Title">Modifiche e ottimizzazioni del sistema</sys:String>
+    <sys:String x:Key="SystemTweaksView_Subtitle">Configura Windows ottimizzazioni del sistema e modifiche alle prestazioni</sys:String>
+    <sys:String x:Key="SystemTweaksView_RefreshAll">Aggiorna tutto</sys:String>
+    <sys:String x:Key="SystemTweaksView_RefreshAllTooltip">Aggiorna tutti gli stati delle modifiche</sys:String>
+    <sys:String x:Key="SystemTweaksView_TweakTooltip">Attiva/disattiva questo tweak Windows</sys:String>
+    <sys:String x:Key="SystemTweaksView_Status">Stato</sys:String>
+
+    <!-- SystemTweaks Names and Descriptions -->
+    <sys:String x:Key="SystemTweak_CoreParking_Name">Core Parking</sys:String>
+    <sys:String x:Key="SystemTweak_CoreParking_Desc">Controlla CPU core parking per la gestione dell'alimentazione</sys:String>
+    <sys:String x:Key="SystemTweak_CStates_Name">C-States</sys:String>
+    <sys:String x:Key="SystemTweak_CStates_Desc">Controlla CPU C-States per la gestione dell'alimentazione</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Name">HPET</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Desc">Timer eventi ad alta precisione per la temporizzazione del sistema</sys:String>
+    <sys:String x:Key="SystemTweak_SysMain_Name">SysMain Servizio</sys:String>
+    <sys:String x:Key="SystemTweak_SysMain_Desc">Windows Superfetch/SysMain servizio per la gestione della memoria</sys:String>
+    <sys:String x:Key="SystemTweak_Prefetch_Name">Prefetch</sys:String>
+    <sys:String x:Key="SystemTweak_Prefetch_Desc">Funzionalità Windows Prefetch per un caricamento più rapido dell'applicazione</sys:String>
+    <sys:String x:Key="SystemTweak_PowerThrottling_Name">Power Throttling</sys:String>
+    <sys:String x:Key="SystemTweak_PowerThrottling_Desc">Windows Power Throttling per l'efficienza energetica</sys:String>
+    <sys:String x:Key="SystemTweak_HighSchedulingCategory_Name">Categoria di pianificazione elevata</sys:String>
+    <sys:String x:Key="SystemTweak_HighSchedulingCategory_Desc">Alta priorità di pianificazione per le applicazioni di gioco</sys:String>
+    <sys:String x:Key="SystemTweak_MenuShowDelay_Name">Menu Mostra ritardo</sys:String>
+    <sys:String x:Key="SystemTweak_MenuShowDelay_Desc">Ritardo prima di mostrare i menu contestuali</sys:String>
+
+    <!-- SystemTweaksViewModel Messages -->
+    <sys:String x:Key="SystemTweaks_StatusReady">Pronto</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshing">Aggiornamento delle modifiche al sistema...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLastRefreshedFormat">Ultimo aggiornamento: {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshFailed">Impossibile aggiornare le modifiche al sistema</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshFailedShort">Aggiornamento non riuscito</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusTogglingFormat">Attivazione/disattivazione di {0}...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnabledFormat">{0} abilitato correttamente</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisabledFormat">{0} disabilitato correttamente</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyEnabledFormat">{0} è stato abilitato</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyDisabledFormat">{0} è stato disabilitato</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyUpdatedTitle">Modifica del sistema aggiornata</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusToggleFailedFormat">Impossibile attivare/disattivare {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnableFailedFormat">Impossibile abilitare {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisableFailedFormat">Impossibile disattivare {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyFailedTitle">Modifica del sistema non riuscita</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyFailedFormat">Impossibile {0} {1}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusErrorTogglingFormat">Errore durante l'attivazione/disattivazione di {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyErrorFormat">Errore durante l'attivazione/disattivazione di {0}: {1}</sys:String>
+    <sys:String x:Key="SystemTweaks_WordEnable">abilitare</sys:String>
+    <sys:String x:Key="SystemTweaks_WordDisable">disabilitare</sys:String>
+    <sys:String x:Key="SystemTweaks_WordEnabled">abilitato</sys:String>
+    <sys:String x:Key="SystemTweaks_WordDisabled">disabilitato</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnabled">Abilitato</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisabled">Disabilitato</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusNotAvailable">Non disponibile</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLoading">Caricamento modifiche al sistema...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLoadedSuccess">Le modifiche al sistema sono state caricate correttamente</sys:String>
+
+    <!-- SystemTray Context Menu & Status -->
+    <sys:String x:Key="SystemTray_OpenDashboard">Apri Dashboard</sys:String>
+    <sys:String x:Key="SystemTray_OpenDiagnostics">Apri Diagnostica</sys:String>
+    <sys:String x:Key="SystemTray_PauseMonitoring">Sospendi il monitoraggio dell'automazione</sys:String>
+    <sys:String x:Key="SystemTray_ResumeMonitoring">Riprendi il monitoraggio dell'automazione</sys:String>
+    <sys:String x:Key="SystemTray_SystemStatus">Stato del sistema</sys:String>
+    <sys:String x:Key="SystemTray_NoProcessSelected">Nessun processo selezionato</sys:String>
+    <sys:String x:Key="SystemTray_SelectedProcessFormat">Selezionato: {0}</sys:String>
+    <sys:String x:Key="SystemTray_ApplyPendingToSelected">Applica le impostazioni in sospeso al processo selezionato</sys:String>
+    <sys:String x:Key="SystemTray_ApplyPendingToProcessFormat">Applica impostazioni in sospeso a {0}</sys:String>
+    <sys:String x:Key="SystemTray_PowerPlans">🔋 Piani di alimentazione</sys:String>
+    <sys:String x:Key="SystemTray_Profiles">📋 Profili</sys:String>
+    <sys:String x:Key="SystemTray_Settings">Impostazioni</sys:String>
+    <sys:String x:Key="SystemTray_Exit">Esci</sys:String>
+    <sys:String x:Key="SystemTray_NoProfilesAvailable">Nessun profilo disponibile</sys:String>
+    <sys:String x:Key="SystemTray_PowerPlanFormat">Piano di alimentazione: {0}</sys:String>
+    <sys:String x:Key="SystemTray_StatusWmiError">Automazione WMI Errore</sys:String>
+    <sys:String x:Key="SystemTray_StatusActive">Automazione attiva</sys:String>
+    <sys:String x:Key="SystemTray_StatusDisabled">Automazione disabilitata</sys:String>
+    <sys:String x:Key="SystemTray_Unknown">Sconosciuto</sys:String>
+    <sys:String x:Key="SystemTray_CpuRamStatusFormat">💻 CPU: {0:F1}% | RAM: {1:F1}% | {2}</sys:String>
+
+    <!-- ProcessOperationUserMessages -->
+    <sys:String x:Key="ProcessOperationUserMessages_AccessDenied">Windows ha negato questa modifica. Il processo potrebbe richiedere diritti di amministratore o potrebbe essere protetto.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_AntiCheatProtectedLikely">Il processo appare protetto da anti-cheat o protezione del processo. ThreadPilot non tenterà di aggirarlo.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_AdminClarification">La modalità amministratore può aiutare con i normali problemi di autorizzazione, ma non può aggirare le restrizioni anti-cheat o sui processi protetti.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_LegacyFallbackBlocked">Questa selezione CPU non può essere rappresentata in modo sicuro dalle API di affinità legacy su questa topologia. CPU Per questa selezione sono necessari i set.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_InvalidTopology">Questa selezione CPU non corrisponde alla topologia CPU corrente. Rivedi o ricrea la preimpostazione.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_ProcessExited">Il processo è terminato prima che ThreadPilot potesse applicare la modifica.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_CpuSetsUnavailable">Windows CPU I set non sono disponibili o hanno rifiutato questa selezione. ThreadPilot utilizzerà un fallback sicuro solo quando possibile.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_HighPriorityWarning">Una priorità elevata può migliorare la reattività per alcuni carichi di lavoro ma può ridurre la reattività del sistema.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_RealtimePriorityBlocked">La priorità in tempo reale è bloccata da ThreadPilot perché può rendere Windows instabile o non rispondere.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentLaunchTimePriorityNotice">La priorità persistente al momento del lancio può essere supportata per i processi normali, ma non ignora i processi protetti o le restrizioni anti-cheat.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentRulesDescription">Applica le regole salvate all'avvio di un processo di corrispondenza. Alcuni processi protetti o anti-cheat potrebbero rifiutare le modifiche. La modalità amministratore può aiutare con i normali problemi di autorizzazione ma non può aggirare la protezione.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentRulesProtectedProcessWarning">Il processo appare protetto da anti-cheat o protezione del processo. ThreadPilot non tenterà di sovrascriverlo.</sys:String>
+
+    <!-- Notifications -->
+    <sys:String x:Key="Notification_PowerPlanChangedTitle">Piano di alimentazione modificato</sys:String>
+    <sys:String x:Key="Notification_PowerPlanChangedFormat">Il piano di risparmio energia è stato modificato da '{0}' a '{1}'</sys:String>
+    <sys:String x:Key="Notification_PowerPlanChangedProcessFormat">Il piano di risparmio energia è stato modificato in '{0}' per il processo '{1}'</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringEnabled">Monitoraggio del processo abilitato</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringDisabled">Monitoraggio del processo disabilitato</sys:String>
+    <sys:String x:Key="Notification_CpuAffinityAppliedTitle">CPU Affinità applicata</sys:String>
+    <sys:String x:Key="Notification_CpuAffinityAppliedFormat">CPU affinità impostata per '{0}': {1}</sys:String>
+    <sys:String x:Key="Notification_GameBoostActivatedTitle">Potenziamento del gioco attivato</sys:String>
+    <sys:String x:Key="Notification_GameBoostActivatedFormat">Modalità Game Boost attivata per {0}</sys:String>
+    <sys:String x:Key="Notification_GameBoostDeactivatedTitle">Potenziamento del gioco disattivato</sys:String>
+    <sys:String x:Key="Notification_GameBoostDeactivatedFormat">Modalità Game Boost disattivata dopo {0}</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitorErrorTitle">Errore di monitoraggio del processo</sys:String>
+    <sys:String x:Key="Notification_AffinityBlockedTitle">Affinità bloccata</sys:String>
+    <sys:String x:Key="Notification_AffinityAppliedTitle">Affinità applicata</sys:String>
+    <sys:String x:Key="Notification_AffinityAdjustedTitle">Affinità modificata</sys:String>
+    <sys:String x:Key="Notification_AffinityFailedTitle">Affinità fallita</sys:String>
+    <sys:String x:Key="Notification_AffinityErrorTitle">Errore di affinità</sys:String>
+    <sys:String x:Key="Notification_PriorityBlockedTitle">Priorità bloccata</sys:String>
+    <sys:String x:Key="Notification_PriorityWarningTitle">Avvertimento prioritario</sys:String>
+    <sys:String x:Key="Notification_PriorityAppliedTitle">Priorità applicata</sys:String>
+    <sys:String x:Key="Notification_PriorityAdjustedTitle">Priorità modificata</sys:String>
+    <sys:String x:Key="Notification_PriorityErrorTitle">Errore di priorità</sys:String>
+    <sys:String x:Key="Notification_KeyboardShortcutTitle">Scorciatoia da tastiera</sys:String>
+    <sys:String x:Key="Notification_ToggleMonitoringShortcut">Attiva/disattiva la scorciatoia di monitoraggio attivata</sys:String>
+    <sys:String x:Key="Notification_HighPerformanceShortcut">Collegamento al piano di alimentazione ad alte prestazioni attivato</sys:String>
+    <sys:String x:Key="Notification_RefreshProcessListShortcut">Scorciatoia Aggiorna elenco processi attivata</sys:String>
+    <sys:String x:Key="Notification_ThreadPilotStartedTitle">ThreadPilot Avviato</sys:String>
+    <sys:String x:Key="Notification_ThreadPilotStartedMessage">Il monitoraggio del processo e la gestione del piano di alimentazione sono ora attivi</sys:String>
+    <sys:String x:Key="Notification_StartupErrorTitle">Errore di avvio</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringStartFailed">Impossibile avviare il gestore del monitoraggio del processo</sys:String>
+    <sys:String x:Key="Notification_AutomationMonitoringErrorTitle">Errore di monitoraggio dell'automazione</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedTitle">Impostazioni salvate</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedMessage">Le impostazioni dell'applicazione sono state salvate correttamente</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedWarningsTitle">Impostazioni salvate con avvisi</sys:String>
+    <sys:String x:Key="Notification_SettingsErrorTitle">Errore nelle impostazioni</sys:String>
+    <sys:String x:Key="Notification_SettingsSaveFailed">Impossibile salvare le impostazioni</sys:String>
+    <sys:String x:Key="Notification_TestNotificationMessage">Questa è una notifica di prova per verificare che le tue impostazioni funzionino correttamente.</sys:String>
+
+    <!-- Elevation Service -->
+    <sys:String x:Key="Elevation_RequestPromptText">ThreadPilot richiede privilegi di amministratore per gestire l'affinità dei processi e i piani di alimentazione.&#x0a;&#x0a;Desideri riavviare l'applicazione con privilegi di amministratore?</sys:String>
+    <sys:String x:Key="Elevation_RequestPromptTitle">Privilegi di amministratore richiesti</sys:String>
+    <sys:String x:Key="Elevation_FailedText">Impossibile riavviare con i privilegi di amministratore. Esegui manualmente ThreadPilot come amministratore.</sys:String>
+    <sys:String x:Key="Elevation_FailedTitle">Elevazione non riuscita</sys:String>
+    <sys:String x:Key="Elevation_StatusRunning">In esecuzione con privilegi di amministratore</sys:String>
+    <sys:String x:Key="Elevation_StatusLimited">In esecuzione con privilegi limitati</sys:String>
+
+    <!-- System Tweaks Errors -->
+    <sys:String x:Key="SystemTweak_Error_QueryCoreParking">Impossibile eseguire la query del valore Core Parking tramite powercfg</sys:String>
+    <sys:String x:Key="SystemTweak_Error_QueryCStates">Impossibile eseguire la query del valore C-States tramite powercfg</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PrefetchKeyNotFound">Chiave di registro Prefetch non trovata</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PowerThrottlingNotAvailable">Power Throttling non disponibile su questo sistema</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PriorityControlKeyNotFound">Chiave di registro PriorityControl non trovata</sys:String>
+    <sys:String x:Key="SystemTweak_Error_DesktopKeyNotFound">Chiave di registro del desktop non trovata</sys:String>
+</ResourceDictionary>

--- a/Locales/ru-RU.xaml
+++ b/Locales/ru-RU.xaml
@@ -1,0 +1,665 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- MainWindow / General -->
+    <sys:String x:Key="MainWindow_Title">ThreadPilot — Менеджер процесса и плана электропитания</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningTitle">Рекомендуемые права администратора</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningDescription">ThreadPilot работает с ограниченными привилегиями. Некоторые функции могут быть недоступны.</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningRequired">Доступ администратора необходим для:</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningPowerPlans">• Изменение конфигурации плана электропитания.</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningAffinity">• Изменение привязки процесса к CPU и его приоритета</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningTweaks">• Применение оптимизаций и настроек на уровне системы.</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningProtected">• Управление защищенными процессами</sys:String>
+    <sys:String x:Key="MainWindow_ContinueWithoutElevation">Продолжить без повышения</sys:String>
+    <sys:String x:Key="MainWindow_RequestElevation">Запросить повышение</sys:String>
+
+    <!-- MainWindow Navigation -->
+    <sys:String x:Key="MainWindow_NavProcess">Управление процессами</sys:String>
+    <sys:String x:Key="MainWindow_NavMasks">Маски CPU</sys:String>
+    <sys:String x:Key="MainWindow_NavPower">Планы электропитания</sys:String>
+    <sys:String x:Key="MainWindow_NavRules">Правила</sys:String>
+    <sys:String x:Key="MainWindow_NavDiagnostics">Диагностика</sys:String>
+    <sys:String x:Key="MainWindow_NavActivity">Активность ThreadPilot</sys:String>
+    <sys:String x:Key="MainWindow_NavTweaks">Тонкая настройка</sys:String>
+    <sys:String x:Key="MainWindow_NavSettings">Настройки</sys:String>
+
+    <!-- MainWindow Overlays -->
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestionTitle">Запуск свернут</sys:String>
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestionDescription">Включите свертывание запуска, если вы хотите, чтобы ThreadPilot автоматически запускался в области уведомлений при последующих входах в систему Windows.</sys:String>
+    <sys:String x:Key="MainWindow_Recommended">Рекомендуется</sys:String>
+    <sys:String x:Key="MainWindow_DontShowAgain">Больше не показывать</sys:String>
+    <sys:String x:Key="MainWindow_OpenSettings">Открыть настройки</sys:String>
+    <sys:String x:Key="MainWindow_PrimaryNavigation">Основная навигация</sys:String>
+    <sys:String x:Key="MainWindow_ElevationWarningOverlay">Предупреждение о повышении прав</sys:String>
+    <sys:String x:Key="MainWindow_PerformanceIntroductionOverlay">Оверлей представления производительности</sys:String>
+    <sys:String x:Key="MainWindow_StartupMinimizedSuggestion">Предложение при запуске свернуто</sys:String>
+    <sys:String x:Key="MainWindow_UnsavedSettingsDialog">Диалог несохраненных настроек</sys:String>
+    <sys:String x:Key="MainWindow_LoadingOverlay">Оверлей загрузки приложения при запуске</sys:String>
+
+    <!-- LogViewerView -->
+    <sys:String x:Key="LogViewerView_Title">ThreadPilot Активность</sys:String>
+    <sys:String x:Key="LogViewerView_Subtitle">Показывает действия, выполняемые ThreadPilot, включая примененные правила, изменения привязки, изменения приоритета, изменения плана электропитания, изменения настроек, настройки, оптимизации и сообщения о безопасных сбоях.</sys:String>
+    <sys:String x:Key="LogViewerView_Search">Поиск:</sys:String>
+    <sys:String x:Key="LogViewerView_CategoryLabel">Категория:</sys:String>
+    <sys:String x:Key="LogViewerView_LevelLabel">Уровень:</sys:String>
+    <sys:String x:Key="LogViewerView_From">От:</sys:String>
+    <sys:String x:Key="LogViewerView_To">Кому:</sys:String>
+    <sys:String x:Key="LogViewerView_Refresh">Обновить</sys:String>
+    <sys:String x:Key="LogViewerView_ClearDisplay">Очистить список</sys:String>
+    <sys:String x:Key="LogViewerView_ExportActivity">Экспортировать журнал</sys:String>
+    <sys:String x:Key="LogViewerView_CleanupDiagnostics">Очистка диагностических файлов</sys:String>
+    <sys:String x:Key="LogViewerView_OpenFolder">Открыть папку диагностики</sys:String>
+
+    <!-- LogViewerView Grid Headers -->
+    <sys:String x:Key="LogViewerView_HeaderTime">Время</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderStatus">Статус</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderCategory">Категория</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderMessage">Сообщение</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderDetails">Подробности</sys:String>
+    <sys:String x:Key="LogViewerView_HeaderId">идентификатор</sys:String>
+    <sys:String x:Key="LogViewerView_ContextMenuCopy">Копировать запись</sys:String>
+    <sys:String x:Key="LogViewerView_ContextMenuRefresh">Обновить</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntries">Нет записей журнала для отображения</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntriesTip">Настройте фильтры или обновите журналы, чтобы загрузить недавнюю активность ThreadPilot.</sys:String>
+
+    <!-- LogViewerView Details -->
+    <sys:String x:Key="LogViewerView_DetailsTitle">Детали деятельности</sys:String>
+    <sys:String x:Key="LogViewerView_Timestamp">Временная метка:</sys:String>
+    <sys:String x:Key="LogViewerView_Status">Статус:</sys:String>
+    <sys:String x:Key="LogViewerView_Category">Категория:</sys:String>
+    <sys:String x:Key="LogViewerView_Message">Сообщение:</sys:String>
+    <sys:String x:Key="LogViewerView_Details">Подробности:</sys:String>
+    <sys:String x:Key="LogViewerView_CorrelationId">Идентификатор корреляции:</sys:String>
+    <sys:String x:Key="LogViewerView_NoEntrySelected">Запись журнала не выбрана</sys:String>
+    <sys:String x:Key="LogViewerView_Files">Файлы:</sys:String>
+    <sys:String x:Key="LogViewerView_Size">Размер:</sys:String>
+    <sys:String x:Key="LogViewerView_DebugDiagnostics">Отладочная диагностика</sys:String>
+    <sys:String x:Key="LogViewerView_MaxSize">Максимальный размер (MB):</sys:String>
+    <sys:String x:Key="LogViewerView_Retention">Срок хранения (дней):</sys:String>
+    <sys:String x:Key="LogViewerView_SaveSettings">Сохранить настройки</sys:String>
+
+    <!-- MasksView -->
+    <sys:String x:Key="MasksView_Title">Маски CPU</sys:String>
+    <sys:String x:Key="MasksView_Subtitle">Создавайте повторно используемые наборы привязки к CPU для отдельных процессов.</sys:String>
+    <sys:String x:Key="MasksView_EditingClarification">Выбор маски здесь редактирует только предустановку. Привязка CPU не изменяется до тех пор, пока вы не примените ее к процессу или не сохраните в правиле процесса.</sys:String>
+    <sys:String x:Key="MasksView_New">Новый</sys:String>
+    <sys:String x:Key="MasksView_Delete">Удалить</sys:String>
+    <sys:String x:Key="MasksView_Duplicate">Дублировать маску</sys:String>
+    <sys:String x:Key="MasksView_Info">Информация о маске</sys:String>
+    <sys:String x:Key="MasksView_Name">Имя:</sys:String>
+    <sys:String x:Key="MasksView_Description">Описание:</sys:String>
+    <sys:String x:Key="MasksView_Enabled">Включено</sys:String>
+    <sys:String x:Key="MasksView_DefaultPreset">Предустановка по умолчанию</sys:String>
+    <sys:String x:Key="MasksView_DefaultPresetTip">Выбирается заранее, когда ThreadPilot требуется резервная маска или при создании правил для каждого процесса. Привязка CPU не применяется автоматически.</sys:String>
+    <sys:String x:Key="MasksView_DisableTip">Отключите, чтобы временно скрыть эту маску.</sys:String>
+    <sys:String x:Key="MasksView_SelectCpus">Выбрать CPU</sys:String>
+    <sys:String x:Key="MasksView_SelectCpusTip">Переключите CPUs, чтобы отредактировать эту предустановку маски. Изменения сохраняются автоматически и не влияют на запущенные процессы. «Все ядра» — это защищенная предустановка по умолчанию.</sys:String>
+    <sys:String x:Key="MasksView_SavedAutomatically">Имена масок, описания, выбор CPU и параметры сохраняются автоматически.</sys:String>
+    <sys:String x:Key="MasksView_CreateNewTooltip">Создайте новую маску CPU.</sys:String>
+    <sys:String x:Key="MasksView_DeleteTooltip">Удалить выбранную маску</sys:String>
+    <sys:String x:Key="MasksView_CpusHeader">CPUs</sys:String>
+    <sys:String x:Key="MasksView_Cpu">CPU</sys:String>
+    <sys:String x:Key="MasksView_Options">Параметры маски</sys:String>
+
+    <!-- PerformanceView -->
+    <sys:String x:Key="PerformanceView_OptionalDiagnostics">Дополнительная диагностика</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc">Диагностика не является обязательной и предназначена для устранения неполадок. Для внутриигровых наложений и подробных графиков производительности используйте специальные инструменты.</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc1">Диагностика не является обязательной и предназначена для устранения неполадок.</sys:String>
+    <sys:String x:Key="PerformanceView_DiagnosticsDesc2">Для внутриигровых наложений и подробных графиков производительности используйте специальные инструменты.</sys:String>
+    <sys:String x:Key="PerformanceView_QuickTips">Быстрые советы:</sys:String>
+    <sys:String x:Key="PerformanceView_Tip1">1. Открывайте диагностику только в том случае, если вам нужен снимок целенаправленного устранения неполадок.</sys:String>
+    <sys:String x:Key="PerformanceView_Tip2">2. Просмотрите горячие точки только в качестве подсказки перед созданием правил автоматизации.</sys:String>
+    <sys:String x:Key="PerformanceView_Tip3">3. Остановите оперативные показатели после завершения устранения неполадок.</sys:String>
+    <sys:String x:Key="PerformanceView_Continue">Перейти к диагностике</sys:String>
+
+    <sys:String x:Key="PerformanceView_ActiveProcesses">Активные процессы</sys:String>
+    <sys:String x:Key="PerformanceView_TopConsumersDesc">Лучшие потребители CPU и памяти с созданием правил в один клик.</sys:String>
+    <sys:String x:Key="PerformanceView_SearchPlaceholder">Поиск процессов по названию</sys:String>
+    <sys:String x:Key="PerformanceView_RuleBackedOnly">Только на основе правил</sys:String>
+    <sys:String x:Key="PerformanceView_ActionableOnly">Действует только</sys:String>
+    <sys:String x:Key="PerformanceView_RuleImpact">Влияние правила</sys:String>
+    <sys:String x:Key="PerformanceView_CreateRuleButton">Создать/обновить правило из выбора</sys:String>
+    <sys:String x:Key="PerformanceView_CreateRuleTooltip">Создайте или обновите правило автоматизации из выбранного процесса горячей точки.</sys:String>
+
+    <sys:String x:Key="PerformanceView_Timeline">График стабильности</sys:String>
+    <sys:String x:Key="PerformanceView_ClearHistory">Очистить историю</sys:String>
+    <sys:String x:Key="PerformanceView_ClearHistoryTooltip">Очистите отображаемые показатели и историю временной шкалы.</sys:String>
+    <sys:String x:Key="PerformanceView_CoreSnapshot">Сводка по ядрам</sys:String>
+    <sys:String x:Key="PerformanceView_CoreSnapshotDesc">Загрузка каждого ядра для быстрого выявления дисбаланса.</sys:String>
+    <sys:String x:Key="PerformanceView_ToggleCore">Переключить основную панель</sys:String>
+    <sys:String x:Key="PerformanceView_ToggleProcess">Переключить панель процессов</sys:String>
+    <sys:String x:Key="PerformanceView_StartLive">Запустить живые метрики</sys:String>
+    <sys:String x:Key="PerformanceView_StartLiveTooltip">Начать сбор показателей в реальном времени для этой информационной панели.</sys:String>
+    <sys:String x:Key="PerformanceView_StopLive">Остановить живые показатели</sys:String>
+    <sys:String x:Key="PerformanceView_StopLiveTooltip">Приостановить сбор показателей в реальном времени; фоновая автоматизация отдельная</sys:String>
+    <sys:String x:Key="PerformanceView_Refresh">Обновить</sys:String>
+    <sys:String x:Key="PerformanceView_RefreshTooltip">Обновить текущий снимок панели мониторинга</sys:String>
+
+    <sys:String x:Key="PerformanceView_GlobalPowerPlan">Глобальный план электроэнергетики</sys:String>
+    <sys:String x:Key="PerformanceView_ProcessHotspots">Горячие точки процесса</sys:String>
+    <sys:String x:Key="PerformanceView_Filter">Фильтр</sys:String>
+    <sys:String x:Key="PerformanceView_Memory">Память</sys:String>
+    <sys:String x:Key="PerformanceView_Name">Имя</sys:String>
+    <sys:String x:Key="PerformanceView_Priority">Приоритет</sys:String>
+    <sys:String x:Key="PerformanceView_Window">Окно</sys:String>
+    <sys:String x:Key="PerformanceView_MemoryUsed">Используемая память</sys:String>
+    <sys:String x:Key="PerformanceView_CpuPercent">CPU %</sys:String>
+    <sys:String x:Key="PerformanceView_MemPercent">Мем %</sys:String>
+    <sys:String x:Key="PerformanceView_Threads">Потоки</sys:String>
+    <sys:String x:Key="PerformanceView_Events">События</sys:String>
+    <sys:String x:Key="PerformanceView_Severity">Серьезность</sys:String>
+    <sys:String x:Key="PerformanceView_Detail">Деталь</sys:String>
+    <sys:String x:Key="PerformanceView_Time">Время</sys:String>
+    <sys:String x:Key="PerformanceView_Category">Категория</sys:String>
+    <sys:String x:Key="PerformanceView_Process">Процесс</sys:String>
+    <sys:String x:Key="PerformanceView_SelectedHotspot">Выбранный процесс горячей точки</sys:String>
+    <sys:String x:Key="PerformanceView_Metrics">Метрики</sys:String>
+    <sys:String x:Key="PerformanceView_Processes">Процессы</sys:String>
+
+    <!-- PowerPlanView -->
+    <sys:String x:Key="PowerPlanView_Title">Планы электропитания</sys:String>
+    <sys:String x:Key="PowerPlanView_Subtitle">Управляйте активным планом электропитания Windows и импортируйте пользовательские профили .pow.</sys:String>
+    <sys:String x:Key="PowerPlanView_WindowsPowerPlans">Windows Планы электропитания</sys:String>
+    <sys:String x:Key="PowerPlanView_SelectActiveTip">Выберите план Windows, чтобы активировать его.</sys:String>
+    <sys:String x:Key="PowerPlanView_SetActive">Установить как активный план Windows</sys:String>
+    <sys:String x:Key="PowerPlanView_SetActiveTooltip">Измените активный план электропитания Windows на выбранный план.</sys:String>
+    <sys:String x:Key="PowerPlanView_Refresh">Обновить планы</sys:String>
+    <sys:String x:Key="PowerPlanView_RefreshTooltip">Обновить список доступных планов электропитания.</sys:String>
+    <sys:String x:Key="PowerPlanView_CustomPowerPlans">Пользовательские планы электропитания</sys:String>
+    <sys:String x:Key="PowerPlanView_LocalPlansTip">Локальные файлы .pow, готовые к импорту в Windows.</sys:String>
+    <sys:String x:Key="PowerPlanView_ImportSelected">Импортировать выбранный .pow</sys:String>
+    <sys:String x:Key="PowerPlanView_ImportSelectedTooltip">Импортируйте выбранный пользовательский файл .pow в Windows.</sys:String>
+    <sys:String x:Key="PowerPlanView_AddFile">Добавить файл .pow</sys:String>
+    <sys:String x:Key="PowerPlanView_AddFileTooltip">Добавьте новый файл пользовательского плана электропитания в пользовательскую библиотеку.</sys:String>
+    <sys:String x:Key="PowerPlanView_Delete">Удалить</sys:String>
+    <sys:String x:Key="PowerPlanView_Active">Активный</sys:String>
+
+    <!-- ProcessPowerPlanAssociationView -->
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Title">Правила и автоматизация</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Subtitle">Мониторинг автоматизации отслеживает события запуска и остановки процесса и применяет настроенный план электропитания, маску CPU и правила приоритета.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleEditor">Редактор правил</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EditorSubtitle">Создайте правило из исполняемого или запущенного процесса для автоматизации плана электропитания, маски CPU и приоритетного поведения.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ExecutableMatch">Исполняемое совпадение:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_MatchByPath">Сопоставление по пути</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_MatchByPathTooltip">Сопоставление процессов по полному пути, а не только по имени исполняемого файла.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Browse">Найдите исполняемый файл</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_BrowseTooltip">Нажмите, чтобы выбрать исполняемый файл (.exe) на вашем компьютере.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ExecutableHelp">Выберите исполняемый файл. Сопоставление по пути является более точным; сопоставление по имени применяется к любому процессу с этим именем исполняемого файла.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseRunningProcess">Использовать запущенный процесс:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseRunningProcessTooltip">Выберите текущий запущенный процесс, чтобы использовать его исполняемый файл.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseSelectedProcess">Использовать выбранный процесс</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UseSelectedProcessTooltip">Использовать исполняемый файл выбранного запущенного процесса.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePowerPlan">План электропитания правил (глобальный коммутатор):</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePowerPlanHelp">Если это правило соответствует, Windows переключает глобальный план активной мощности.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleCpuMask">Правило CPU Маска:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RuleCpuMaskHelp">Необязательно: выберите маску CPU, которая будет применяться при запуске этого процесса.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePriority">Приоритет правила</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Update">Обновить</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulePriorityHelp">Необязательно: выберите приоритет процесса, который будет применяться при запуске этого процесса.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AssociationPriority">Приоритет Ассоциации:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AssociationPriorityHelp">Ассоциации с более высоким приоритетом имеют приоритет при множественном совпадении.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AddRule">Добавить правило</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UpdateRule">Обновить выбранное правило</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_UpdateRuleTooltip">Обновить выбранную ассоциацию</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ClearSelection">Очистить выбор</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ClearSelectionTooltip">Очистить выбранный исполняемый файл</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_CurrentRules">Текущие правила</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulesDescription">Определите правила для каждого процесса. Планы электропитания являются глобальными; маски и приоритеты применяются к процессам сопоставления.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Remove">Удалить</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RemoveTooltip">Удалить выбранную ассоциацию</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DefaultPowerPlan">План электропитания по умолчанию (резервный вариант, если ни одно правило не соответствует)</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DefaultPowerPlanHelp">План электропитания, который будет использоваться, когда никакие связанные процессы не запущены:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SetDefault">Установить план электропитания по умолчанию</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SettingsTitle">Настройки мониторинга автоматизации</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EnableWmi">Включить автоматизацию на основе событий (WMI)</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_EnableFallback">Включить резервный опрос автоматизации</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PollingInterval">Интервал опроса (секунды):</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ChangeDelay">Задержка изменения плана электропитания (мс):</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PreventDuplicates">Предотвращение дублирования изменений плана электропитания</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SaveConfig">Сохранить конфигурацию</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_NoRules">Правил автоматизации пока нет</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Status">Статус:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationMonitoring">Автоматизация мониторинга</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_StartAutomation">Начать мониторинг автоматизации</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_StopAutomation">Остановить мониторинг автоматизации</sys:String>
+
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AppliedToMatching">Применяется к каждому процессу сопоставления при выполнении правила автоматизации.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AppliedOnlyToMatching">Применяется только к соответствующим процессам; это не меняет глобальный план электропитания Windows.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SelectedExecutable">Выбранный исполняемый файл:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_DescriptionLabel">Описание:</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationService">Служба автоматизации</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_RulesHeader">Правила</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Исполняемый файл</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">План электропитания</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_CpuMask">CPU Маска</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Priority">Приоритет</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_Description">Описание</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_ProcessPriority">Приоритет процесса:</sys:String>
+
+    <!-- ProcessView -->
+    <sys:String x:Key="ProcessView_Title">Управление процессами</sys:String>
+    <sys:String x:Key="ProcessView_Subtitle">Поиск, фильтрация и контроль активных конфигураций процессов</sys:String>
+    <sys:String x:Key="ProcessView_SearchPlaceholder">Поиск процессов по названию</sys:String>
+    <sys:String x:Key="ProcessView_SearchAutomationName">Процесс поиска</sys:String>
+    <sys:String x:Key="ProcessView_HideSystem">Скрыть системные процессы Windows</sys:String>
+    <sys:String x:Key="ProcessView_HideSystemShort">Скрыть системные процессы</sys:String>
+    <sys:String x:Key="ProcessView_HideLowCpu">Скрыть процессы с очень низким использованием CPU</sys:String>
+    <sys:String x:Key="ProcessView_HideIdle">Скрыть простаивающие процессы</sys:String>
+    <sys:String x:Key="ProcessView_VisibleWindowsOnly">Показывать только приложения с видимым windows</sys:String>
+    <sys:String x:Key="ProcessView_ActiveAppsOnly">Только активные приложения</sys:String>
+    <sys:String x:Key="ProcessView_LockList">Блокировать список процессов</sys:String>
+    <sys:String x:Key="ProcessView_LockListTooltip">Приостановите обновление списка процессов и сортировку обновлений во время работы с текущим списком. Фоновый мониторинг и автоматическое применение сохраненных правил продолжаются, пока работает ThreadPilot.</sys:String>
+    <sys:String x:Key="ProcessView_SortBy">Сортировать по:</sys:String>
+    <sys:String x:Key="ProcessView_SortByTooltip">Выберите способ сортировки списка процессов</sys:String>
+
+    <sys:String x:Key="ProcessView_SelectedProcess">Выбранный процесс</sys:String>
+    <sys:String x:Key="ProcessView_NoProcessSelected">Процесс не выбран</sys:String>
+    <sys:String x:Key="ProcessView_SelectProcessTip">Выберите процесс в таблице, чтобы настроить привязку к CPU, приоритет, план электропитания и правила.</sys:String>
+    <sys:String x:Key="ProcessView_PowerPlanPending">План электропитания/ожидающие настройки</sys:String>
+    <sys:String x:Key="ProcessView_PowerPlanTooltip">Выберите план электропитания для активации вручную или включите его с помощью быстрого применения.</sys:String>
+    <sys:String x:Key="ProcessView_SetPowerPlan">Установить план электропитания</sys:String>
+    <sys:String x:Key="ProcessView_SetPowerPlanTooltip">Активируйте выбранный план электропитания Windows.</sys:String>
+
+    <sys:String x:Key="ProcessView_PendingCoreMask">Ожидаемая основная маска</sys:String>
+    <sys:String x:Key="ProcessView_StageMaskTooltip">Выберите маску для ее создания. Привязка ОС не изменится до тех пор, пока не будет нажата кнопка Применить привязку.</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinity">Применить привязку</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinityTooltip">Примените ожидающую основную маску к выбранному процессу и проверьте состояние привязки Windows.</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinitySaveRule">Применить привязку и сохранить как правило</sys:String>
+    <sys:String x:Key="ProcessView_ApplyAffinitySaveRuleTooltip">Сохраните текущие настройки процесса как правило. Эти настройки будут автоматически применены при запуске этого процесса в будущем.</sys:String>
+
+    <sys:String x:Key="ProcessView_SetCpuPriority">Установить приоритет CPU</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPriorityTooltip">Применить выбранный приоритет к процессу</sys:String>
+    <sys:String x:Key="ProcessView_EnforcePriorityRegistry">Обеспечение приоритета реестра</sys:String>
+    <sys:String x:Key="ProcessView_EnforcePriorityRegistryTooltip">Примените приоритет через реестр Windows. Чтобы изменения вступили в силу, процесс необходимо перезапустить. Этот параметр сохраняется при перезагрузке системы.</sys:String>
+    <sys:String x:Key="ProcessView_SetPriority">Установить приоритет</sys:String>
+    <sys:String x:Key="ProcessView_RealtimeBlockedHelp">Приоритет реального времени блокируется ThreadPilot, поскольку это может сделать Windows нестабильным или перестать отвечать на запросы.</sys:String>
+    <sys:String x:Key="ProcessView_RealtimeBlocked">В реальном времени (заблокировано)</sys:String>
+
+    <sys:String x:Key="ProcessView_DisableIdleServer">Отключить простаивающий сервер</sys:String>
+    <sys:String x:Key="ProcessView_DisableIdleServerTooltip">Предотвращает переход системы в состояние ожидания во время выполнения этого процесса. Полезно для игр и приложений, критичных к производительности.</sys:String>
+
+    <sys:String x:Key="ProcessView_ProfileRule">Профиль/Правило</sys:String>
+    <sys:String x:Key="ProcessView_ProfileNamePlaceholder">Введите имя профиля, чтобы сохранить или загрузить настройки.</sys:String>
+    <sys:String x:Key="ProcessView_SaveProfile">Сохранить профиль</sys:String>
+    <sys:String x:Key="ProcessView_SaveProfileTooltip">Сохранить текущие настройки привязки к CPU и приоритета как повторно используемый профиль.</sys:String>
+    <sys:String x:Key="ProcessView_LoadProfile">Загрузить профиль</sys:String>
+    <sys:String x:Key="ProcessView_LoadProfileTooltip">Загрузите ранее сохраненный профиль</sys:String>
+    <sys:String x:Key="ProcessView_SaveCurrentRule">Сохранить текущие настройки как правило</sys:String>
+
+    <sys:String x:Key="ProcessView_LastAction">Последнее действие ThreadPilot:</sys:String>
+    <sys:String x:Key="ProcessView_Refresh">Обновить</sys:String>
+    <sys:String x:Key="ProcessView_RefreshTooltip">Обновить список процессов</sys:String>
+    <sys:String x:Key="ProcessView_LoadMore">Загрузить больше</sys:String>
+    <sys:String x:Key="ProcessView_LoadMoreTooltip">Загрузить больше процессов</sys:String>
+    <sys:String x:Key="ProcessView_RefreshAutomationName">Обновить процессы</sys:String>
+    <sys:String x:Key="ProcessView_LoadMoreAutomationName">Загрузить больше процессов</sys:String>
+    <sys:String x:Key="ProcessView_RunningListAutomationName">Список запущенных процессов</sys:String>
+    <sys:String x:Key="ProcessView_RunningListAutomationHelp">Виртуализированная таблица процессов с сортировкой и выбором</sys:String>
+
+    <sys:String x:Key="ProcessView_ColProcessName">Имя процесса</sys:String>
+    <sys:String x:Key="ProcessView_ColWindowTitle">Название окна</sys:String>
+    <sys:String x:Key="ProcessView_ColCpuUsage">Загрузка CPU</sys:String>
+    <sys:String x:Key="ProcessView_ColMemory">Использование памяти</sys:String>
+
+    <sys:String x:Key="ProcessView_AffinityStagedTooltip">Привязка подготовлена в интерфейсе и будет применена только после нажатия кнопки «Применить привязку».</sys:String>
+    <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Текущая привязка выбранного процесса по данным Windows</sys:String>
+    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Предварительный просмотр текущего или ожидающего выбора CPU только для чтения</sys:String>
+    <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Откройте вкладку «Маски» CPU, чтобы создать новую пользовательскую маску.</sys:String>
+    <sys:String x:Key="ProcessView_HyperThreadingTooltip">Показывает, присутствует ли и активен ли Hyper-Threading (Intel) или SMT (AMD) в этой системе.</sys:String>
+
+    <sys:String x:Key="ProcessView_CopyProcessInfo">Копировать информацию о процессе</sys:String>
+    <sys:String x:Key="ProcessView_OpenLocation">Открыть расположение исполняемого файла</sys:String>
+    <sys:String x:Key="ProcessView_ClearCpuSets">Очистить наборы CPU</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPendingSettings">Применить ожидающие настройки</sys:String>
+    <sys:String x:Key="ProcessView_ApplyPendingSettingsTooltip">Примените ожидающее соответствие и выбранный план электропитания к выбранному процессу.</sys:String>
+    <sys:String x:Key="ProcessView_RulesAppliedOnlyWhenConfigured">Правила и изменения применяются ThreadPilot только после настройки.</sys:String>
+    <sys:String x:Key="ProcessView_CurrentProcessStatus">Текущий статус процесса</sys:String>
+    <sys:String x:Key="ProcessView_AdvancedAffinityPicker">Расширенный выбор привязки</sys:String>
+    <sys:String x:Key="ProcessView_RowMaskTooltip">Выберите ожидающую маску для действий привязки контекстного меню строки.</sys:String>
+    <sys:String x:Key="ProcessView_SelectedPowerPlan">Выбранный план электропитания</sys:String>
+    <sys:String x:Key="ProcessView_SaveAsRule">Сохранить как правило</sys:String>
+    <sys:String x:Key="ProcessView_NoVisibleWindowTitle">Нет видимого заголовка окна</sys:String>
+    <sys:String x:Key="ProcessView_BatchLabel">Пакетный</sys:String>
+    <sys:String x:Key="ProcessView_TotalSuffix">всего)</sys:String>
+    <sys:String x:Key="ProcessView_PriorityInlineLabel">Приоритет</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuUnavailable">CPU: недоступен</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryUnavailable">Память: недоступна</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuPriorityUnavailable">CPU приоритет: недоступен</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryPriorityUnavailable">Приоритет памяти недоступен</sys:String>
+    <sys:String x:Key="ProcessSummary_AffinityUnavailable">Родственность: недоступна</sys:String>
+    <sys:String x:Key="ProcessSummary_NoSavedRule">Нет сохраненного правила</sys:String>
+    <sys:String x:Key="ProcessSummary_NoRecentAction">Нет недавних действий ThreadPilot</sys:String>
+    <sys:String x:Key="ProcessSummary_SelectedProcessFormat">Выбранный процесс: {0} (PID {1})</sys:String>
+    <sys:String x:Key="ProcessSummary_StatusProtected">Текущий статус процесса: защищен или доступ запрещен.</sys:String>
+    <sys:String x:Key="ProcessSummary_StatusSelected">Текущий статус процесса: выбрано</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuFormat">CPU: {0:N1}%</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryFormat">Память: {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_CpuPriorityFormat">CPU приоритет: {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_AffinityLegacyFormat">Привязка: устаревшая маска 0x{0:X}</sys:String>
+    <sys:String x:Key="ProcessSummary_MemoryPriorityFormat">Приоритет памяти: {0}</sys:String>
+    <sys:String x:Key="ProcessSummary_SavedRuleFallback">сохраненное правило</sys:String>
+    <sys:String x:Key="ProcessSummary_SavedRuleExistsFormat">Существует сохраненное правило: {0}.</sys:String>
+
+    <sys:String x:Key="ProcessView_PriorityAboveNormal">Выше нормы</sys:String>
+    <sys:String x:Key="ProcessView_PriorityBelowNormal">Ниже нормы</sys:String>
+    <sys:String x:Key="ProcessView_PriorityHigh">Высокий</sys:String>
+    <sys:String x:Key="ProcessView_PriorityIdle">Простой</sys:String>
+    <sys:String x:Key="ProcessView_PriorityLow">Низкий</sys:String>
+    <sys:String x:Key="ProcessView_PriorityNormal">Нормальный</sys:String>
+    <sys:String x:Key="ProcessView_PriorityRealtime">В реальном времени</sys:String>
+    <sys:String x:Key="ProcessView_PriorityBatch">Пакетный</sys:String>
+    <sys:String x:Key="ProcessView_PriorityCustom">Пользовательский</sys:String>
+
+    <sys:String x:Key="ProcessView_HasWindow">Имеет окно</sys:String>
+    <sys:String x:Key="ProcessView_Window">Окно</sys:String>
+    <sys:String x:Key="ProcessView_PID">PID</sys:String>
+    <sys:String x:Key="ProcessView_ID">идентификатор</sys:String>
+    <sys:String x:Key="ProcessView_MemoryMb">Память (MB)</sys:String>
+    <sys:String x:Key="ProcessView_Affinity">Привязка</sys:String>
+    <sys:String x:Key="ProcessView_Priority">Приоритет</sys:String>
+    <sys:String x:Key="ProcessView_Rules">Правила</sys:String>
+    <sys:String x:Key="ProcessView_Name">Имя</sys:String>
+    <sys:String x:Key="ProcessView_SetMemoryPriority">Установить приоритет памяти</sys:String>
+    <sys:String x:Key="ProcessView_PriorityVeryLow">Очень низкий</sys:String>
+    <sys:String x:Key="ProcessView_PriorityMedium">Средний</sys:String>
+    <sys:String x:Key="ProcessView_RefreshInfo">Обновить информацию о процессе</sys:String>
+
+    <!-- SettingsView -->
+    <sys:String x:Key="SettingsView_Title">Настройки приложения</sys:String>
+    <sys:String x:Key="SettingsView_Subtitle">Настройка уведомлений, панели задач и поведения приложений</sys:String>
+    <sys:String x:Key="SettingsView_Notifications">Уведомления</sys:String>
+    <sys:String x:Key="SettingsView_EnableNotifications">Включить уведомления</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevel">Уровень уведомления</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelAll">Все</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelWarningsErrors">Только предупреждения/ошибки</sys:String>
+    <sys:String x:Key="SettingsView_NotificationLevelSilent">Тихий</sys:String>
+    <sys:String x:Key="SettingsView_EnableBalloon">Включить всплывающие уведомления (в системном трее)</sys:String>
+    <sys:String x:Key="SettingsView_EnableToast">Включить всплывающие уведомления (Windows 10+)</sys:String>
+    <sys:String x:Key="SettingsView_NotificationTypes">Типы уведомлений</sys:String>
+    <sys:String x:Key="SettingsView_NotifyPowerPlan">Изменения в схеме электропитания</sys:String>
+    <sys:String x:Key="SettingsView_NotifyProcess">События мониторинга процесса</sys:String>
+    <sys:String x:Key="SettingsView_NotifyError">Уведомления об ошибках</sys:String>
+    <sys:String x:Key="SettingsView_NotifySuccess">Уведомления об успехах</sys:String>
+    <sys:String x:Key="SettingsView_Duration">Длительность (мс):</sys:String>
+    <sys:String x:Key="SettingsView_TestNotification">Тестовое уведомление</sys:String>
+
+    <sys:String x:Key="SettingsView_SystemTray">Системный трей</sys:String>
+    <sys:String x:Key="SettingsView_ShowTrayIcon">Показать значок в трее</sys:String>
+    <sys:String x:Key="SettingsView_MinimizeToTray">Свернуть в трей</sys:String>
+    <sys:String x:Key="SettingsView_CloseToTray">Рядом с лотком (вместо выхода)</sys:String>
+    <sys:String x:Key="SettingsView_StartMinimized">Начать сворачивать</sys:String>
+    <sys:String x:Key="SettingsView_QuickApply">Включить ожидающие настройки, применимые из трея</sys:String>
+    <sys:String x:Key="SettingsView_MonitoringControl">Включить элементы управления мониторингом автоматизации из трея</sys:String>
+    <sys:String x:Key="SettingsView_DetailedTooltips">Показать подробные подсказки</sys:String>
+
+    <sys:String x:Key="SettingsView_BasicPreferences">Основные настройки</sys:String>
+    <sys:String x:Key="SettingsView_Autostart">Автозапуск</sys:String>
+    <sys:String x:Key="SettingsView_StartWithWindows">Начните с Windows</sys:String>
+    <sys:String x:Key="SettingsView_AutostartDescription">Автоматически запускать ThreadPilot при запуске Windows.</sys:String>
+    <sys:String x:Key="SettingsView_LowImpactMode">Режим низкого воздействия в фоновом режиме</sys:String>
+    <sys:String x:Key="SettingsView_LowImpactDescription">Понизьте приоритет процесса ThreadPilot, пока он свёрнут или скрыт в трее.</sys:String>
+
+    <sys:String x:Key="SettingsView_Appearance">Внешний вид</sys:String>
+    <sys:String x:Key="SettingsView_UseDarkTheme">Использовать темную тему</sys:String>
+    <sys:String x:Key="SettingsView_ThemeDescription">Применяет глобальную темную/светлую тему на всех вкладках.</sys:String>
+
+    <sys:String x:Key="SettingsView_Language">Язык</sys:String>
+    <sys:String x:Key="SettingsView_LanguageZhCn">简体中文 (Simplified Chinese)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageEnUs">English (English)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageItIt">Italiano (Italian)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageFrFr">Français (French)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageDeDe">Deutsch (German)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageEsEs">Español (Spanish)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageRuRu">Русский (Russian)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageDescription">Применяет глобальный язык отображения ко всему интерфейсу приложения.</sys:String>
+
+    <sys:String x:Key="SettingsView_RulesAutomation">Правила и автоматизация</sys:String>
+    <sys:String x:Key="SettingsView_RuleAutoApply">Сохраненное правило применяется автоматически</sys:String>
+    <sys:String x:Key="SettingsView_ApplyOnStart">Применять сохраненные правила при запуске соответствующих процессов</sys:String>
+    <sys:String x:Key="SettingsView_ApplyOnStartDescription">Применяет включенные сохраненные правила во время работы ThreadPilot. При этом служба Windows не устанавливается и не используется сохранение реестра/IFEO.</sys:String>
+    <sys:String x:Key="SettingsView_EnableWmi">Включить события процесса WMI</sys:String>
+    <sys:String x:Key="SettingsView_WmiDescription">Используйте Windows Инструментарий управления для событий запуска/остановки процесса.</sys:String>
+    <sys:String x:Key="SettingsView_EnableFallback">Включить резервный опрос</sys:String>
+    <sys:String x:Key="SettingsView_FallbackDescription">Используйте опрос в качестве резервной копии в случае сбоя событий процесса WMI.</sys:String>
+    <sys:String x:Key="SettingsView_PollingInterval">Интервал опроса (мс):</sys:String>
+    <sys:String x:Key="SettingsView_FallbackPollingInterval">Резервный опрос (мс):</sys:String>
+
+    <sys:String x:Key="SettingsView_Advanced">Расширенный</sys:String>
+    <sys:String x:Key="SettingsView_NotificationHistory">Включить историю уведомлений</sys:String>
+    <sys:String x:Key="SettingsView_MaxHistory">Максимальное количество элементов истории:</sys:String>
+    <sys:String x:Key="SettingsView_AutoHide">Автоматическое скрытие уведомлений</sys:String>
+    <sys:String x:Key="SettingsView_NotificationSound">Включить звук уведомлений</sys:String>
+    <sys:String x:Key="SettingsView_DebugLogging">Включить ведение журнала отладки</sys:String>
+    <sys:String x:Key="SettingsView_PerformanceCounters">Включить счетчики производительности</sys:String>
+
+    <sys:String x:Key="SettingsView_About">О</sys:String>
+    <sys:String x:Key="SettingsView_Version">Версия:</sys:String>
+    <sys:String x:Key="SettingsView_Copyright">© 2026 PrimeBuild.</sys:String>
+    <sys:String x:Key="SettingsView_Translator">Переводчик: Ylimhs</sys:String>
+    <sys:String x:Key="SettingsView_License">Лицензия: AGPLv3</sys:String>
+    <sys:String x:Key="SettingsView_CheckUpdates">Проверьте наличие обновлений</sys:String>
+    <sys:String x:Key="SettingsView_DownloadInstallUpdate">Загрузите и установите обновление</sys:String>
+    <sys:String x:Key="SettingsView_EnableAutomaticUpdateChecks">Автоматическая проверка при запуске</sys:String>
+    <sys:String x:Key="SettingsView_UpdateIntervalDays">Интервал проверки (дни):</sys:String>
+    <sys:String x:Key="SettingsView_IncludePrereleaseUpdates">Включить предварительные обновления</sys:String>
+    <sys:String x:Key="SettingsView_LatestVersion">Последняя версия:</sys:String>
+    <sys:String x:Key="SettingsView_LastUpdateCheck">Последняя проверка:</sys:String>
+    <sys:String x:Key="SettingsView_UpdatesDescription">Проверяется по требованию с использованием официальных выпусков GitHub.</sys:String>
+
+    <sys:String x:Key="SettingsView_ResetDefaults">Сброс к настройкам по умолчанию</sys:String>
+    <sys:String x:Key="SettingsView_ExportConfig">Экспортировать конфигурацию</sys:String>
+    <sys:String x:Key="SettingsView_ImportConfig">Импортировать конфигурацию</sys:String>
+    <sys:String x:Key="SettingsView_SaveSettings">Сохранить настройки</sys:String>
+    <sys:String x:Key="SettingsView_ThreadPilot">ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_StatusThemeChangedFormat">Тема изменена на {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusThemeChangeFailedFormat">Не удалось изменить тему на {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusLanguageChangedFormat">Язык изменен на {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusLanguageChangeFailed">Не удалось изменить язык.</sys:String>
+    <sys:String x:Key="Settings_StatusSaving">Сохранение настроек...</sys:String>
+    <sys:String x:Key="Settings_StatusSavedWarningsFormat">Настройки сохранены с предупреждениями: {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusSavedApplied">Настройки сохранены и успешно применены.</sys:String>
+    <sys:String x:Key="Settings_StatusErrorSavingFormat">Ошибка сохранения настроек: {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusResetting">Сброс к настройкам по умолчанию...</sys:String>
+    <sys:String x:Key="Settings_StatusResetPending">Настройки сброшены на значения по умолчанию (еще не сохранены)</sys:String>
+    <sys:String x:Key="Settings_StatusErrorResettingFormat">Ошибка сброса настроек: {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusExporting">Экспорт пакета конфигурации...</sys:String>
+    <sys:String x:Key="Settings_StatusExportCanceled">Экспорт отменен</sys:String>
+    <sys:String x:Key="Settings_StatusExportedFormat">Конфигурация экспортирована в: {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusErrorExportingFormat">Ошибка экспорта настроек: {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusImporting">Импорт конфигурации...</sys:String>
+    <sys:String x:Key="Settings_StatusImportCanceled">Импорт отменен</sys:String>
+    <sys:String x:Key="Settings_StatusImportedApplied">Пакет конфигурации импортирован и применен.</sys:String>
+    <sys:String x:Key="Settings_StatusLegacyImported">Импортированы устаревшие настройки (правила не изменены).</sys:String>
+    <sys:String x:Key="Settings_StatusErrorImportingFormat">Ошибка импорта настроек: {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusTestSent">Уведомление о тестировании отправлено</sys:String>
+    <sys:String x:Key="Settings_StatusErrorTestFormat">Ошибка отправки тестового уведомления: {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusLoading">Загрузка настроек...</sys:String>
+    <sys:String x:Key="Settings_StatusLoaded">Настройки загружены</sys:String>
+    <sys:String x:Key="Settings_StatusErrorLoadingFormat">Ошибка загрузки настроек: {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusSynchronized">Настройки синхронизированы</sys:String>
+    <sys:String x:Key="Settings_StatusCheckingUpdates">Проверяем наличие обновлений...</sys:String>
+    <sys:String x:Key="Settings_StatusLatestUnknown">Не удалось определить последнюю версию.</sys:String>
+    <sys:String x:Key="Settings_StatusNewVersionFormat">Доступна новая версия: {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusUpToDateFormat">Приложение актуальное. Установленная версия: {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateErrorFormat">Ошибка при проверке обновлений: {0}.</sys:String>
+    <sys:String x:Key="Settings_UpdateLatestUnknown">Неизвестно</sys:String>
+    <sys:String x:Key="Settings_UpdateNotChecked">Не проверено</sys:String>
+    <sys:String x:Key="Settings_UpdateLastCheckedNever">Никогда</sys:String>
+    <sys:String x:Key="Settings_UpdateConfirmTitle">Установите обновление ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_UpdateConfirmMessageFormat">ThreadPilot загрузит и проверит версию {0}, затем запросит у Windows разрешение на запуск установщика. Продолжить?</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateCanceled">Обновление отменено.</sys:String>
+    <sys:String x:Key="Settings_StatusDownloadingUpdate">Загрузка и проверка обновления...</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateInstallerStarted">Установщик обновлений запустился.</sys:String>
+    <sys:String x:Key="Settings_StatusUpdateInstallFailedFormat">Не удалось установить обновление: {0}.</sys:String>
+    <sys:String x:Key="Settings_StatusModified">Настройки были изменены</sys:String>
+    <sys:String x:Key="Settings_StatusMatchSaved">Настройки соответствуют сохраненной конфигурации</sys:String>
+    <sys:String x:Key="Settings_LanguageSimplifiedChinese">Китайский (упрощённый)</sys:String>
+    <sys:String x:Key="Settings_LanguageEnglish">Английский</sys:String>
+    <sys:String x:Key="Settings_LanguageItalian">Итальянский</sys:String>
+    <sys:String x:Key="Settings_LanguageFrench">Французский</sys:String>
+    <sys:String x:Key="Settings_LanguageGerman">Немецкий</sys:String>
+    <sys:String x:Key="Settings_LanguageSpanish">Испанский</sys:String>
+    <sys:String x:Key="Settings_LanguageRussian">Русский</sys:String>
+    <sys:String x:Key="Settings_ThemeDark">Тёмная</sys:String>
+    <sys:String x:Key="Settings_ThemeLight">Светлая</sys:String>
+    <sys:String x:Key="Settings_DialogExportTitle">Экспорт конфигурации ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_DialogImportTitle">Импорт конфигурации ThreadPilot</sys:String>
+    <sys:String x:Key="Settings_WarningAutostartFailed">Не удалось обновить автозапуск Windows. Сохранение предыдущего состояния автозапуска.</sys:String>
+
+    <!-- SettingsWindow -->
+    <sys:String x:Key="SettingsWindow_Title">ThreadPilot Настройки</sys:String>
+    <sys:String x:Key="SettingsWindow_UnsavedTitle">Несохраненные настройки</sys:String>
+    <sys:String x:Key="SettingsWindow_UnsavedDescription">Есть несохранённые изменения. Сохраните или отмените их либо вернитесь к редактированию.</sys:String>
+    <sys:String x:Key="SettingsWindow_Cancel">Отмена</sys:String>
+    <sys:String x:Key="SettingsWindow_Discard">Отбросить</sys:String>
+    <sys:String x:Key="SettingsWindow_Save">Сохранить</sys:String>
+
+    <!-- SystemTweaksView -->
+    <sys:String x:Key="SystemTweaksView_Title">Системные настройки и оптимизации</sys:String>
+    <sys:String x:Key="SystemTweaksView_Subtitle">Настройте оптимизацию системы Windows и настройки производительности.</sys:String>
+    <sys:String x:Key="SystemTweaksView_RefreshAll">Обновить все</sys:String>
+    <sys:String x:Key="SystemTweaksView_RefreshAllTooltip">Обновить все состояния настройки</sys:String>
+    <sys:String x:Key="SystemTweaksView_TweakTooltip">Переключить эту настройку Windows</sys:String>
+    <sys:String x:Key="SystemTweaksView_Status">Статус</sys:String>
+
+    <!-- SystemTweaks Names and Descriptions -->
+    <sys:String x:Key="SystemTweak_CoreParking_Name">Core Parking</sys:String>
+    <sys:String x:Key="SystemTweak_CoreParking_Desc">Элементы управления CPU core parking для управления питанием</sys:String>
+    <sys:String x:Key="SystemTweak_CStates_Name">C-States</sys:String>
+    <sys:String x:Key="SystemTweak_CStates_Desc">Элементы управления CPU C-States для управления питанием</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Name">HPET</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Desc">Высокоточный таймер событий для системной синхронизации</sys:String>
+    <sys:String x:Key="SystemTweak_SysMain_Name">SysMain Сервис</sys:String>
+    <sys:String x:Key="SystemTweak_SysMain_Desc">Windows Superfetch/SysMain сервис управления памятью</sys:String>
+    <sys:String x:Key="SystemTweak_Prefetch_Name">Prefetch</sys:String>
+    <sys:String x:Key="SystemTweak_Prefetch_Desc">Windows Prefetch функция для более быстрой загрузки приложений</sys:String>
+    <sys:String x:Key="SystemTweak_PowerThrottling_Name">Power Throttling</sys:String>
+    <sys:String x:Key="SystemTweak_PowerThrottling_Desc">Windows Power Throttling для энергоэффективности</sys:String>
+    <sys:String x:Key="SystemTweak_HighSchedulingCategory_Name">Категория высокого планирования</sys:String>
+    <sys:String x:Key="SystemTweak_HighSchedulingCategory_Desc">Высокий приоритет планирования для игровых приложений</sys:String>
+    <sys:String x:Key="SystemTweak_MenuShowDelay_Name">Задержка показа меню</sys:String>
+    <sys:String x:Key="SystemTweak_MenuShowDelay_Desc">Задержка перед показом контекстных меню</sys:String>
+
+    <!-- SystemTweaksViewModel Messages -->
+    <sys:String x:Key="SystemTweaks_StatusReady">Готово</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshing">Обновление настроек системы...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLastRefreshedFormat">Последнее обновление: {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshFailed">Не удалось обновить настройки системы.</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusRefreshFailedShort">Обновить не удалось</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusTogglingFormat">Переключение {0}...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnabledFormat">{0} успешно включен</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisabledFormat">{0} успешно отключен</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyEnabledFormat">{0} включен</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyDisabledFormat">{0} отключен</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyUpdatedTitle">Системная настройка обновлена</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusToggleFailedFormat">Не удалось переключить {0}.</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnableFailedFormat">Не удалось включить {0}.</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisableFailedFormat">Не удалось отключить {0}.</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyFailedTitle">Настройка системы не удалась</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyFailedFormat">Не удалось выполнить {0} {1}.</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusErrorTogglingFormat">Ошибка переключения {0}</sys:String>
+    <sys:String x:Key="SystemTweaks_NotifyErrorFormat">Ошибка переключения {0}: {1}</sys:String>
+    <sys:String x:Key="SystemTweaks_WordEnable">включить</sys:String>
+    <sys:String x:Key="SystemTweaks_WordDisable">отключить</sys:String>
+    <sys:String x:Key="SystemTweaks_WordEnabled">включен</sys:String>
+    <sys:String x:Key="SystemTweaks_WordDisabled">отключен</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusEnabled">Включено</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDisabled">Отключено</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusNotAvailable">Недоступно</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLoading">Загрузка настроек системы...</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusLoadedSuccess">Системные настройки успешно загружены</sys:String>
+
+    <!-- SystemTray Context Menu & Status -->
+    <sys:String x:Key="SystemTray_OpenDashboard">Открыть панель управления</sys:String>
+    <sys:String x:Key="SystemTray_OpenDiagnostics">Открыть диагностику</sys:String>
+    <sys:String x:Key="SystemTray_PauseMonitoring">Приостановить мониторинг автоматизации</sys:String>
+    <sys:String x:Key="SystemTray_ResumeMonitoring">Возобновить мониторинг автоматизации</sys:String>
+    <sys:String x:Key="SystemTray_SystemStatus">Статус системы</sys:String>
+    <sys:String x:Key="SystemTray_NoProcessSelected">Процесс не выбран</sys:String>
+    <sys:String x:Key="SystemTray_SelectedProcessFormat">Выбрано: {0}</sys:String>
+    <sys:String x:Key="SystemTray_ApplyPendingToSelected">Применить ожидающие настройки к выбранному процессу</sys:String>
+    <sys:String x:Key="SystemTray_ApplyPendingToProcessFormat">Применить ожидающие настройки к {0}</sys:String>
+    <sys:String x:Key="SystemTray_PowerPlans">🔋 Планы электропитания</sys:String>
+    <sys:String x:Key="SystemTray_Profiles">📋 Профили</sys:String>
+    <sys:String x:Key="SystemTray_Settings">Настройки</sys:String>
+    <sys:String x:Key="SystemTray_Exit">Выход</sys:String>
+    <sys:String x:Key="SystemTray_NoProfilesAvailable">Нет доступных профилей</sys:String>
+    <sys:String x:Key="SystemTray_PowerPlanFormat">Схема электропитания: {0}</sys:String>
+    <sys:String x:Key="SystemTray_StatusWmiError">Ошибка автоматизации WMI</sys:String>
+    <sys:String x:Key="SystemTray_StatusActive">Автоматизация активна</sys:String>
+    <sys:String x:Key="SystemTray_StatusDisabled">Автоматизация отключена</sys:String>
+    <sys:String x:Key="SystemTray_Unknown">Неизвестно</sys:String>
+    <sys:String x:Key="SystemTray_CpuRamStatusFormat">💻 CPU: {0:F1}% | RAM: {1:F1}% | {2}</sys:String>
+
+    <!-- ProcessOperationUserMessages -->
+    <sys:String x:Key="ProcessOperationUserMessages_AccessDenied">Windows отклонил это изменение. Для этого процесса могут потребоваться права администратора или он может быть защищен.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_AntiCheatProtectedLikely">Процесс выглядит защищенным античитом или защитой процесса. ThreadPilot не будет пытаться обойти его.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_AdminClarification">Режим администратора может помочь решить обычные проблемы с разрешениями, но не может обойти ограничения античитов или защищенных процессов.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_LegacyFallbackBlocked">Этот выбор CPU не может быть безопасно представлен устаревшими API привязки в этой топологии. CPU Для этого выбора необходимы наборы.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_InvalidTopology">Этот выбор CPU не соответствует текущей топологии CPU. Просмотрите или воссоздайте предустановку.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_ProcessExited">Процесс завершился до того, как ThreadPilot смог применить изменение.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_CpuSetsUnavailable">Windows CPU Наборы недоступны или этот выбор отклонен. ThreadPilot будет использовать безопасный резервный вариант только тогда, когда это возможно.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_HighPriorityWarning">Высокий приоритет может улучшить скорость реагирования на некоторые рабочие нагрузки, но может снизить скорость реагирования системы.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_RealtimePriorityBlocked">Приоритет реального времени блокируется ThreadPilot, поскольку это может сделать Windows нестабильным или перестать отвечать на запросы.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentLaunchTimePriorityNotice">Постоянный приоритет времени запуска может поддерживаться для обычных процессов, но он не обходит защищенные процессы или ограничения защиты от мошенничества.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentRulesDescription">Применяет сохраненные правила при запуске процесса сопоставления. Некоторые защищенные или античит-процессы могут отклонять изменения. Режим администратора может помочь решить обычные проблемы с разрешениями, но не может обойти защиту.</sys:String>
+    <sys:String x:Key="ProcessOperationUserMessages_PersistentRulesProtectedProcessWarning">Процесс выглядит защищенным античитом или защитой процесса. ThreadPilot не будет пытаться его переопределить.</sys:String>
+
+    <!-- Notifications -->
+    <sys:String x:Key="Notification_PowerPlanChangedTitle">План электропитания изменен</sys:String>
+    <sys:String x:Key="Notification_PowerPlanChangedFormat">План электропитания изменен с «{0}» на «{1}».</sys:String>
+    <sys:String x:Key="Notification_PowerPlanChangedProcessFormat">Схема электропитания изменена на «{0}» для процесса «{1}».</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringEnabled">Мониторинг процессов включен</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringDisabled">Мониторинг процессов отключен</sys:String>
+    <sys:String x:Key="Notification_CpuAffinityAppliedTitle">CPU Привязка применена</sys:String>
+    <sys:String x:Key="Notification_CpuAffinityAppliedFormat">CPU набор привязок для «{0}»: {1}</sys:String>
+    <sys:String x:Key="Notification_GameBoostActivatedTitle">Ускорение игры активировано</sys:String>
+    <sys:String x:Key="Notification_GameBoostActivatedFormat">Режим Game Boost активирован для {0}</sys:String>
+    <sys:String x:Key="Notification_GameBoostDeactivatedTitle">Ускорение игры отключено</sys:String>
+    <sys:String x:Key="Notification_GameBoostDeactivatedFormat">Режим Game Boost отключен после {0}</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitorErrorTitle">Ошибка монитора процесса</sys:String>
+    <sys:String x:Key="Notification_AffinityBlockedTitle">Родственность заблокирована</sys:String>
+    <sys:String x:Key="Notification_AffinityAppliedTitle">Привязка применена</sys:String>
+    <sys:String x:Key="Notification_AffinityAdjustedTitle">Привязка скорректирована</sys:String>
+    <sys:String x:Key="Notification_AffinityFailedTitle">Не удалось применить привязку</sys:String>
+    <sys:String x:Key="Notification_AffinityErrorTitle">Ошибка привязки</sys:String>
+    <sys:String x:Key="Notification_PriorityBlockedTitle">Приоритет заблокирован</sys:String>
+    <sys:String x:Key="Notification_PriorityWarningTitle">Приоритетное предупреждение</sys:String>
+    <sys:String x:Key="Notification_PriorityAppliedTitle">Приоритет применен</sys:String>
+    <sys:String x:Key="Notification_PriorityAdjustedTitle">Приоритет изменен</sys:String>
+    <sys:String x:Key="Notification_PriorityErrorTitle">Ошибка приоритета</sys:String>
+    <sys:String x:Key="Notification_KeyboardShortcutTitle">Сочетание клавиш</sys:String>
+    <sys:String x:Key="Notification_ToggleMonitoringShortcut">Переключить ярлык мониторинга активирован</sys:String>
+    <sys:String x:Key="Notification_HighPerformanceShortcut">Ярлык плана электропитания высокой производительности активирован</sys:String>
+    <sys:String x:Key="Notification_RefreshProcessListShortcut">Ярлык обновления списка процессов активирован</sys:String>
+    <sys:String x:Key="Notification_ThreadPilotStartedTitle">ThreadPilot Начато</sys:String>
+    <sys:String x:Key="Notification_ThreadPilotStartedMessage">Мониторинг процессов и управление планом электропитания теперь активны</sys:String>
+    <sys:String x:Key="Notification_StartupErrorTitle">Ошибка запуска</sys:String>
+    <sys:String x:Key="Notification_ProcessMonitoringStartFailed">Не удалось запустить диспетчер мониторинга процессов.</sys:String>
+    <sys:String x:Key="Notification_AutomationMonitoringErrorTitle">Ошибка мониторинга автоматизации</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedTitle">Настройки сохранены</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedMessage">Настройки приложения успешно сохранены</sys:String>
+    <sys:String x:Key="Notification_SettingsSavedWarningsTitle">Настройки сохранены с предупреждениями</sys:String>
+    <sys:String x:Key="Notification_SettingsErrorTitle">Ошибка настроек</sys:String>
+    <sys:String x:Key="Notification_SettingsSaveFailed">Не удалось сохранить настройки.</sys:String>
+    <sys:String x:Key="Notification_TestNotificationMessage">Это тестовое уведомление, позволяющее убедиться, что ваши настройки работают правильно.</sys:String>
+
+    <!-- Elevation Service -->
+    <sys:String x:Key="Elevation_RequestPromptText">ThreadPilot требуются права администратора для управления привязкой процессов и планами электропитания.&#x0a;&#x0a;Хотите перезапустить приложение с правами администратора?</sys:String>
+    <sys:String x:Key="Elevation_RequestPromptTitle">Требуются права администратора</sys:String>
+    <sys:String x:Key="Elevation_FailedText">Не удалось перезагрузить компьютер с правами администратора. Пожалуйста, запустите ThreadPilot вручную от имени администратора.</sys:String>
+    <sys:String x:Key="Elevation_FailedTitle">Не удалось повысить высоту</sys:String>
+    <sys:String x:Key="Elevation_StatusRunning">Запуск с правами администратора</sys:String>
+    <sys:String x:Key="Elevation_StatusLimited">Работа с ограниченными привилегиями</sys:String>
+
+    <!-- System Tweaks Errors -->
+    <sys:String x:Key="SystemTweak_Error_QueryCoreParking">Не удалось запросить значение Core Parking через powercfg.</sys:String>
+    <sys:String x:Key="SystemTweak_Error_QueryCStates">Не удалось запросить значение C-States через powercfg.</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PrefetchKeyNotFound">Ключ реестра Prefetch не найден</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PowerThrottlingNotAvailable">Power Throttling недоступен в этой системе</sys:String>
+    <sys:String x:Key="SystemTweak_Error_PriorityControlKeyNotFound">Ключ реестра PriorityControl не найден</sys:String>
+    <sys:String x:Key="SystemTweak_Error_DesktopKeyNotFound">Ключ реестра рабочего стола не найден</sys:String>
+</ResourceDictionary>

--- a/Locales/zh-CN.xaml
+++ b/Locales/zh-CN.xaml
@@ -409,6 +409,11 @@
     <sys:String x:Key="SettingsView_Language">显示语言</sys:String>
     <sys:String x:Key="SettingsView_LanguageZhCn">简体中文 (Simplified Chinese)</sys:String>
     <sys:String x:Key="SettingsView_LanguageEnUs">English (English)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageItIt">Italiano (Italian)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageFrFr">Français (French)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageDeDe">Deutsch (German)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageEsEs">Español (Spanish)</sys:String>
+    <sys:String x:Key="SettingsView_LanguageRuRu">Русский (Russian)</sys:String>
     <sys:String x:Key="SettingsView_LanguageDescription">在整个应用程序界面应用全局的语言设置。</sys:String>
     
     <sys:String x:Key="SettingsView_RulesAutomation">规则与自动化</sys:String>
@@ -493,6 +498,11 @@
     <sys:String x:Key="Settings_StatusMatchSaved">设置与已保存的配置一致</sys:String>
     <sys:String x:Key="Settings_LanguageSimplifiedChinese">简体中文</sys:String>
     <sys:String x:Key="Settings_LanguageEnglish">英文</sys:String>
+    <sys:String x:Key="Settings_LanguageItalian">意大利语</sys:String>
+    <sys:String x:Key="Settings_LanguageFrench">法语</sys:String>
+    <sys:String x:Key="Settings_LanguageGerman">德语</sys:String>
+    <sys:String x:Key="Settings_LanguageSpanish">西班牙语</sys:String>
+    <sys:String x:Key="Settings_LanguageRussian">俄语</sys:String>
     <sys:String x:Key="Settings_ThemeDark">深色</sys:String>
     <sys:String x:Key="Settings_ThemeLight">浅色</sys:String>
     <sys:String x:Key="Settings_DialogExportTitle">导出 ThreadPilot 配置</sys:String>
@@ -502,7 +512,7 @@
     <!-- SettingsWindow -->
     <sys:String x:Key="SettingsWindow_Title">ThreadPilot 设置</sys:String>
     <sys:String x:Key="SettingsWindow_UnsavedTitle">未保存的设置</sys:String>
-    <sys:String x:Key="SettingsWindow_UnsavedDescription">您有尚未保存的更改。请选择在关闭前保存、放弃修改或取消并返回编辑。</sys:String>
+    <sys:String x:Key="SettingsWindow_UnsavedDescription">您有尚未保存的更改。请选择保存、放弃修改或取消并继续编辑。</sys:String>
     <sys:String x:Key="SettingsWindow_Cancel">取消</sys:String>
     <sys:String x:Key="SettingsWindow_Discard">放弃更改</sys:String>
     <sys:String x:Key="SettingsWindow_Save">保存</sys:String>
@@ -520,14 +530,14 @@
     <sys:String x:Key="SystemTweak_CoreParking_Desc">控制 CPU 核心休眠以进行电源管理</sys:String>
     <sys:String x:Key="SystemTweak_CStates_Name">C-States 状态</sys:String>
     <sys:String x:Key="SystemTweak_CStates_Desc">控制 CPU C-States 以进行节能电源管理</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Name">HPET 定时器</sys:String>
+    <sys:String x:Key="SystemTweak_Hpet_Desc">高精度事件计时器，用于系统精准定时</sys:String>
     <sys:String x:Key="SystemTweak_SysMain_Name">SysMain 服务</sys:String>
     <sys:String x:Key="SystemTweak_SysMain_Desc">Windows Superfetch/SysMain 服务，用于内存管理</sys:String>
     <sys:String x:Key="SystemTweak_Prefetch_Name">预取 (Prefetch)</sys:String>
     <sys:String x:Key="SystemTweak_Prefetch_Desc">Windows Prefetch 功能，用于加速应用程序加载</sys:String>
     <sys:String x:Key="SystemTweak_PowerThrottling_Name">电源限流 (Power Throttling)</sys:String>
     <sys:String x:Key="SystemTweak_PowerThrottling_Desc">Windows 电源限流功能，用于能效优化</sys:String>
-    <sys:String x:Key="SystemTweak_Hpet_Name">HPET 定时器</sys:String>
-    <sys:String x:Key="SystemTweak_Hpet_Desc">高精度事件计时器，用于系统精准定时</sys:String>
     <sys:String x:Key="SystemTweak_HighSchedulingCategory_Name">高调度优先级类别</sys:String>
     <sys:String x:Key="SystemTweak_HighSchedulingCategory_Desc">为游戏应用程序提供高调度优先级</sys:String>
     <sys:String x:Key="SystemTweak_MenuShowDelay_Name">菜单显示延迟</sys:String>

--- a/MainWindow.Behaviors.partial.cs
+++ b/MainWindow.Behaviors.partial.cs
@@ -770,8 +770,7 @@ namespace ThreadPilot
                 return true;
             }
 
-            var result = await this.ShowUnsavedSettingsDialogAsync(
-                "You have unsaved changes in Settings. Save before exiting, discard the changes, or cancel to return to ThreadPilot.");
+            var result = await this.ShowUnsavedSettingsDialogAsync();
 
             if (result == MessageBoxResult.Cancel)
             {
@@ -1653,11 +1652,11 @@ namespace ThreadPilot
             this.PerformanceIntroOverlay.Visibility = Visibility.Collapsed;
         }
 
-        private Task<MessageBoxResult> ShowUnsavedSettingsDialogAsync(string message)
+        private Task<MessageBoxResult> ShowUnsavedSettingsDialogAsync()
         {
             if (!this.Dispatcher.CheckAccess())
             {
-                return this.Dispatcher.InvokeAsync(() => this.ShowUnsavedSettingsDialogAsync(message)).Task.Unwrap();
+                return this.Dispatcher.InvokeAsync(this.ShowUnsavedSettingsDialogAsync).Task.Unwrap();
             }
 
             if (this.unsavedSettingsDialogCompletionSource != null)
@@ -1665,7 +1664,6 @@ namespace ThreadPilot
                 return Task.FromResult(MessageBoxResult.Cancel);
             }
 
-            this.UnsavedSettingsDialogMessage.Text = message;
             this.unsavedSettingsDialogCompletionSource = new TaskCompletionSource<MessageBoxResult>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
             this.UnsavedSettingsOverlay.Visibility = Visibility.Visible;
@@ -1736,7 +1734,7 @@ namespace ThreadPilot
             try
             {
                 var settings = this.settingsService.Settings;
-                
+
                 // Only show if user is not admin AND hasn't dismissed the warning yet
                 if (this.elevationService?.IsRunningAsAdministrator() == true || settings.HasSeenElevationWarning)
                 {
@@ -1944,8 +1942,7 @@ namespace ThreadPilot
                 var canNavigate = await NavigationBehavior.EnsureCanNavigateAsync(
                     tag,
                     this.settingsViewModel,
-                    () => this.ShowUnsavedSettingsDialogAsync(
-                        "You have unsaved changes in Settings. Save before switching tabs, discard the changes, or cancel to stay on Settings."));
+                    this.ShowUnsavedSettingsDialogAsync);
                 if (!canNavigate)
                 {
                     return;

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -254,8 +254,8 @@
                                     <Button Content="{DynamicResource MainWindow_RequestElevation}"
                                             Command="{Binding RequestElevationCommand}"
                                             Click="ElevationWarningRequestElevation_Click"
-                                            Background="{DynamicResource AccentFillColorDefaultBrush}"
-                                            Foreground="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
+                                            Background="{DynamicResource ControlFillColorTertiaryBrush}"
+                                            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                             Padding="16,8"/>
                                 </StackPanel>
                             </StackPanel>
@@ -361,8 +361,8 @@
                                 Content="{DynamicResource PerformanceView_Continue}"
                                 Click="PerformanceIntroContinue_Click"
                                 HorizontalAlignment="Right"
-                                Background="{DynamicResource AccentFillColorDefaultBrush}"
-                                Foreground="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
+                                Background="{DynamicResource ControlFillColorTertiaryBrush}"
+                                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                 Padding="16,8"/>
                     </StackPanel>
                 </Border>
@@ -388,8 +388,8 @@
                         <DropShadowEffect BlurRadius="12" ShadowDepth="0" Opacity="0.16"/>
                     </Border.Effect>
                     <StackPanel>
-                        <Border Background="{DynamicResource InfoBackgroundBrush}"
-                                BorderBrush="{DynamicResource InfoBorderBrush}"
+                        <Border Background="{DynamicResource StatusPillBackgroundBrush}"
+                                BorderBrush="{DynamicResource StatusPillBorderBrush}"
                                 BorderThickness="1"
                                 CornerRadius="{DynamicResource StandardCardCornerRadius}"
                                 Padding="8,3"
@@ -398,7 +398,7 @@
                             <TextBlock Text="{DynamicResource MainWindow_Recommended}"
                                        FontSize="{DynamicResource CaptionFontSize}"
                                        FontWeight="SemiBold"
-                                       Foreground="{DynamicResource InfoTextBrush}"/>
+                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                         </Border>
                         <TextBlock Text="{DynamicResource MainWindow_StartupMinimizedSuggestionTitle}"
                                    FontSize="20"
@@ -418,8 +418,8 @@
                                     Margin="0,0,10,0"/>
                             <Button Content="{DynamicResource MainWindow_OpenSettings}"
                                     Click="StartupSuggestionOpenSettings_Click"
-                                    Background="{DynamicResource AccentFillColorDefaultBrush}"
-                                    Foreground="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
+                                    Background="{DynamicResource ControlFillColorTertiaryBrush}"
+                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                     Padding="14,7"/>
                         </StackPanel>
                     </StackPanel>
@@ -451,6 +451,7 @@
                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                    Margin="0,0,0,10"/>
                         <TextBlock x:Name="UnsavedSettingsDialogMessage"
+                                   Text="{DynamicResource SettingsWindow_UnsavedDescription}"
                                    TextWrapping="Wrap"
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                    Margin="0,0,0,18"/>
@@ -469,8 +470,8 @@
                                     Margin="0,0,10,0"/>
                             <Button Content="{DynamicResource SettingsWindow_Save}"
                                     Click="UnsavedSettingsSave_Click"
-                                    Background="{DynamicResource AccentFillColorDefaultBrush}"
-                                    Foreground="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
+                                    Background="{DynamicResource ControlFillColorTertiaryBrush}"
+                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                     Padding="16,8"/>
                         </StackPanel>
                     </StackPanel>

--- a/Services/ApplicationSettingsService.cs
+++ b/Services/ApplicationSettingsService.cs
@@ -1,6 +1,7 @@
 namespace ThreadPilot.Services
 {
     using System;
+    using System.Globalization;
     using System.IO;
     using System.Text;
     using System.Text.Json;
@@ -15,6 +16,7 @@ namespace ThreadPilot.Services
         private readonly ISettingsStorage settingsStorage;
         private readonly string settingsFilePath;
         private readonly string? legacySettingsPath;
+        private readonly Func<CultureInfo> systemUiCultureProvider;
         private ApplicationSettingsModel settings;
         private static readonly JsonSerializerOptions JsonOptions = new()
         {
@@ -34,7 +36,8 @@ namespace ThreadPilot.Services
                 logger,
                 CreateDefaultStorage(),
                 StoragePaths.SettingsFilePath,
-                Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "settings.json"))
+                Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "settings.json"),
+                () => CultureInfo.CurrentUICulture)
         {
         }
 
@@ -42,16 +45,18 @@ namespace ThreadPilot.Services
             ILogger<ApplicationSettingsService> logger,
             ISettingsStorage settingsStorage,
             string settingsFilePath,
-            string? legacySettingsPath)
+            string? legacySettingsPath,
+            Func<CultureInfo>? systemUiCultureProvider = null)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.settingsStorage = settingsStorage ?? throw new ArgumentNullException(nameof(settingsStorage));
             this.settingsFilePath = settingsFilePath ?? throw new ArgumentNullException(nameof(settingsFilePath));
             this.legacySettingsPath = legacySettingsPath;
+            this.systemUiCultureProvider = systemUiCultureProvider ?? (() => CultureInfo.CurrentUICulture);
 
             this.MigrateLegacySettingsIfNeeded();
 
-            this.settings = new ApplicationSettingsModel();
+            this.settings = this.CreateDefaultSettings();
         }
 
         public async Task LoadSettingsAsync()
@@ -63,7 +68,7 @@ namespace ThreadPilot.Services
                 if (!this.settingsStorage.Exists(this.settingsFilePath))
                 {
                     this.logger.LogInformation("Settings file not found, using defaults");
-                    this.settings = new ApplicationSettingsModel();
+                    this.settings = this.CreateDefaultSettings();
                     await this.SaveSettingsAsync();
                     return;
                 }
@@ -72,12 +77,13 @@ namespace ThreadPilot.Services
                 if (string.IsNullOrWhiteSpace(json))
                 {
                     this.logger.LogWarning("Settings file was empty, using defaults");
-                    this.settings = new ApplicationSettingsModel();
+                    this.settings = this.CreateDefaultSettings();
                     await this.SaveSettingsAsync();
                     return;
                 }
 
                 var legacyThemePreferenceDetected = false;
+                var hasLanguagePreference = false;
 
                 try
                 {
@@ -87,6 +93,9 @@ namespace ThreadPilot.Services
                         var hasThemePreferenceFlag = document.RootElement.TryGetProperty("hasUserThemePreference", out _);
                         var hasUseDarkThemeFlag = document.RootElement.TryGetProperty("useDarkTheme", out _);
                         legacyThemePreferenceDetected = !hasThemePreferenceFlag && hasUseDarkThemeFlag;
+                        hasLanguagePreference = document.RootElement.TryGetProperty("language", out var languageElement) &&
+                            languageElement.ValueKind == JsonValueKind.String &&
+                            !string.IsNullOrWhiteSpace(languageElement.GetString());
                     }
                 }
                 catch (JsonException ex)
@@ -103,9 +112,28 @@ namespace ThreadPilot.Services
                         loadedSettings.HasUserThemePreference = true;
                     }
 
+                    if (!hasLanguagePreference)
+                    {
+                        loadedSettings.Language = string.Empty;
+                    }
+
+                    var languageIsSupported = LocalizationService.TryNormalizeSupportedLanguage(
+                        loadedSettings.Language,
+                        out var normalizedLanguage);
+                    var requiresLanguageRepair = !languageIsSupported ||
+                        !string.Equals(loadedSettings.Language, normalizedLanguage, StringComparison.Ordinal);
+                    loadedSettings.Language = LocalizationService.ResolveLanguagePreference(
+                        loadedSettings.Language,
+                        this.systemUiCultureProvider());
+
                     var oldSettings = (ApplicationSettingsModel)this.settings.Clone();
                     this.settings.CopyFrom(loadedSettings);
                     this.ValidateAndFixSettings();
+
+                    if (requiresLanguageRepair)
+                    {
+                        await this.SaveSettingsAsync();
+                    }
 
                     this.logger.LogInformation("Settings loaded successfully");
                     this.OnSettingsChanged(oldSettings, this.settings);
@@ -113,13 +141,14 @@ namespace ThreadPilot.Services
                 else
                 {
                     this.logger.LogWarning("Failed to deserialize settings, using defaults");
-                    this.settings = new ApplicationSettingsModel();
+                    this.settings = this.CreateDefaultSettings();
+                    await this.SaveSettingsAsync();
                 }
             }
             catch (Exception ex)
             {
                 this.logger.LogError(ex, "Error loading settings, using defaults");
-                this.settings = new ApplicationSettingsModel();
+                this.settings = this.CreateDefaultSettings();
             }
         }
 
@@ -153,7 +182,11 @@ namespace ThreadPilot.Services
             try
             {
                 var oldSettings = (ApplicationSettingsModel)this.settings.Clone();
+                var resolvedLanguage = LocalizationService.ResolveLanguagePreference(
+                    newSettings.Language,
+                    this.systemUiCultureProvider());
                 this.settings.CopyFrom(newSettings);
+                this.settings.Language = resolvedLanguage;
 
                 await this.SaveSettingsAsync();
 
@@ -174,7 +207,7 @@ namespace ThreadPilot.Services
                 this.logger.LogInformation("Resetting settings to defaults");
 
                 var oldSettings = (ApplicationSettingsModel)this.settings.Clone();
-                this.settings = new ApplicationSettingsModel();
+                this.settings = this.CreateDefaultSettings();
 
                 await this.SaveSettingsAsync();
 
@@ -237,7 +270,9 @@ namespace ThreadPilot.Services
                 }
             }
 
-            this.settings.Language = LocalizationService.NormalizeLanguage(this.settings.Language);
+            this.settings.Language = LocalizationService.ResolveLanguagePreference(
+                this.settings.Language,
+                this.systemUiCultureProvider());
 
             if (this.settings.UpdateCheckIntervalDays < 1)
             {
@@ -320,6 +355,15 @@ namespace ThreadPilot.Services
             {
                 this.logger.LogError(ex, "Error firing settings changed event");
             }
+        }
+
+        private ApplicationSettingsModel CreateDefaultSettings()
+        {
+            var defaults = new ApplicationSettingsModel
+            {
+                Language = LocalizationService.ResolveSystemLanguage(this.systemUiCultureProvider()),
+            };
+            return defaults;
         }
 
         private void MigrateLegacySettingsIfNeeded()

--- a/Services/LocalizationService.cs
+++ b/Services/LocalizationService.cs
@@ -2,6 +2,7 @@ namespace ThreadPilot.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Windows;
     using Microsoft.Extensions.Logging;
 
@@ -9,13 +10,26 @@ namespace ThreadPilot.Services
     {
         public const string DefaultLanguage = "en-US";
         public const string SimplifiedChineseLanguage = "zh-CN";
+        public const string ItalianLanguage = "it-IT";
+        public const string FrenchLanguage = "fr-FR";
+        public const string GermanLanguage = "de-DE";
+        public const string SpanishLanguage = "es-ES";
+        public const string RussianLanguage = "ru-RU";
 
-        private const string EnUsDictionaryPath = "Locales/en-US.xaml";
-        private const string ZhCnDictionaryPath = "Locales/zh-CN.xaml";
+        private static readonly Dictionary<string, string> LocaleDictionaryPaths =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [DefaultLanguage] = "Locales/en-US.xaml",
+                [SimplifiedChineseLanguage] = "Locales/zh-CN.xaml",
+                [ItalianLanguage] = "Locales/it-IT.xaml",
+                [FrenchLanguage] = "Locales/fr-FR.xaml",
+                [GermanLanguage] = "Locales/de-DE.xaml",
+                [SpanishLanguage] = "Locales/es-ES.xaml",
+                [RussianLanguage] = "Locales/ru-RU.xaml",
+            };
 
         private readonly ILogger<LocalizationService> logger;
-        private readonly IReadOnlyDictionary<string, string>? englishStrings;
-        private readonly IReadOnlyDictionary<string, string>? chineseStrings;
+        private readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>? localizedStringOverrides;
         private ResourceDictionary? activeLocaleDictionary;
         private ResourceDictionary? englishFallbackDictionary;
         private Uri? activeLocaleUri;
@@ -25,7 +39,7 @@ namespace ThreadPilot.Services
         public event EventHandler<string>? LanguageChanged;
 
         public LocalizationService(ILogger<LocalizationService> logger)
-            : this(logger, englishStrings: null, chineseStrings: null)
+            : this(logger, localizedStringOverrides: null)
         {
         }
 
@@ -33,20 +47,71 @@ namespace ThreadPilot.Services
             ILogger<LocalizationService> logger,
             IReadOnlyDictionary<string, string>? englishStrings,
             IReadOnlyDictionary<string, string>? chineseStrings)
+            : this(logger, CreateOverrides(englishStrings, chineseStrings))
+        {
+        }
+
+        internal LocalizationService(
+            ILogger<LocalizationService> logger,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>? localizedStringOverrides)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            this.englishStrings = englishStrings;
-            this.chineseStrings = chineseStrings;
+            this.localizedStringOverrides = localizedStringOverrides;
         }
+
+        internal static IReadOnlyCollection<string> SupportedLanguages => LocaleDictionaryPaths.Keys;
 
         public static string NormalizeLanguage(string? language)
         {
-            if (string.Equals(language, SimplifiedChineseLanguage, StringComparison.OrdinalIgnoreCase))
+            return TryNormalizeSupportedLanguage(language, out var normalizedLanguage)
+                ? normalizedLanguage
+                : DefaultLanguage;
+        }
+
+        internal static bool TryNormalizeSupportedLanguage(string? language, out string normalizedLanguage)
+        {
+            if (!string.IsNullOrWhiteSpace(language))
             {
-                return SimplifiedChineseLanguage;
+                foreach (var supportedLanguage in LocaleDictionaryPaths.Keys)
+                {
+                    if (string.Equals(language, supportedLanguage, StringComparison.OrdinalIgnoreCase))
+                    {
+                        normalizedLanguage = supportedLanguage;
+                        return true;
+                    }
+                }
             }
 
-            return DefaultLanguage;
+            normalizedLanguage = DefaultLanguage;
+            return false;
+        }
+
+        internal static string ResolveLanguagePreference(string? language, CultureInfo systemUiCulture)
+        {
+            if (TryNormalizeSupportedLanguage(language, out var normalizedLanguage))
+            {
+                return normalizedLanguage;
+            }
+
+            return ResolveSystemLanguage(systemUiCulture);
+        }
+
+        internal static string ResolveSystemLanguage(CultureInfo systemUiCulture)
+        {
+            ArgumentNullException.ThrowIfNull(systemUiCulture);
+
+            var language = systemUiCulture.TwoLetterISOLanguageName;
+            return language.ToLowerInvariant() switch
+            {
+                "en" => DefaultLanguage,
+                "it" => ItalianLanguage,
+                "fr" => FrenchLanguage,
+                "de" => GermanLanguage,
+                "es" => SpanishLanguage,
+                "ru" => RussianLanguage,
+                "zh" when IsSimplifiedChineseCulture(systemUiCulture) => SimplifiedChineseLanguage,
+                _ => DefaultLanguage,
+            };
         }
 
         public void ApplyLanguage(string? language)
@@ -54,11 +119,10 @@ namespace ThreadPilot.Services
             var normalizedLanguage = NormalizeLanguage(language);
             var targetUri = new Uri(GetDictionaryPath(normalizedLanguage), UriKind.Relative);
 
-            this.CurrentLanguage = normalizedLanguage;
-
             var appResources = System.Windows.Application.Current?.Resources;
             if (appResources == null)
             {
+                this.CurrentLanguage = normalizedLanguage;
                 this.activeLocaleUri = targetUri;
                 this.LanguageChanged?.Invoke(this, normalizedLanguage);
                 return;
@@ -67,6 +131,7 @@ namespace ThreadPilot.Services
             try
             {
                 this.ApplyLanguageDictionary(appResources, targetUri);
+                this.CurrentLanguage = normalizedLanguage;
                 this.activeLocaleUri = targetUri;
                 this.logger.LogInformation("Applied display language {Language}", normalizedLanguage);
                 this.LanguageChanged?.Invoke(this, normalizedLanguage);
@@ -74,6 +139,7 @@ namespace ThreadPilot.Services
             catch (Exception ex)
             {
                 this.logger.LogError(ex, "Failed to apply language {Language}", normalizedLanguage);
+                this.ApplyEnglishFallback(appResources, normalizedLanguage);
             }
         }
 
@@ -150,14 +216,27 @@ namespace ThreadPilot.Services
 
         private static string GetDictionaryPath(string language)
         {
-            return language == SimplifiedChineseLanguage ? ZhCnDictionaryPath : EnUsDictionaryPath;
+            return LocaleDictionaryPaths.TryGetValue(language, out var path)
+                ? path
+                : LocaleDictionaryPaths[DefaultLanguage];
         }
 
         private static bool IsLocaleDictionary(string? source)
         {
-            return !string.IsNullOrWhiteSpace(source) &&
-                (source.EndsWith(EnUsDictionaryPath, StringComparison.OrdinalIgnoreCase) ||
-                 source.EndsWith(ZhCnDictionaryPath, StringComparison.OrdinalIgnoreCase));
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                return false;
+            }
+
+            foreach (var path in LocaleDictionaryPaths.Values)
+            {
+                if (source.EndsWith(path, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool TryGetString(ResourceDictionary dictionary, string key, out string value)
@@ -174,8 +253,10 @@ namespace ThreadPilot.Services
 
         private bool TryGetStringFromOverrides(string language, string key, out string value)
         {
-            var source = language == SimplifiedChineseLanguage ? this.chineseStrings : this.englishStrings;
-            if (source != null && source.TryGetValue(key, out var text) && !string.IsNullOrEmpty(text))
+            if (this.localizedStringOverrides != null &&
+                this.localizedStringOverrides.TryGetValue(language, out var source) &&
+                source.TryGetValue(key, out var text) &&
+                !string.IsNullOrEmpty(text))
             {
                 value = text;
                 return true;
@@ -236,7 +317,7 @@ namespace ThreadPilot.Services
             {
                 this.englishFallbackDictionary ??= new ResourceDictionary
                 {
-                    Source = new Uri(EnUsDictionaryPath, UriKind.Relative),
+                    Source = new Uri(LocaleDictionaryPaths[DefaultLanguage], UriKind.Relative),
                 };
                 return TryGetString(this.englishFallbackDictionary, key, out value);
             }
@@ -245,6 +326,61 @@ namespace ThreadPilot.Services
                 this.logger.LogDebug(ex, "Failed to load English fallback localization dictionary");
                 return false;
             }
+        }
+
+        private static bool IsSimplifiedChineseCulture(CultureInfo culture)
+        {
+            var name = culture.Name;
+            return name.Contains("Hans", StringComparison.OrdinalIgnoreCase) ||
+                name.Contains("CHS", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(name, "zh-CN", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(name, "zh-SG", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void ApplyEnglishFallback(ResourceDictionary appResources, string failedLanguage)
+        {
+            var fallbackUri = new Uri(GetDictionaryPath(DefaultLanguage), UriKind.Relative);
+            try
+            {
+                if (!string.Equals(failedLanguage, DefaultLanguage, StringComparison.OrdinalIgnoreCase))
+                {
+                    this.ApplyLanguageDictionary(appResources, fallbackUri);
+                }
+
+                this.CurrentLanguage = DefaultLanguage;
+                this.activeLocaleUri = fallbackUri;
+                this.LanguageChanged?.Invoke(this, DefaultLanguage);
+            }
+            catch (Exception fallbackException)
+            {
+                this.CurrentLanguage = DefaultLanguage;
+                this.activeLocaleUri = fallbackUri;
+                this.logger.LogError(fallbackException, "Failed to apply English fallback language");
+                this.LanguageChanged?.Invoke(this, DefaultLanguage);
+            }
+        }
+
+        private static Dictionary<string, IReadOnlyDictionary<string, string>>? CreateOverrides(
+            IReadOnlyDictionary<string, string>? englishStrings,
+            IReadOnlyDictionary<string, string>? chineseStrings)
+        {
+            if (englishStrings == null && chineseStrings == null)
+            {
+                return null;
+            }
+
+            var overrides = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+            if (englishStrings != null)
+            {
+                overrides[DefaultLanguage] = englishStrings;
+            }
+
+            if (chineseStrings != null)
+            {
+                overrides[SimplifiedChineseLanguage] = chineseStrings;
+            }
+
+            return overrides;
         }
     }
 }

--- a/Tests/ThreadPilot.Core.Tests/ApplicationSettingsServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ApplicationSettingsServiceTests.cs
@@ -2,6 +2,7 @@ namespace ThreadPilot.Core.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging.Abstractions;
@@ -27,6 +28,18 @@ namespace ThreadPilot.Core.Tests
             Assert.True(service.Settings.AutostartWithWindows);
             Assert.False(service.Settings.StartMinimized);
             Assert.Equal("en-US", service.Settings.Language);
+        }
+
+        [Fact]
+        public async Task LoadSettingsAsync_UsesAndPersistsWindowsLanguage_WhenFileIsMissing()
+        {
+            var storage = new FakeSettingsStorage();
+            var service = CreateService(storage, "it-CH");
+
+            await service.LoadSettingsAsync();
+
+            Assert.Equal("it-IT", service.Settings.Language);
+            Assert.Contains("\"language\": \"it-IT\"", storage.Writes[TestPaths.SettingsFilePath], StringComparison.Ordinal);
         }
 
         [Fact]
@@ -149,28 +162,15 @@ namespace ThreadPilot.Core.Tests
             Assert.True(service.Settings.HasSeenStartupMinimizedSuggestion);
         }
 
-        [Fact]
-        public async Task LoadSettingsAsync_PreservesSupportedLanguage()
-        {
-            var storage = new FakeSettingsStorage();
-            storage.Files[TestPaths.SettingsFilePath] = """
-                {
-                  "language": "zh-CN"
-                }
-                """;
-            var service = CreateService(storage);
-
-            await service.LoadSettingsAsync();
-
-            Assert.Equal("zh-CN", service.Settings.Language);
-        }
-
         [Theory]
-        [InlineData("")]
-        [InlineData("   ")]
+        [InlineData("en-US")]
+        [InlineData("zh-CN")]
+        [InlineData("it-IT")]
         [InlineData("fr-FR")]
-        [InlineData("zh")]
-        public async Task LoadSettingsAsync_FallsBackToEnglish_WhenLanguageIsInvalid(string language)
+        [InlineData("de-DE")]
+        [InlineData("es-ES")]
+        [InlineData("ru-RU")]
+        public async Task LoadSettingsAsync_PreservesSupportedLanguage(string language)
         {
             var storage = new FakeSettingsStorage();
             storage.Files[TestPaths.SettingsFilePath] = $$"""
@@ -178,11 +178,94 @@ namespace ThreadPilot.Core.Tests
                   "language": "{{language}}"
                 }
                 """;
-            var service = CreateService(storage);
+            var service = CreateService(storage, "it-IT");
 
             await service.LoadSettingsAsync();
 
-            Assert.Equal("en-US", service.Settings.Language);
+            Assert.Equal(language, service.Settings.Language);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("pt-BR")]
+        [InlineData("zh")]
+        public async Task LoadSettingsAsync_UsesAndPersistsWindowsLanguage_WhenLanguageIsInvalid(string language)
+        {
+            var storage = new FakeSettingsStorage();
+            storage.Files[TestPaths.SettingsFilePath] = $$"""
+                {
+                  "language": "{{language}}"
+                }
+                """;
+            var service = CreateService(storage, "ru-KZ");
+
+            await service.LoadSettingsAsync();
+
+            Assert.Equal("ru-RU", service.Settings.Language);
+            Assert.Contains("\"language\": \"ru-RU\"", storage.Writes[TestPaths.SettingsFilePath], StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task LoadSettingsAsync_UsesWindowsLanguage_WhenLanguagePropertyIsMissing()
+        {
+            var storage = new FakeSettingsStorage();
+            storage.Files[TestPaths.SettingsFilePath] = """
+                {
+                  "startMinimized": true
+                }
+                """;
+            var service = CreateService(storage, "fr-CA");
+
+            await service.LoadSettingsAsync();
+
+            Assert.Equal("fr-FR", service.Settings.Language);
+            Assert.Contains("\"language\": \"fr-FR\"", storage.Writes[TestPaths.SettingsFilePath], StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task LoadSettingsAsync_NormalizesAndPersistsSupportedLanguageCasing()
+        {
+            var storage = new FakeSettingsStorage();
+            storage.Files[TestPaths.SettingsFilePath] = """
+                {
+                  "language": "IT-it"
+                }
+                """;
+            var service = CreateService(storage, "ru-RU");
+
+            await service.LoadSettingsAsync();
+
+            Assert.Equal("it-IT", service.Settings.Language);
+            Assert.Contains("\"language\": \"it-IT\"", storage.Writes[TestPaths.SettingsFilePath], StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task ResetToDefaultsAsync_UsesWindowsLanguage()
+        {
+            var storage = new FakeSettingsStorage();
+            var service = CreateService(storage, "de-AT");
+
+            await service.ResetToDefaultsAsync();
+
+            Assert.Equal("de-DE", service.Settings.Language);
+        }
+
+        [Fact]
+        public async Task ImportSettingsAsync_UsesWindowsLanguage_WhenLanguageIsInvalid()
+        {
+            const string ImportPath = "import-settings.json";
+            var storage = new FakeSettingsStorage();
+            storage.Files[ImportPath] = """
+                {
+                  "language": "unsupported"
+                }
+                """;
+            var service = CreateService(storage, "es-MX");
+
+            await service.ImportSettingsAsync(ImportPath);
+
+            Assert.Equal("es-ES", service.Settings.Language);
         }
 
         [Fact]
@@ -210,13 +293,16 @@ namespace ThreadPilot.Core.Tests
             Assert.False(service.Settings.UseCustomTrayIcon);
         }
 
-        private static ApplicationSettingsService CreateService(FakeSettingsStorage storage)
+        private static ApplicationSettingsService CreateService(
+            FakeSettingsStorage storage,
+            string systemUiCultureName = "en-US")
         {
             return new ApplicationSettingsService(
                 NullLogger<ApplicationSettingsService>.Instance,
                 storage,
                 TestPaths.SettingsFilePath,
-                legacySettingsPath: null);
+                legacySettingsPath: null,
+                () => new CultureInfo(systemUiCultureName));
         }
 
         private static class TestPaths

--- a/Tests/ThreadPilot.Core.Tests/DialogThemePolicyTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/DialogThemePolicyTests.cs
@@ -1,0 +1,76 @@
+namespace ThreadPilot.Core.Tests
+{
+    using System.Xml.Linq;
+
+    public sealed class DialogThemePolicyTests
+    {
+        [Fact]
+        public void UnsavedSettingsDialogs_UseLocalizedMessageAndNeutralButtons()
+        {
+            var mainWindow = XDocument.Load(GetRepositoryFilePath("MainWindow.xaml"));
+            var mainOverlay = FindNamedElement(mainWindow, "UnsavedSettingsOverlay");
+            var message = FindNamedElement(mainWindow, "UnsavedSettingsDialogMessage");
+            var settingsWindow = XDocument.Load(GetRepositoryFilePath("Views", "SettingsWindow.xaml"));
+            var settingsOverlay = FindNamedElement(settingsWindow, "UnsavedSettingsOverlay");
+
+            Assert.Equal(
+                "{DynamicResource SettingsWindow_UnsavedDescription}",
+                message.Attribute("Text")?.Value);
+            AssertNeutralButtons(mainOverlay);
+            AssertNeutralButtons(settingsOverlay);
+        }
+
+        [Fact]
+        public void MainWindowMessageOverlays_DoNotUseBlueAccentButtons()
+        {
+            var document = XDocument.Load(GetRepositoryFilePath("MainWindow.xaml"));
+
+            AssertNeutralButtons(FindNamedElement(document, "ElevationWarningOverlay"));
+            AssertNeutralButtons(FindNamedElement(document, "PopupOverlay"));
+        }
+
+        [Theory]
+        [InlineData("FluentDark.xaml", "#FF303030", "#FF4A4A4A")]
+        [InlineData("FluentLight.xaml", "#FFF3F3F3", "#FFDADADA")]
+        public void Theme_StateMessagesUseNeutralSurfaces(string themeFile, string background, string border)
+        {
+            var theme = File.ReadAllText(GetRepositoryFilePath("Themes", themeFile));
+
+            Assert.Contains($"x:Key=\"InfoBackgroundBrush\" Color=\"{background}\"", theme, StringComparison.Ordinal);
+            Assert.Contains($"x:Key=\"SuccessBackgroundBrush\" Color=\"{background}\"", theme, StringComparison.Ordinal);
+            Assert.Contains($"x:Key=\"WarningBackgroundBrush\" Color=\"{background}\"", theme, StringComparison.Ordinal);
+            Assert.Contains($"x:Key=\"ErrorBackgroundBrush\" Color=\"{background}\"", theme, StringComparison.Ordinal);
+            Assert.Contains($"x:Key=\"InfoBorderBrush\" Color=\"{border}\"", theme, StringComparison.Ordinal);
+            Assert.Contains($"x:Key=\"ErrorBorderBrush\" Color=\"{border}\"", theme, StringComparison.Ordinal);
+        }
+
+        private static void AssertNeutralButtons(XElement container)
+        {
+            var buttonBackgrounds = container
+                .Descendants()
+                .Where(element => element.Name.LocalName == "Button")
+                .Select(element => element.Attribute("Background")?.Value)
+                .Where(value => !string.IsNullOrWhiteSpace(value));
+
+            Assert.DoesNotContain(buttonBackgrounds, value => value!.Contains("Accent", StringComparison.Ordinal));
+        }
+
+        private static XElement FindNamedElement(XDocument document, string name)
+        {
+            XNamespace x = "http://schemas.microsoft.com/winfx/2006/xaml";
+            return document.Descendants().Single(element => (string?)element.Attribute(x + "Name") == name);
+        }
+
+        private static string GetRepositoryFilePath(params string[] segments)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "ThreadPilot_1.sln")))
+            {
+                directory = directory.Parent;
+            }
+
+            var root = directory?.FullName ?? throw new InvalidOperationException("Repository root was not found.");
+            return Path.Combine(new[] { root }.Concat(segments).ToArray());
+        }
+    }
+}

--- a/Tests/ThreadPilot.Core.Tests/LocalizationServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/LocalizationServiceTests.cs
@@ -1,13 +1,26 @@
 namespace ThreadPilot.Core.Tests
 {
+    using System.Globalization;
     using System.Reflection;
     using System.Text.RegularExpressions;
     using System.Windows;
+    using System.Xml.Linq;
     using Microsoft.Extensions.Logging.Abstractions;
     using ThreadPilot.Services;
 
     public sealed partial class LocalizationServiceTests
     {
+        private static readonly string[] LocaleCodes =
+        [
+            "en-US",
+            "zh-CN",
+            "it-IT",
+            "fr-FR",
+            "de-DE",
+            "es-ES",
+            "ru-RU",
+        ];
+
         [Fact]
         public void Constructor_DefaultsToEnglish()
         {
@@ -16,14 +29,52 @@ namespace ThreadPilot.Core.Tests
             Assert.Equal("en-US", service.CurrentLanguage);
         }
 
-        [Fact]
-        public void ApplyLanguage_AppliesChinese_WhenSupported()
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("zh-CN")]
+        [InlineData("it-IT")]
+        [InlineData("fr-FR")]
+        [InlineData("de-DE")]
+        [InlineData("es-ES")]
+        [InlineData("ru-RU")]
+        public void ApplyLanguage_AppliesLanguage_WhenSupported(string language)
         {
             var service = CreateService();
 
-            service.ApplyLanguage("zh-CN");
+            service.ApplyLanguage(language);
 
-            Assert.Equal("zh-CN", service.CurrentLanguage);
+            Assert.Equal(language, service.CurrentLanguage);
+        }
+
+        [Theory]
+        [InlineData("EN-us", "en-US")]
+        [InlineData("ZH-cn", "zh-CN")]
+        [InlineData("IT-it", "it-IT")]
+        [InlineData("FR-fr", "fr-FR")]
+        [InlineData("DE-de", "de-DE")]
+        [InlineData("ES-es", "es-ES")]
+        [InlineData("RU-ru", "ru-RU")]
+        public void NormalizeLanguage_ReturnsCanonicalSupportedCode(string input, string expected)
+        {
+            Assert.Equal(expected, LocalizationService.NormalizeLanguage(input));
+        }
+
+        [Theory]
+        [InlineData("en-GB", "en-US")]
+        [InlineData("it-CH", "it-IT")]
+        [InlineData("fr-CA", "fr-FR")]
+        [InlineData("de-AT", "de-DE")]
+        [InlineData("es-MX", "es-ES")]
+        [InlineData("ru-KZ", "ru-RU")]
+        [InlineData("zh-CN", "zh-CN")]
+        [InlineData("zh-SG", "zh-CN")]
+        [InlineData("zh-Hans", "zh-CN")]
+        [InlineData("zh-TW", "en-US")]
+        [InlineData("zh-Hant", "en-US")]
+        [InlineData("pt-BR", "en-US")]
+        public void ResolveSystemLanguage_MapsSupportedLanguageFamilies(string cultureName, string expected)
+        {
+            Assert.Equal(expected, LocalizationService.ResolveSystemLanguage(new CultureInfo(cultureName)));
         }
 
         [Fact]
@@ -85,7 +136,7 @@ namespace ThreadPilot.Core.Tests
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        [InlineData("fr-FR")]
+        [InlineData("pt-BR")]
         [InlineData("zh")]
         public void ApplyLanguage_FallsBackToEnglish_WhenLanguageIsInvalid(string? language)
         {
@@ -133,19 +184,25 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
-        public void LocaleFiles_DefineEnglishDefaultAndOptionalChineseLanguageLabels()
+        public void LocaleFiles_DefineEnglishDefaultAndAllLanguageLabels()
         {
             var root = FindRepositoryRoot();
             var english = File.ReadAllText(Path.Combine(root, "Locales", "en-US.xaml"));
-            var chinese = File.ReadAllText(Path.Combine(root, "Locales", "zh-CN.xaml"));
             var appXaml = File.ReadAllText(Path.Combine(root, "App.xaml"));
 
             Assert.Contains("Source=\"Locales/en-US.xaml\"", appXaml, StringComparison.Ordinal);
-            Assert.DoesNotContain("Source=\"Locales/zh-CN.xaml\"", appXaml, StringComparison.Ordinal);
+            foreach (var localeCode in LocaleCodes.Where(code => code != "en-US"))
+            {
+                Assert.DoesNotContain($"Source=\"Locales/{localeCode}.xaml\"", appXaml, StringComparison.Ordinal);
+            }
+
             Assert.Contains("x:Key=\"SettingsView_LanguageEnUs\"", english, StringComparison.Ordinal);
             Assert.Contains("x:Key=\"SettingsView_LanguageZhCn\"", english, StringComparison.Ordinal);
-            Assert.Contains("x:Key=\"SettingsView_LanguageEnUs\"", chinese, StringComparison.Ordinal);
-            Assert.Contains("x:Key=\"SettingsView_LanguageZhCn\"", chinese, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"SettingsView_LanguageItIt\"", english, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"SettingsView_LanguageFrFr\"", english, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"SettingsView_LanguageDeDe\"", english, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"SettingsView_LanguageEsEs\"", english, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"SettingsView_LanguageRuRu\"", english, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -153,10 +210,59 @@ namespace ThreadPilot.Core.Tests
         {
             var root = FindRepositoryRoot();
             var english = ReadLocaleKeys(Path.Combine(root, "Locales", "en-US.xaml"));
-            var chinese = ReadLocaleKeys(Path.Combine(root, "Locales", "zh-CN.xaml"));
+            foreach (var localeCode in LocaleCodes.Where(code => code != "en-US"))
+            {
+                var localized = ReadLocaleKeys(Path.Combine(root, "Locales", $"{localeCode}.xaml"));
+                Assert.Empty(english.Except(localized).Order(StringComparer.Ordinal));
+                Assert.Empty(localized.Except(english).Order(StringComparer.Ordinal));
+            }
+        }
 
-            Assert.Empty(english.Except(chinese).Order(StringComparer.Ordinal));
-            Assert.Empty(chinese.Except(english).Order(StringComparer.Ordinal));
+        [Fact]
+        public void LocaleFiles_DefineUniqueNonEmptyValuesAndMatchingFormatPlaceholders()
+        {
+            var root = FindRepositoryRoot();
+            var english = ReadLocaleEntries(Path.Combine(root, "Locales", "en-US.xaml"));
+
+            foreach (var localeCode in LocaleCodes)
+            {
+                var path = Path.Combine(root, "Locales", $"{localeCode}.xaml");
+                var matches = LocaleStringRegex().Matches(File.ReadAllText(path));
+                var localized = ReadLocaleEntries(path);
+
+                Assert.Equal(matches.Count, localized.Count);
+                Assert.DoesNotContain(localized, entry => string.IsNullOrWhiteSpace(entry.Value));
+                foreach (var key in english.Keys)
+                {
+                    Assert.Equal(ReadFormatPlaceholders(english[key]), ReadFormatPlaceholders(localized[key]));
+                }
+            }
+        }
+
+        [Fact]
+        public void LocaleFiles_AreWellFormedResourceDictionaries()
+        {
+            var root = FindRepositoryRoot();
+            foreach (var localeCode in LocaleCodes)
+            {
+                var document = XDocument.Load(Path.Combine(root, "Locales", $"{localeCode}.xaml"));
+
+                Assert.Equal("ResourceDictionary", document.Root?.Name.LocalName);
+            }
+        }
+
+        [Fact]
+        public void SettingsView_LanguageTagsMatchSupportedLanguageRegistry()
+        {
+            var root = FindRepositoryRoot();
+            var settingsView = File.ReadAllText(Path.Combine(root, "Views", "SettingsView.xaml"));
+            var tags = Regex.Matches(settingsView, "Tag=\"(?<code>[a-z]{2}-[A-Z]{2})\"", RegexOptions.CultureInvariant)
+                .Select(match => match.Groups["code"].Value)
+                .ToHashSet(StringComparer.Ordinal);
+
+            Assert.Equal(
+                LocalizationService.SupportedLanguages.Order(StringComparer.Ordinal),
+                tags.Order(StringComparer.Ordinal));
         }
 
         [Fact]
@@ -260,6 +366,24 @@ namespace ThreadPilot.Core.Tests
             return keys;
         }
 
+        private static Dictionary<string, string> ReadLocaleEntries(string path)
+        {
+            return LocaleStringRegex().Matches(File.ReadAllText(path))
+                .ToDictionary(
+                    match => match.Groups["key"].Value,
+                    match => match.Groups["value"].Value,
+                    StringComparer.Ordinal);
+        }
+
+        private static string[] ReadFormatPlaceholders(string value)
+        {
+            return Regex.Matches(value, "\\{\\d+(?:[^}]*)\\}", RegexOptions.CultureInvariant)
+                .Select(match => match.Value)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+        }
+
         private static bool IsAllowedHardcodedUiValue(string attribute, string value)
         {
             if (value.Contains('{', StringComparison.Ordinal) ||
@@ -298,5 +422,8 @@ namespace ThreadPilot.Core.Tests
 
         [GeneratedRegex("(?<attribute>Text|Content|Header|Title|ToolTip|PlaceholderText|AutomationProperties\\.Name|AutomationProperties\\.HelpText)=\"(?<value>[^\"]*[A-Za-z][^\"]*)\"", RegexOptions.CultureInvariant)]
         private static partial Regex HardcodedUiAttributeRegex();
+
+        [GeneratedRegex("<sys:String x:Key=\"(?<key>[^\"]+)\">(?<value>.*?)</sys:String>", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+        private static partial Regex LocaleStringRegex();
     }
 }

--- a/Tests/ThreadPilot.Core.Tests/SettingsViewModelThemeTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/SettingsViewModelThemeTests.cs
@@ -4,6 +4,7 @@ namespace ThreadPilot.Core.Tests
     using CommunityToolkit.Mvvm.Input;
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
+    using ThreadPilot.Helpers;
     using ThreadPilot.Models;
     using ThreadPilot.Services;
     using ThreadPilot.ViewModels;
@@ -152,6 +153,28 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
+        public async Task NavigationPrompt_SavePersistsPendingSettingsBeforeNavigating()
+        {
+            var harness = new Harness();
+            harness.SettingsService
+                .Setup(service => service.UpdateSettingsAsync(It.IsAny<ApplicationSettingsModel>()))
+                .Returns(Task.CompletedTask);
+            var viewModel = harness.CreateViewModel();
+            viewModel.Settings.Language = "it-IT";
+
+            var canNavigate = await NavigationBehavior.EnsureCanNavigateAsync(
+                "Process",
+                viewModel,
+                () => Task.FromResult(System.Windows.MessageBoxResult.Yes));
+
+            Assert.True(canNavigate);
+            Assert.False(viewModel.HasUnsavedChanges);
+            harness.SettingsService.Verify(
+                service => service.UpdateSettingsAsync(It.Is<ApplicationSettingsModel>(settings => settings.Language == "it-IT")),
+                Times.Once);
+        }
+
+        [Fact]
         public void SettingsView_ExposesPersistentRuleAutoApplyToggle()
         {
             var settingsViewPath = Path.Combine(
@@ -173,7 +196,7 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
-        public void SettingsView_ExposesOptionalChineseLanguageSelection()
+        public void SettingsView_ExposesAllSupportedLanguageSelections()
         {
             var settingsViewPath = Path.Combine(
                 AppContext.BaseDirectory,
@@ -187,8 +210,10 @@ namespace ThreadPilot.Core.Tests
             var serialized = File.ReadAllText(settingsViewPath);
 
             Assert.Contains("SelectedValue=\"{Binding Settings.Language}\"", serialized, StringComparison.Ordinal);
-            Assert.Contains("Tag=\"en-US\"", serialized, StringComparison.Ordinal);
-            Assert.Contains("Tag=\"zh-CN\"", serialized, StringComparison.Ordinal);
+            foreach (var language in new[] { "en-US", "zh-CN", "it-IT", "fr-FR", "de-DE", "es-ES", "ru-RU" })
+            {
+                Assert.Contains($"Tag=\"{language}\"", serialized, StringComparison.Ordinal);
+            }
         }
 
         private sealed class Harness

--- a/Themes/FluentDark.xaml
+++ b/Themes/FluentDark.xaml
@@ -52,7 +52,7 @@
 
     <SolidColorBrush x:Key="BorderBrush" Color="{StaticResource ControlStrokeColorDefault}"/>
     <SolidColorBrush x:Key="BorderSubtleBrush" Color="{StaticResource ControlStrokeColorSecondary}"/>
-    <SolidColorBrush x:Key="OverlayBrush" Color="#99020617"/>
+    <SolidColorBrush x:Key="OverlayBrush" Color="#99000000"/>
     <SolidColorBrush x:Key="SpinnerTrackBrush" Color="{StaticResource ControlStrokeColorDefault}"/>
 
     <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource ControlFillColorDefault}"/>
@@ -76,21 +76,21 @@
     <SolidColorBrush x:Key="StatusPillBackgroundBrush" Color="{StaticResource ControlFillColorSecondary}"/>
     <SolidColorBrush x:Key="StatusPillBorderBrush" Color="{StaticResource ControlStrokeColorDefault}"/>
     
-    <!-- State Colors (system-derived, soft contrast) -->
-    <SolidColorBrush x:Key="InfoBackgroundBrush" Color="#FF243241"/>
-    <SolidColorBrush x:Key="InfoBorderBrush" Color="#FF36516B"/>
-    <SolidColorBrush x:Key="InfoTextBrush" Color="#FF8ACDFF"/>
+    <!-- Neutral state surfaces with semantic text only where it aids recognition. -->
+    <SolidColorBrush x:Key="InfoBackgroundBrush" Color="#FF303030"/>
+    <SolidColorBrush x:Key="InfoBorderBrush" Color="#FF4A4A4A"/>
+    <SolidColorBrush x:Key="InfoTextBrush" Color="{StaticResource TextFillColorPrimary}"/>
 
-    <SolidColorBrush x:Key="SuccessBackgroundBrush" Color="#FF26372A"/>
-    <SolidColorBrush x:Key="SuccessBorderBrush" Color="#FF34543B"/>
+    <SolidColorBrush x:Key="SuccessBackgroundBrush" Color="#FF303030"/>
+    <SolidColorBrush x:Key="SuccessBorderBrush" Color="#FF4A4A4A"/>
     <SolidColorBrush x:Key="SuccessTextBrush" Color="#FF6CCB7F"/>
 
-    <SolidColorBrush x:Key="WarningBackgroundBrush" Color="#FF3A3120"/>
-    <SolidColorBrush x:Key="WarningBorderBrush" Color="#FF5A4A24"/>
+    <SolidColorBrush x:Key="WarningBackgroundBrush" Color="#FF303030"/>
+    <SolidColorBrush x:Key="WarningBorderBrush" Color="#FF4A4A4A"/>
     <SolidColorBrush x:Key="WarningTextBrush" Color="#FFFFD66B"/>
 
-    <SolidColorBrush x:Key="ErrorBackgroundBrush" Color="#FF3B2426"/>
-    <SolidColorBrush x:Key="ErrorBorderBrush" Color="#FF623236"/>
+    <SolidColorBrush x:Key="ErrorBackgroundBrush" Color="#FF303030"/>
+    <SolidColorBrush x:Key="ErrorBorderBrush" Color="#FF4A4A4A"/>
     <SolidColorBrush x:Key="ErrorTextBrush" Color="#FFFF8A8A"/>
 
     <SolidColorBrush x:Key="SoftSelectionBackgroundBrush" Color="{StaticResource SystemAccentColorPrimary}" Opacity="0.16"/>

--- a/Themes/FluentLight.xaml
+++ b/Themes/FluentLight.xaml
@@ -76,21 +76,21 @@
     <SolidColorBrush x:Key="StatusPillBackgroundBrush" Color="{StaticResource ControlFillColorSecondary}"/>
     <SolidColorBrush x:Key="StatusPillBorderBrush" Color="{StaticResource ControlStrokeColorDefault}"/>
     
-    <!-- State Colors (system-derived, soft contrast) -->
-    <SolidColorBrush x:Key="InfoBackgroundBrush" Color="#FFEFF6FC"/>
-    <SolidColorBrush x:Key="InfoBorderBrush" Color="#FFCFE4F7"/>
-    <SolidColorBrush x:Key="InfoTextBrush" Color="#FF005A9E"/>
+    <!-- Neutral state surfaces with semantic text only where it aids recognition. -->
+    <SolidColorBrush x:Key="InfoBackgroundBrush" Color="#FFF3F3F3"/>
+    <SolidColorBrush x:Key="InfoBorderBrush" Color="#FFDADADA"/>
+    <SolidColorBrush x:Key="InfoTextBrush" Color="{StaticResource TextFillColorPrimary}"/>
 
-    <SolidColorBrush x:Key="SuccessBackgroundBrush" Color="#FFEAF6ED"/>
-    <SolidColorBrush x:Key="SuccessBorderBrush" Color="#FFC8E6D0"/>
+    <SolidColorBrush x:Key="SuccessBackgroundBrush" Color="#FFF3F3F3"/>
+    <SolidColorBrush x:Key="SuccessBorderBrush" Color="#FFDADADA"/>
     <SolidColorBrush x:Key="SuccessTextBrush" Color="#FF0F6C2F"/>
 
-    <SolidColorBrush x:Key="WarningBackgroundBrush" Color="#FFFFF4CE"/>
-    <SolidColorBrush x:Key="WarningBorderBrush" Color="#FFE5C365"/>
+    <SolidColorBrush x:Key="WarningBackgroundBrush" Color="#FFF3F3F3"/>
+    <SolidColorBrush x:Key="WarningBorderBrush" Color="#FFDADADA"/>
     <SolidColorBrush x:Key="WarningTextBrush" Color="#FF7A4F00"/>
 
-    <SolidColorBrush x:Key="ErrorBackgroundBrush" Color="#FFFDE7E9"/>
-    <SolidColorBrush x:Key="ErrorBorderBrush" Color="#FFF3B7BE"/>
+    <SolidColorBrush x:Key="ErrorBackgroundBrush" Color="#FFF3F3F3"/>
+    <SolidColorBrush x:Key="ErrorBorderBrush" Color="#FFDADADA"/>
     <SolidColorBrush x:Key="ErrorTextBrush" Color="#FFC42B1C"/>
 
     <SolidColorBrush x:Key="SoftSelectionBackgroundBrush" Color="{StaticResource SystemAccentColorPrimary}" Opacity="0.12"/>

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -228,9 +228,17 @@ namespace ThreadPilot.ViewModels
             {
                 this.localizationService.ApplyLanguage(normalizedLanguage);
                 this.Settings.Language = normalizedLanguage;
-                var languageName = normalizedLanguage == LocalizationService.SimplifiedChineseLanguage
-                    ? this.GetLocalizedString("Settings_LanguageSimplifiedChinese", "Simplified Chinese")
-                    : this.GetLocalizedString("Settings_LanguageEnglish", "English");
+                var (languageNameKey, languageNameFallback) = normalizedLanguage switch
+                {
+                    LocalizationService.SimplifiedChineseLanguage => ("Settings_LanguageSimplifiedChinese", "Simplified Chinese"),
+                    LocalizationService.ItalianLanguage => ("Settings_LanguageItalian", "Italian"),
+                    LocalizationService.FrenchLanguage => ("Settings_LanguageFrench", "French"),
+                    LocalizationService.GermanLanguage => ("Settings_LanguageGerman", "German"),
+                    LocalizationService.SpanishLanguage => ("Settings_LanguageSpanish", "Spanish"),
+                    LocalizationService.RussianLanguage => ("Settings_LanguageRussian", "Russian"),
+                    _ => ("Settings_LanguageEnglish", "English"),
+                };
+                var languageName = this.GetLocalizedString(languageNameKey, languageNameFallback);
                 this.StatusMessage = this.GetLocalizedString("Settings_StatusLanguageChangedFormat", "Language changed to {0}.", languageName);
 
                 if (logUserAction)

--- a/Views/SettingsView.xaml
+++ b/Views/SettingsView.xaml
@@ -212,6 +212,11 @@
                             <ComboBox SelectedValue="{Binding Settings.Language}" SelectedValuePath="Tag" Margin="0,0,0,5">
                                 <ComboBoxItem Content="{DynamicResource SettingsView_LanguageEnUs}" Tag="en-US"/>
                                 <ComboBoxItem Content="{DynamicResource SettingsView_LanguageZhCn}" Tag="zh-CN"/>
+                                <ComboBoxItem Content="{DynamicResource SettingsView_LanguageItIt}" Tag="it-IT"/>
+                                <ComboBoxItem Content="{DynamicResource SettingsView_LanguageFrFr}" Tag="fr-FR"/>
+                                <ComboBoxItem Content="{DynamicResource SettingsView_LanguageDeDe}" Tag="de-DE"/>
+                                <ComboBoxItem Content="{DynamicResource SettingsView_LanguageEsEs}" Tag="es-ES"/>
+                                <ComboBoxItem Content="{DynamicResource SettingsView_LanguageRuRu}" Tag="ru-RU"/>
                             </ComboBox>
                             <TextBlock Text="{DynamicResource SettingsView_LanguageDescription}"
                                        Style="{StaticResource DescriptionStyle}"

--- a/Views/SettingsWindow.xaml
+++ b/Views/SettingsWindow.xaml
@@ -63,8 +63,8 @@
                                 Margin="0,0,10,0"/>
                         <Button Content="{DynamicResource SettingsWindow_Save}"
                                 Click="UnsavedSettingsSave_Click"
-                                Background="{DynamicResource AccentFillColorDefaultBrush}"
-                                Foreground="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
+                                Background="{DynamicResource ControlFillColorTertiaryBrush}"
+                                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                 Padding="16,8"/>
                     </StackPanel>
                 </StackPanel>


### PR DESCRIPTION
## Summary

- add complete Italian, French, German, Spanish, and Russian resource dictionaries alongside English and Simplified Chinese
- detect the initial language from Windows, normalize regional variants, and keep English as the safe fallback
- persist language changes reliably, including the Save action in the unsaved-settings dialog
- use neutral Windows 11-style surfaces for dialogs and status messages

## Validation

- 625/625 Release tests passed
- localization dictionaries have matching keys and format placeholders
- `git diff --check` passed