### PR TITLE
Prepare v1.5.0 release

### DIFF
--- a/Installer/Installer.iss
+++ b/Installer/Installer.iss
@@ -5,7 +5,7 @@
 #define MyAppPublisher "ThreadPilot"
 #define MyAppURL "https://github.com/"
 #define MyAppExeName "ThreadPilot.exe"
-#define MyAppVersion "1.4.4"
+#define MyAppVersion "1.5.0"
 
 #ifndef MyWizardStyle
   #define MyWizardStyle "modern dynamic windows11"

--- a/Installer/ThreadPilot.wxs
+++ b/Installer/ThreadPilot.wxs
@@ -7,7 +7,7 @@
   <Package
       Name="ThreadPilot"
       Manufacturer="Prime Build"
-      Version="1.4.4.0"
+      Version="1.5.0.0"
       UpgradeCode="PUT-GENERATED-UPGRADE-CODE-HERE"
       Language="1033">
     <SummaryInformation Description="ThreadPilot MSI template" />

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -11,7 +11,7 @@
 #endif
 
 #ifndef MyAppVersion
-	#define MyAppVersion "1.4.4"
+	#define MyAppVersion "1.5.0"
 #endif
 
 #ifndef MyAppSourceDir

--- a/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
@@ -4,8 +4,8 @@ namespace ThreadPilot.Core.Tests
 
     public sealed partial class PackagingMetadataTests
     {
-        private const string ReleaseVersion = "1.4.4";
-        private const string ReleaseAssemblyVersion = "1.4.4.0";
+        private const string ReleaseVersion = "1.5.0";
+        private const string ReleaseAssemblyVersion = "1.5.0.0";
 
         [Fact]
         public void InnoInstallers_UseStableDisplayNameAndSeparateVersionMetadata()
@@ -99,7 +99,7 @@ namespace ThreadPilot.Core.Tests
             throw new InvalidOperationException("Repository root could not be located.");
         }
 
-        [GeneratedRegex("#define MyAppVersion \"1\\.4\\.4\"", RegexOptions.CultureInvariant)]
+        [GeneratedRegex("#define MyAppVersion \"1\\.5\\.0\"", RegexOptions.CultureInvariant)]
         private static partial Regex MyAppVersionRegex();
     }
 }

--- a/ThreadPilot.csproj
+++ b/ThreadPilot.csproj
@@ -16,10 +16,10 @@
     <TrimMode>link</TrimMode>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1998;CS0067;CS0414;WFAC010;IL3000;MVVMTK0034</NoWarn>
-    <Version>1.4.4</Version>
-    <AssemblyVersion>1.4.4.0</AssemblyVersion>
-    <FileVersion>1.4.4.0</FileVersion>
-    <InformationalVersion>1.4.4</InformationalVersion>
+    <Version>1.5.0</Version>
+    <AssemblyVersion>1.5.0.0</AssemblyVersion>
+    <FileVersion>1.5.0.0</FileVersion>
+    <InformationalVersion>1.5.0</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.4.4.0" name="ThreadPilot.app"/>
+  <assemblyIdentity version="1.5.0.0" name="ThreadPilot.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.4.4",
+    [string]$Version = "1.5.0",
     [string]$Configuration = "Release",
     [switch]$SkipPublish
 )

--- a/build/build-release.ps1
+++ b/build/build-release.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.4.4",
+    [string]$Version = "1.5.0",
     [string]$Configuration = "Release",
     [string]$Runtime = "win-x64"
 )

--- a/build/package-release-zips.ps1
+++ b/build/package-release-zips.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.4.4"
+    [string]$Version = "1.5.0"
 )
 
 $ErrorActionPreference = "Stop"

--- a/chocolatey/threadpilot.nuspec
+++ b/chocolatey/threadpilot.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>threadpilot</id>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <title>ThreadPilot</title>
     <authors>Prime Build</authors>
     <projectUrl>https://github.com/PrimeBuild-pc/ThreadPilot</projectUrl>
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Advanced Windows process and power plan manager with rules automation and performance controls.</description>
     <summary>ThreadPilot process and power plan manager.</summary>
-    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.4.4</releaseNotes>
+    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.5.0</releaseNotes>
     <tags>threadpilot process powerplan performance windows</tags>
   </metadata>
   <files>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project are documented in this file.
 
+## v1.5.0 - Languages, Windows 11 polish, and one-click updates
+
+### Added
+
+- Added complete Italian, French, German, Spanish, and Russian localization.
+- Added Windows language detection with safe English fallback.
+- Added one-click in-app updates: ThreadPilot checks on every enabled startup, asks for consent, verifies and installs the update, then relaunches automatically.
+
+### Changed
+
+- System tweak state is detected at every startup and verified again after changes.
+- Core Parking and C-State detection now use native Windows power APIs instead of localized command output.
+- Updated tweak controls, dialogs, and selected states with more neutral Windows 11 styling.
+- Removed the unsupported HPET performance toggle and corrected the MMCSS Games scheduling tweak.
+
+### Fixed
+
+- Saving from the unsaved-settings dialog now persists language and other pending settings correctly.
+- In-app upgrades preserve the user's `%AppData%` settings and no longer require a manual installer download or app restart.
+
 ## v1.4.4 - Runtime efficiency
 
 ### Performance

--- a/docs/release/RELEASE_NOTES.md
+++ b/docs/release/RELEASE_NOTES.md
@@ -1,38 +1,20 @@
-## ThreadPilot v1.4.4
+## ThreadPilot v1.5.0
 
-Patch release focused on reducing ThreadPilot's foreground and background runtime overhead while preserving process automation and persistent CPU-priority verification.
+ThreadPilot 1.5.0 adds five languages, refines the Windows 11 experience, and makes future updates one-click.
 
-### Measured improvements
+### Highlights
 
-Compared with the official v1.4.3 build on the same system and using the same Release profile:
+- Italian, French, German, Spanish, and Russian translations, with automatic Windows language detection.
+- One-click updates checked at every enabled startup: consent once, then ThreadPilot downloads, verifies, installs, and restarts automatically.
+- Reliable startup detection and persistence for supported Windows system tweaks.
+- Native Windows power API handling for Core Parking and C-States.
+- More neutral Windows 11 styling for tweaks, dialogs, and selected items.
+- Fixed saving pending settings from the navigation/close confirmation dialog.
 
-- **Approximately 80-100% lower background idle CPU** in measured tray scenarios, reaching 0% in the final idle sample.
-- **Approximately 8% lower CPU overhead during process churn** with 80 short-lived processes.
-- **Approximately 4-5% lower hidden working-set memory**.
-- **Approximately 12-13% lower peak handle usage** while hidden.
-- **Approximately 85% fewer external command launches during visible startup**, reduced from 27 to 4.
-
-Results vary by hardware, Windows configuration, active page, and workload. The Process page remains intentionally more active while visible because it refreshes live process information.
-
-### Runtime changes
-
-- Cached persistent-rule snapshots in memory and pre-matched process starts before expensive enrichment.
-- Disposed process handles consistently and cleared PID-scoped caches on process exit.
-- Deferred initialization of inactive Power Plans, Rules, Settings, Tweaks, and Logs pages.
-- Reused the process monitor's initial snapshot and PID/start-time-validated static process metadata.
-- Parsed the active plan from a single `powercfg /list` call and limited periodic power-plan refresh to the visible Power Plans page.
-- Suspended Log Viewer collection updates while hidden and changed log flushing to one-shot scheduling.
-- Added WMI recovery backoff while preserving fallback polling reliability.
-
-### Compatibility and safety
-
-- Persistent rules, process start/stop tracking, and lazy diagnostics remain covered by regression tests.
-- CPU-priority verification and the bounded retry introduced for issue #32 are unchanged.
-- No default ThreadPilot affinity limit was enabled.
+Existing settings, profiles, masks, rules, imported power plans, and logs are preserved during upgrades.
 
 ### Validation
 
-- Release build completed with zero warnings and zero errors.
-- All 581 automated tests passed before release preparation.
-- CI and CodeQL passed for both performance pull requests.
-- NuGet dependency audit found no known vulnerable packages.
+- 634 automated Release tests passed before release preparation.
+- CI and CodeQL passed for both feature pull requests.
+- Release single-file publish, smoke test, and Inno Setup compilation passed.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=threadpilot
 sonar.projectName=ThreadPilot
-sonar.projectVersion=1.4.4
+sonar.projectVersion=1.5.0
 
 sonar.sourceEncoding=UTF-8
 sonar.sources=.


### PR DESCRIPTION
## Summary

- bump all application, assembly, installer, packaging, Chocolatey, and analysis metadata to `1.5.0`
- add the v1.5.0 changelog entry and concise release notes
- document language support, Windows 11 tweak corrections, one-click updates, and settings preservation

## Validation

- 634/634 Release tests passed
- single-file Release publish passed
- `ThreadPilot.exe --smoke-test` exited 0
- Inno Setup produced `ThreadPilot_v1.5.0_Setup.exe`
- local installer SHA256: `70670B552BD23706EBE58956B77148A8DA10C6084D9320C0FB7921A3954615F1`
- local installer is unsigned; CI signing remains optional and uses repository secrets when configured