### PR TITLE
Prepare release v1.5.3

### DIFF
--- a/Installer/Installer.iss
+++ b/Installer/Installer.iss
@@ -5,7 +5,7 @@
 #define MyAppPublisher "ThreadPilot"
 #define MyAppURL "https://github.com/"
 #define MyAppExeName "ThreadPilot.exe"
-#define MyAppVersion "1.5.2"
+#define MyAppVersion "1.5.3"
 
 #ifndef MyWizardStyle
   #define MyWizardStyle "modern dynamic windows11"

--- a/Installer/ThreadPilot.wxs
+++ b/Installer/ThreadPilot.wxs
@@ -7,7 +7,7 @@
   <Package
       Name="ThreadPilot"
       Manufacturer="Prime Build"
-      Version="1.5.2.0"
+      Version="1.5.3.0"
       UpgradeCode="PUT-GENERATED-UPGRADE-CODE-HERE"
       Language="1033">
     <SummaryInformation Description="ThreadPilot MSI template" />

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -11,7 +11,7 @@
 #endif
 
 #ifndef MyAppVersion
-	#define MyAppVersion "1.5.2"
+	#define MyAppVersion "1.5.3"
 #endif
 
 #ifndef MyAppSourceDir

--- a/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
@@ -4,8 +4,8 @@ namespace ThreadPilot.Core.Tests
 
     public sealed partial class PackagingMetadataTests
     {
-        private const string ReleaseVersion = "1.5.2";
-        private const string ReleaseAssemblyVersion = "1.5.2.0";
+        private const string ReleaseVersion = "1.5.3";
+        private const string ReleaseAssemblyVersion = "1.5.3.0";
 
         [Fact]
         public void InnoInstallers_UseStableDisplayNameAndSeparateVersionMetadata()
@@ -99,7 +99,7 @@ namespace ThreadPilot.Core.Tests
             throw new InvalidOperationException("Repository root could not be located.");
         }
 
-        [GeneratedRegex("#define MyAppVersion \"1\\.5\\.2\"", RegexOptions.CultureInvariant)]
+        [GeneratedRegex("#define MyAppVersion \"1\\.5\\.3\"", RegexOptions.CultureInvariant)]
         private static partial Regex MyAppVersionRegex();
     }
 }

--- a/ThreadPilot.csproj
+++ b/ThreadPilot.csproj
@@ -16,10 +16,10 @@
     <TrimMode>link</TrimMode>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1998;CS0067;CS0414;WFAC010;IL3000;MVVMTK0034</NoWarn>
-    <Version>1.5.2</Version>
-    <AssemblyVersion>1.5.2.0</AssemblyVersion>
-    <FileVersion>1.5.2.0</FileVersion>
-    <InformationalVersion>1.5.2</InformationalVersion>
+    <Version>1.5.3</Version>
+    <AssemblyVersion>1.5.3.0</AssemblyVersion>
+    <FileVersion>1.5.3.0</FileVersion>
+    <InformationalVersion>1.5.3</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.5.2.0" name="ThreadPilot.app"/>
+  <assemblyIdentity version="1.5.3.0" name="ThreadPilot.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.5.2",
+    [string]$Version = "1.5.3",
     [string]$Configuration = "Release",
     [switch]$SkipPublish
 )

--- a/build/build-release.ps1
+++ b/build/build-release.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.5.2",
+    [string]$Version = "1.5.3",
     [string]$Configuration = "Release",
     [string]$Runtime = "win-x64"
 )

--- a/build/package-release-zips.ps1
+++ b/build/package-release-zips.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.5.2"
+    [string]$Version = "1.5.3"
 )
 
 $ErrorActionPreference = "Stop"

--- a/chocolatey/threadpilot.nuspec
+++ b/chocolatey/threadpilot.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>threadpilot</id>
-    <version>1.5.2</version>
+    <version>1.5.3</version>
     <title>ThreadPilot</title>
     <authors>Prime Build</authors>
     <projectUrl>https://github.com/PrimeBuild-pc/ThreadPilot</projectUrl>
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Advanced Windows process and power plan manager with rules automation and performance controls.</description>
     <summary>ThreadPilot process and power plan manager.</summary>
-    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.5.2</releaseNotes>
+    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.5.3</releaseNotes>
     <tags>threadpilot process powerplan performance windows</tags>
   </metadata>
   <files>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## Unreleased - Reliability, lifecycle and threading hardening
+## v1.5.3 - Reliability, lifecycle and threading hardening
 
 ### Fixed
 

--- a/docs/release/RELEASE_NOTES.md
+++ b/docs/release/RELEASE_NOTES.md
@@ -1,14 +1,17 @@
-## ThreadPilot v1.5.2
+## ThreadPilot v1.5.3
 
-ThreadPilot 1.5.2 consolidates process-monitoring configuration so every monitoring control has a real runtime effect.
+ThreadPilot 1.5.3 hardens persistence, monitoring, notifications, autostart, tray updates, and application shutdown.
 
 ### Highlights
 
-- Application settings are now the single runtime source for WMI monitoring, fallback polling, and fallback polling interval.
-- Removed ineffective duplicate monitoring controls from Rules & Automation.
-- Existing configuration JSON files remain compatible; obsolete duplicate fields are safely ignored when loaded.
+- Saved process rules are protected from overwrite after transient read or recovery-copy failures.
+- Pending Settings edits now merge safely with unrelated background updates.
+- CPU monitoring preserves logical processor identity and avoids overlapping callbacks after rapid stop/start cycles.
+- Notification quiet hours, retries, default hotkeys, autostart ordering, tray refreshes, and shutdown disposal are more reliable.
+- Process Management now shows a clean disabled state when automation monitoring is off.
 
 ### Validation
 
-- 641 automated Release tests passed before release preparation.
-- Release build completed successfully.
+- 675 automated Release tests passed before release preparation.
+- CI DevSecOps and CodeQL passed on the merged reliability changes.
+- The elevated Windows UI and disabled-monitoring state were manually validated.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=threadpilot
 sonar.projectName=ThreadPilot
-sonar.projectVersion=1.5.2
+sonar.projectVersion=1.5.3
 
 sonar.sourceEncoding=UTF-8
 sonar.sources=.


### PR DESCRIPTION
## Summary

- Bump project, assembly, installer, package, build-script, and quality metadata to version 1.5.3.
- Promote the reliability-hardening changelog entry and refresh the release notes.

## Validation

- `dotnet build ThreadPilot_1.sln --configuration Release --no-restore` — 0 warnings, 0 errors.
- `dotnet test ThreadPilot_1.sln --configuration Release --no-build --no-restore` — 675 passed.
- Packaging metadata tests — 4 passed.
- Dependency vulnerability audit — clean.
- Local single-file publish, Inno Setup installer, portable ZIP, and SHA-256 generation completed.
- Installer and portable package contain version 1.5.3 and all 89 bundled power plans.

## Release behavior

- Pushing tag `v1.5.3` after merge will run the existing release workflow, Windows smoke test, GitHub Release publication, checksums, SBOM, and winget submission.
- Binaries remain unsigned according to the repository's current signing policy.
