### PR TITLE
Prepare release v1.5.2

### DIFF
--- a/Installer/Installer.iss
+++ b/Installer/Installer.iss
@@ -5,7 +5,7 @@
 #define MyAppPublisher "ThreadPilot"
 #define MyAppURL "https://github.com/"
 #define MyAppExeName "ThreadPilot.exe"
-#define MyAppVersion "1.5.1"
+#define MyAppVersion "1.5.2"
 
 #ifndef MyWizardStyle
   #define MyWizardStyle "modern dynamic windows11"

--- a/Installer/ThreadPilot.wxs
+++ b/Installer/ThreadPilot.wxs
@@ -7,7 +7,7 @@
   <Package
       Name="ThreadPilot"
       Manufacturer="Prime Build"
-      Version="1.5.1.0"
+      Version="1.5.2.0"
       UpgradeCode="PUT-GENERATED-UPGRADE-CODE-HERE"
       Language="1033">
     <SummaryInformation Description="ThreadPilot MSI template" />

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -11,7 +11,7 @@
 #endif
 
 #ifndef MyAppVersion
-	#define MyAppVersion "1.5.1"
+	#define MyAppVersion "1.5.2"
 #endif
 
 #ifndef MyAppSourceDir

--- a/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
@@ -4,8 +4,8 @@ namespace ThreadPilot.Core.Tests
 
     public sealed partial class PackagingMetadataTests
     {
-        private const string ReleaseVersion = "1.5.1";
-        private const string ReleaseAssemblyVersion = "1.5.1.0";
+        private const string ReleaseVersion = "1.5.2";
+        private const string ReleaseAssemblyVersion = "1.5.2.0";
 
         [Fact]
         public void InnoInstallers_UseStableDisplayNameAndSeparateVersionMetadata()
@@ -99,7 +99,7 @@ namespace ThreadPilot.Core.Tests
             throw new InvalidOperationException("Repository root could not be located.");
         }
 
-        [GeneratedRegex("#define MyAppVersion \"1\\.5\\.1\"", RegexOptions.CultureInvariant)]
+        [GeneratedRegex("#define MyAppVersion \"1\\.5\\.2\"", RegexOptions.CultureInvariant)]
         private static partial Regex MyAppVersionRegex();
     }
 }

--- a/ThreadPilot.csproj
+++ b/ThreadPilot.csproj
@@ -16,10 +16,10 @@
     <TrimMode>link</TrimMode>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1998;CS0067;CS0414;WFAC010;IL3000;MVVMTK0034</NoWarn>
-    <Version>1.5.1</Version>
-    <AssemblyVersion>1.5.1.0</AssemblyVersion>
-    <FileVersion>1.5.1.0</FileVersion>
-    <InformationalVersion>1.5.1</InformationalVersion>
+    <Version>1.5.2</Version>
+    <AssemblyVersion>1.5.2.0</AssemblyVersion>
+    <FileVersion>1.5.2.0</FileVersion>
+    <InformationalVersion>1.5.2</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.5.1.0" name="ThreadPilot.app"/>
+  <assemblyIdentity version="1.5.2.0" name="ThreadPilot.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.5.1",
+    [string]$Version = "1.5.2",
     [string]$Configuration = "Release",
     [switch]$SkipPublish
 )

--- a/build/build-release.ps1
+++ b/build/build-release.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.5.1",
+    [string]$Version = "1.5.2",
     [string]$Configuration = "Release",
     [string]$Runtime = "win-x64"
 )

--- a/build/package-release-zips.ps1
+++ b/build/package-release-zips.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.5.1"
+    [string]$Version = "1.5.2"
 )
 
 $ErrorActionPreference = "Stop"

--- a/chocolatey/threadpilot.nuspec
+++ b/chocolatey/threadpilot.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>threadpilot</id>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <title>ThreadPilot</title>
     <authors>Prime Build</authors>
     <projectUrl>https://github.com/PrimeBuild-pc/ThreadPilot</projectUrl>
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Advanced Windows process and power plan manager with rules automation and performance controls.</description>
     <summary>ThreadPilot process and power plan manager.</summary>
-    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.5.1</releaseNotes>
+    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.5.2</releaseNotes>
     <tags>threadpilot process powerplan performance windows</tags>
   </metadata>
   <files>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project are documented in this file.
 
+## v1.5.2 - Process monitoring configuration
+
+### Fixed
+
+- Consolidated process-monitoring configuration so application settings are the single runtime source for WMI, fallback polling, and fallback interval behavior.
+- Removed ineffective duplicate WMI, fallback polling, and polling interval settings from Rules & Automation.
+- Existing configuration JSON files remain compatible when they contain the removed legacy fields.
+
 ## v1.5.1 - Persistent automation monitoring preference
 
 ### Fixed

--- a/docs/release/RELEASE_NOTES.md
+++ b/docs/release/RELEASE_NOTES.md
@@ -1,20 +1,14 @@
-## ThreadPilot v1.5.1
+## ThreadPilot v1.5.2
 
-ThreadPilot 1.5.1 adds five languages, refines the Windows 11 experience, and makes future updates one-click.
+ThreadPilot 1.5.2 consolidates process-monitoring configuration so every monitoring control has a real runtime effect.
 
 ### Highlights
 
-- Italian, French, German, Spanish, and Russian translations, with automatic Windows language detection.
-- One-click updates checked at every enabled startup: consent once, then ThreadPilot downloads, verifies, installs, and restarts automatically.
-- Reliable startup detection and persistence for supported Windows system tweaks.
-- Native Windows power API handling for Core Parking and C-States.
-- More neutral Windows 11 styling for tweaks, dialogs, and selected items.
-- Fixed saving pending settings from the navigation/close confirmation dialog.
-
-Existing settings, profiles, masks, rules, imported power plans, and logs are preserved during upgrades.
+- Application settings are now the single runtime source for WMI monitoring, fallback polling, and fallback polling interval.
+- Removed ineffective duplicate monitoring controls from Rules & Automation.
+- Existing configuration JSON files remain compatible; obsolete duplicate fields are safely ignored when loaded.
 
 ### Validation
 
-- 634 automated Release tests passed before release preparation.
-- CI and CodeQL passed for both feature pull requests.
-- Release single-file publish, smoke test, and Inno Setup compilation passed.
+- 641 automated Release tests passed before release preparation.
+- Release build completed successfully.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=threadpilot
 sonar.projectName=ThreadPilot
-sonar.projectVersion=1.5.1
+sonar.projectVersion=1.5.2
 
 sonar.sourceEncoding=UTF-8
 sonar.sources=.


### PR DESCRIPTION
## Summary

- Synchronized project, binary, installer, package, build-script, and quality metadata to version 1.5.2.
- Updated the 1.5.2 changelog entry and release notes for the process-monitoring configuration consolidation.

## Validation

- `dotnet test Tests/ThreadPilot.Core.Tests/ThreadPilot.Core.Tests.csproj -c Release --no-restore` — 645 passed.
- `dotnet build ThreadPilot.csproj -c Release --no-restore` — succeeded with 0 warnings and 0 errors.
- `git diff --check` — clean.