### PR TITLE
Fix duplicated process monitoring configuration

### DIFF
--- a/Configuration/ProcessPowerPlanAssociations.json
+++ b/Configuration/ProcessPowerPlanAssociations.json
@@ -1,9 +1,6 @@
 {
   "DefaultPowerPlanGuid": "",
   "DefaultPowerPlanName": "",
-  "IsEventBasedMonitoringEnabled": true,
-  "IsFallbackPollingEnabled": true,
-  "PollingIntervalSeconds": 5,
   "PreventDuplicatePowerPlanChanges": true,
   "PowerPlanChangeDelayMs": 250,
   "Associations": [

--- a/Models/ProcessMonitorConfiguration.cs
+++ b/Models/ProcessMonitorConfiguration.cs
@@ -13,15 +13,6 @@ namespace ThreadPilot.Models
         private string defaultPowerPlanName = string.Empty;
 
         [ObservableProperty]
-        private bool isEventBasedMonitoringEnabled = true;
-
-        [ObservableProperty]
-        private bool isFallbackPollingEnabled = true;
-
-        [ObservableProperty]
-        private int pollingIntervalSeconds = 5;
-
-        [ObservableProperty]
         private bool preventDuplicatePowerPlanChanges = true;
 
         [ObservableProperty]
@@ -94,11 +85,6 @@ namespace ThreadPilot.Models
         public List<string> Validate()
         {
             var errors = new List<string>();
-
-            if (this.PollingIntervalSeconds < 1)
-            {
-                errors.Add("Polling interval must be at least 1 second");
-            }
 
             if (this.PowerPlanChangeDelayMs < 0)
             {

--- a/Tests/ThreadPilot.Core.Tests/ProcessMonitorConfigurationTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessMonitorConfigurationTests.cs
@@ -1,0 +1,38 @@
+namespace ThreadPilot.Core.Tests
+{
+    using System.Text.Json;
+    using ThreadPilot.Models;
+
+    public sealed class ProcessMonitorConfigurationTests
+    {
+        [Fact]
+        public void LegacyMonitoringFields_AreIgnoredWhenConfigurationIsDeserialized()
+        {
+            const string json = """
+                {
+                  "isEventBasedMonitoringEnabled": false,
+                  "isFallbackPollingEnabled": false,
+                  "pollingIntervalSeconds": 1,
+                  "preventDuplicatePowerPlanChanges": false
+                }
+                """;
+
+            var configuration = JsonSerializer.Deserialize<ProcessMonitorConfiguration>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+            });
+
+            Assert.NotNull(configuration);
+            Assert.False(configuration.PreventDuplicatePowerPlanChanges);
+        }
+
+        [Theory]
+        [InlineData("IsEventBasedMonitoringEnabled")]
+        [InlineData("IsFallbackPollingEnabled")]
+        [InlineData("PollingIntervalSeconds")]
+        public void DoesNotExposeDuplicateMonitoringProperties(string propertyName)
+        {
+            Assert.Null(typeof(ProcessMonitorConfiguration).GetProperty(propertyName));
+        }
+    }
+}

--- a/Tests/ThreadPilot.Core.Tests/ProcessMonitorServiceSettingsTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessMonitorServiceSettingsTests.cs
@@ -1,0 +1,69 @@
+namespace ThreadPilot.Core.Tests
+{
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Moq;
+    using ThreadPilot.Models;
+    using ThreadPilot.Services;
+
+    public sealed class ProcessMonitorServiceSettingsTests
+    {
+        [Fact]
+        public async Task StartMonitoringAsync_WhenWmiDisabled_DoesNotReportWmiAsAvailable()
+        {
+            using var monitor = CreateMonitor(new ApplicationSettingsModel
+            {
+                EnableWmiMonitoring = false,
+                EnableFallbackPolling = false,
+            });
+
+            await monitor.StartMonitoringAsync();
+
+            Assert.False(monitor.IsWmiAvailable);
+        }
+
+        [Fact]
+        public async Task StartMonitoringAsync_WhenFallbackDisabled_DoesNotActivateFallbackWhenWmiIsDisabled()
+        {
+            using var monitor = CreateMonitor(new ApplicationSettingsModel
+            {
+                EnableWmiMonitoring = false,
+                EnableFallbackPolling = false,
+            });
+
+            await monitor.StartMonitoringAsync();
+
+            Assert.False(monitor.IsFallbackPollingActive);
+        }
+
+        [Fact]
+        public async Task StartMonitoringAsync_UsesFallbackPollingIntervalFromApplicationSettings()
+        {
+            using var monitor = CreateMonitor(new ApplicationSettingsModel
+            {
+                EnableWmiMonitoring = false,
+                EnableFallbackPolling = true,
+                FallbackPollingIntervalMs = 12345,
+            });
+            var messages = new List<string?>();
+            monitor.MonitoringStatusChanged += (_, status) => messages.Add(status.StatusMessage);
+
+            await monitor.StartMonitoringAsync();
+
+            Assert.True(monitor.IsFallbackPollingActive);
+            Assert.Contains("Fallback polling started (interval: 12345ms)", messages);
+        }
+
+        private static ProcessMonitorService CreateMonitor(ApplicationSettingsModel settings)
+        {
+            var processService = new Mock<IProcessService>(MockBehavior.Strict);
+            processService.Setup(service => service.GetProcessesAsync())
+                .ReturnsAsync(new System.Collections.ObjectModel.ObservableCollection<ProcessModel>());
+            var settingsService = new Mock<IApplicationSettingsService>(MockBehavior.Strict);
+            settingsService.SetupGet(service => service.Settings).Returns(settings);
+            return new ProcessMonitorService(
+                processService.Object,
+                settingsService.Object,
+                NullLogger<ProcessMonitorService>.Instance);
+        }
+    }
+}

--- a/ViewModels/ProcessPowerPlanAssociationViewModel.cs
+++ b/ViewModels/ProcessPowerPlanAssociationViewModel.cs
@@ -90,18 +90,6 @@ namespace ThreadPilot.ViewModels
         private PowerPlanModel? defaultPowerPlan;
 
         [ObservableProperty]
-        private bool isMonitoringEnabled = true;
-
-        [ObservableProperty]
-        private bool isEventBasedMonitoringEnabled = true;
-
-        [ObservableProperty]
-        private bool isFallbackPollingEnabled = true;
-
-        [ObservableProperty]
-        private int pollingIntervalSeconds = 5;
-
-        [ObservableProperty]
         private bool preventDuplicatePowerPlanChanges = true;
 
         [ObservableProperty]
@@ -182,9 +170,6 @@ namespace ThreadPilot.ViewModels
 
                 // Load configuration settings
                 var config = this.associationService.Configuration;
-                this.IsEventBasedMonitoringEnabled = config.IsEventBasedMonitoringEnabled;
-                this.IsFallbackPollingEnabled = config.IsFallbackPollingEnabled;
-                this.PollingIntervalSeconds = config.PollingIntervalSeconds;
                 this.PreventDuplicatePowerPlanChanges = config.PreventDuplicatePowerPlanChanges;
                 this.PowerPlanChangeDelayMs = config.PowerPlanChangeDelayMs;
 
@@ -391,9 +376,6 @@ namespace ThreadPilot.ViewModels
 
                 // Update configuration with current settings
                 var config = this.associationService.Configuration;
-                config.IsEventBasedMonitoringEnabled = this.IsEventBasedMonitoringEnabled;
-                config.IsFallbackPollingEnabled = this.IsFallbackPollingEnabled;
-                config.PollingIntervalSeconds = this.PollingIntervalSeconds;
                 config.PreventDuplicatePowerPlanChanges = this.PreventDuplicatePowerPlanChanges;
                 config.PowerPlanChangeDelayMs = this.PowerPlanChangeDelayMs;
 

--- a/Views/ProcessPowerPlanAssociationView.xaml
+++ b/Views/ProcessPowerPlanAssociationView.xaml
@@ -325,21 +325,6 @@
                         <!-- Automation Monitoring Settings -->
                         <GroupBox Header="{DynamicResource ProcessPowerPlanAssociationView_SettingsTitle}" Margin="0,0,0,15">
                             <StackPanel>
-                                <CheckBox Content="{DynamicResource ProcessPowerPlanAssociationView_EnableWmi}"
-                                         IsChecked="{Binding IsEventBasedMonitoringEnabled}"
-                                         Margin="0,0,0,10"/>
-
-                                <CheckBox Content="{DynamicResource ProcessPowerPlanAssociationView_EnableFallback}"
-                                         IsChecked="{Binding IsFallbackPollingEnabled}"
-                                         Margin="0,0,0,10"/>
-
-                                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                                    <TextBlock Text="{DynamicResource ProcessPowerPlanAssociationView_PollingInterval}"
-                                              VerticalAlignment="Center" Margin="0,0,10,0"/>
-                                    <TextBox Text="{Binding PollingIntervalSeconds}"
-                                            Width="60" Padding="5"/>
-                                </StackPanel>
-
                                 <CheckBox Content="{DynamicResource ProcessPowerPlanAssociationView_PreventDuplicates}"
                                          IsChecked="{Binding PreventDuplicatePowerPlanChanges}"
                                          Margin="0,0,0,10"/>


### PR DESCRIPTION
## Summary

Process monitoring had two configuration sources: the application settings used by `ProcessMonitorService`, and unused WMI/fallback/polling fields in Rules & Automation. The latter could be saved without changing runtime behavior.

This PR removes the unused Rules & Automation controls and fields for event-based/WMI monitoring, fallback polling, and polling interval. Application settings remain the single runtime source for `EnableWmiMonitoring`, `EnableFallbackPolling`, and `FallbackPollingIntervalMs`.

## Compatibility

Older `ProcessPowerPlanAssociations.json` files continue to load: `System.Text.Json` ignores the removed unknown fields. They are not rewritten at load time; those obsolete fields disappear only on a later normal save.

## Validation

- `dotnet build ThreadPilot.csproj -c Release --no-restore` succeeded.
- `dotnet test Tests/ThreadPilot.Core.Tests/ThreadPilot.Core.Tests.csproj -c Release --no-restore` passed: 641 tests.

## Follow-up

`PollingIntervalMs` remains unchanged. It is not read by the current runtime and is tracked as separate technical debt.