### PR TITLE
Fix CPU affinity apply and surface the assignment controls (1.7.1)

### DIFF
--- a/Installer/Installer.iss
+++ b/Installer/Installer.iss
@@ -5,7 +5,7 @@
 #define MyAppPublisher "ThreadPilot"
 #define MyAppURL "https://github.com/"
 #define MyAppExeName "ThreadPilot.exe"
-#define MyAppVersion "1.7.0"
+#define MyAppVersion "1.7.1"
 
 #ifndef MyWizardStyle
   #define MyWizardStyle "modern dynamic windows11"

--- a/Installer/ThreadPilot.wxs
+++ b/Installer/ThreadPilot.wxs
@@ -7,7 +7,7 @@
   <Package
       Name="ThreadPilot"
       Manufacturer="Prime Build"
-      Version="1.7.0.0"
+      Version="1.7.1.0"
       UpgradeCode="PUT-GENERATED-UPGRADE-CODE-HERE"
       Language="1033">
     <SummaryInformation Description="ThreadPilot MSI template" />

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -11,7 +11,7 @@
 #endif
 
 #ifndef MyAppVersion
-	#define MyAppVersion "1.7.0"
+	#define MyAppVersion "1.7.1"
 #endif
 
 #ifndef MyAppSourceDir

--- a/Locales/de-DE.xaml
+++ b/Locales/de-DE.xaml
@@ -312,7 +312,10 @@
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">CPU-Auswahl vorgemerkt. Sie wird erst über CPU-Zuweisung anwenden übernommen.</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Affinität, die derzeit von Windows für den ausgewählten Prozess gemeldet wird</sys:String>
     <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Schreibgeschützte Vorschau der CPU-Auswahl — ändern Sie sie oben unter 'Ausstehende Kernmaske'.</sys:String>
-    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Nur Vorschau — diese Kästchen zeigen die CPU-Auswahl an, sie sind nicht anklickbar. Wählen Sie oben unter 'Ausstehende Kernmaske' eine Maske aus, um eine andere Auswahl vorzubereiten (Masken werden im Tab CPU-Masken erstellt).</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Nur Vorschau — diese Markierungen zeigen die ausgewählten CPUs an, sie sind nicht anklickbar. Wählen Sie oben unter 'Ausstehende Kernmaske' eine Maske aus, um eine andere Auswahl vorzubereiten (Masken werden im Tab CPU-Masken erstellt).</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreSelected">Ausgewählt</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreNotSelected">Nicht ausgewählt</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreUnavailable">Nicht verfügbar</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Öffnen Sie die Registerkarte CPU Masken, um eine neue benutzerdefinierte Maske zu erstellen</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">Zeigt an, ob Hyper-Threading (Intel) oder SMT (AMD) auf diesem System vorhanden und aktiv ist</sys:String>
 
@@ -578,6 +581,8 @@
     <sys:String x:Key="SystemTweak_GpuMsiMode_Name">GPU-MSI-Modus</sys:String>
     <sys:String x:Key="SystemTweak_GpuMsiMode_Desc">Steuert MSI nur, wenn der Grafiktreiber MSISupported bereits bereitstellt. Neustart erforderlich.</sys:String>
     <sys:String x:Key="SystemTweaks_OpenSettings">Einstellungen öffnen</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOn">EIN</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOff">AUS</sys:String>
     <sys:String x:Key="SystemTweaks_StatusManagedByWindows">Von Windows verwaltet</sys:String>
     <sys:String x:Key="SystemTweaks_StatusOpenSettingsFailed">Windows-Einstellungen konnten nicht geöffnet werden</sys:String>
     <sys:String x:Key="SystemTweaks_StatusSettingsOpenedFormat">Einstellungen für {0} geöffnet</sys:String>

--- a/Locales/de-DE.xaml
+++ b/Locales/de-DE.xaml
@@ -290,6 +290,7 @@
     <sys:String x:Key="ProcessView_LoadProfile">Profil laden</sys:String>
     <sys:String x:Key="ProcessView_LoadProfileTooltip">Laden Sie ein zuvor gespeichertes Profil</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">Aktuelle Einstellungen als Regel speichern</sys:String>
+    <sys:String x:Key="ProcessView_SaveRuleTooltip">Speichert eine prozessbezogene Regel, die ThreadPilot beim nächsten Start dieses Prozesses automatisch erneut anwendet, solange die Automatisierungsüberwachung aktiviert ist. Diese Regeln sind unabhängig von der Registerkarte „Regeln“, der Zuordnungen von Prozessen zu Energiesparplänen verwaltet.</sys:String>
 
     <sys:String x:Key="ProcessView_LastAction">Letzte ThreadPilot-Aktion:</sys:String>
     <sys:String x:Key="ProcessView_Refresh">Aktualisieren</sys:String>
@@ -310,7 +311,8 @@
 
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">CPU-Auswahl vorgemerkt. Sie wird erst über CPU-Zuweisung anwenden übernommen.</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Affinität, die derzeit von Windows für den ausgewählten Prozess gemeldet wird</sys:String>
-    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Schreibgeschützte Vorschau der aktuellen oder ausstehenden CPU-Auswahl</sys:String>
+    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Schreibgeschützte Vorschau der CPU-Auswahl — ändern Sie sie oben unter 'Ausstehende Kernmaske'.</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Nur Vorschau — diese Kästchen zeigen die CPU-Auswahl an, sie sind nicht anklickbar. Wählen Sie oben unter 'Ausstehende Kernmaske' eine Maske aus, um eine andere Auswahl vorzubereiten (Masken werden im Tab CPU-Masken erstellt).</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Öffnen Sie die Registerkarte CPU Masken, um eine neue benutzerdefinierte Maske zu erstellen</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">Zeigt an, ob Hyper-Threading (Intel) oder SMT (AMD) auf diesem System vorhanden und aktiv ist</sys:String>
 

--- a/Locales/en-US.xaml
+++ b/Locales/en-US.xaml
@@ -290,6 +290,7 @@
     <sys:String x:Key="ProcessView_LoadProfile">Load Profile</sys:String>
     <sys:String x:Key="ProcessView_LoadProfileTooltip">Load a previously saved profile</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">Save Current Settings as Rule</sys:String>
+    <sys:String x:Key="ProcessView_SaveRuleTooltip">Saves a per-process rule that ThreadPilot re-applies automatically the next time this process starts, while automation monitoring is enabled. These rules are separate from the Rules tab, which manages process-to-power-plan associations.</sys:String>
     
     <sys:String x:Key="ProcessView_LastAction">Last ThreadPilot action:</sys:String>
     <sys:String x:Key="ProcessView_Refresh">Refresh</sys:String>
@@ -310,7 +311,8 @@
     
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">CPU selection staged in the UI. It is applied only through Apply CPU Assignment.</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Affinity currently reported by Windows for the selected process</sys:String>
-    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Read-only preview of current or pending CPU selection</sys:String>
+    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Read-only preview of the CPU selection — choose a mask under 'Pending core mask' to change it.</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Preview only — these boxes show the CPU selection, they are not clickable. Choose a mask from 'Pending core mask' above to stage a different selection (create masks in the CPU Masks tab).</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Open CPU Masks tab to create a new custom mask</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">Shows whether Hyper-Threading (Intel) or SMT (AMD) is present and active on this system</sys:String>
     

--- a/Locales/en-US.xaml
+++ b/Locales/en-US.xaml
@@ -312,7 +312,10 @@
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">CPU selection staged in the UI. It is applied only through Apply CPU Assignment.</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Affinity currently reported by Windows for the selected process</sys:String>
     <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Read-only preview of the CPU selection — choose a mask under 'Pending core mask' to change it.</sys:String>
-    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Preview only — these boxes show the CPU selection, they are not clickable. Choose a mask from 'Pending core mask' above to stage a different selection (create masks in the CPU Masks tab).</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Preview only — these tags show which CPUs are selected, they are not clickable. Choose a mask from 'Pending core mask' above to stage a different selection (create masks in the CPU Masks tab).</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreSelected">Selected</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreNotSelected">Not selected</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreUnavailable">Unavailable</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Open CPU Masks tab to create a new custom mask</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">Shows whether Hyper-Threading (Intel) or SMT (AMD) is present and active on this system</sys:String>
     
@@ -578,6 +581,8 @@
     <sys:String x:Key="SystemTweak_GpuMsiMode_Name">GPU MSI Mode</sys:String>
     <sys:String x:Key="SystemTweak_GpuMsiMode_Desc">Controls MSI only when the display driver already exposes MSISupported. A restart is required.</sys:String>
     <sys:String x:Key="SystemTweaks_OpenSettings">Open settings</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOn">ON</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOff">OFF</sys:String>
     <sys:String x:Key="SystemTweaks_StatusManagedByWindows">Managed by Windows</sys:String>
     <sys:String x:Key="SystemTweaks_StatusOpenSettingsFailed">Could not open Windows settings</sys:String>
     <sys:String x:Key="SystemTweaks_StatusSettingsOpenedFormat">Opened settings for {0}</sys:String>

--- a/Locales/es-ES.xaml
+++ b/Locales/es-ES.xaml
@@ -312,7 +312,10 @@
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">Selección de CPU pendiente. Solo se aplica mediante Aplicar asignación de CPU.</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Afinidad reportada actualmente por Windows para el proceso seleccionado</sys:String>
     <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Vista previa de solo lectura de la selección de CPU — cámbiela en 'Máscara de núcleos pendiente'.</sys:String>
-    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Solo vista previa — estas casillas muestran la selección de CPU, no se pueden pulsar. Elija una máscara en 'Máscara de núcleos pendiente' más arriba para preparar una selección distinta (las máscaras se crean en la pestaña Máscaras de CPU).</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Solo vista previa — estas etiquetas muestran qué CPU están seleccionadas, no se pueden pulsar. Elija una máscara en 'Máscara de núcleos pendiente' más arriba para preparar una selección distinta (las máscaras se crean en la pestaña Máscaras de CPU).</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreSelected">Seleccionada</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreNotSelected">No seleccionada</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreUnavailable">No disponible</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Abra la pestaña Máscaras CPU para crear una nueva máscara personalizada</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">Muestra si Hyper-Threading (Intel) o SMT (AMD) está presente y activo en este sistema.</sys:String>
 
@@ -578,6 +581,8 @@
     <sys:String x:Key="SystemTweak_GpuMsiMode_Name">Modo MSI de GPU</sys:String>
     <sys:String x:Key="SystemTweak_GpuMsiMode_Desc">Controla MSI solo si el controlador gráfico ya expone MSISupported. Requiere reiniciar.</sys:String>
     <sys:String x:Key="SystemTweaks_OpenSettings">Abrir configuración</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOn">SÍ</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOff">NO</sys:String>
     <sys:String x:Key="SystemTweaks_StatusManagedByWindows">Administrado por Windows</sys:String>
     <sys:String x:Key="SystemTweaks_StatusOpenSettingsFailed">No se pudo abrir la configuración de Windows</sys:String>
     <sys:String x:Key="SystemTweaks_StatusSettingsOpenedFormat">Configuración abierta para {0}</sys:String>

--- a/Locales/es-ES.xaml
+++ b/Locales/es-ES.xaml
@@ -265,7 +265,7 @@
     <sys:String x:Key="ProcessView_SetPowerPlan">Establecer plan de energía</sys:String>
     <sys:String x:Key="ProcessView_SetPowerPlanTooltip">Activar el plan de energía Windows seleccionado</sys:String>
 
-    <sys:String x:Key="ProcessView_PendingCoreMask">Máscara central pendiente</sys:String>
+    <sys:String x:Key="ProcessView_PendingCoreMask">Máscara de núcleos pendiente</sys:String>
     <sys:String x:Key="ProcessView_StageMaskTooltip">Selecciona una máscara pendiente. Nada cambia hasta pulsar Aplicar asignación de CPU.</sys:String>
     <sys:String x:Key="ProcessView_ApplyAffinity">Aplicar asignación de CPU</sys:String>
     <sys:String x:Key="ProcessView_ApplyAffinityTooltip">Aplica la selección de CPU con el modo elegido y verifica el estado de Windows</sys:String>
@@ -290,6 +290,7 @@
     <sys:String x:Key="ProcessView_LoadProfile">Perfil de carga</sys:String>
     <sys:String x:Key="ProcessView_LoadProfileTooltip">Cargar un perfil previamente guardado</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">Guardar la configuración actual como regla</sys:String>
+    <sys:String x:Key="ProcessView_SaveRuleTooltip">Guarda una regla por proceso que ThreadPilot vuelve a aplicar automáticamente la próxima vez que se inicie este proceso, mientras la supervisión de automatización esté activada. Estas reglas son independientes de la pestaña Reglas, que gestiona las asociaciones entre procesos y planes de energía.</sys:String>
 
     <sys:String x:Key="ProcessView_LastAction">Última acción ThreadPilot:</sys:String>
     <sys:String x:Key="ProcessView_Refresh">Actualizar</sys:String>
@@ -310,7 +311,8 @@
 
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">Selección de CPU pendiente. Solo se aplica mediante Aplicar asignación de CPU.</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Afinidad reportada actualmente por Windows para el proceso seleccionado</sys:String>
-    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Vista previa de solo lectura de la selección CPU actual o pendiente</sys:String>
+    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Vista previa de solo lectura de la selección de CPU — cámbiela en 'Máscara de núcleos pendiente'.</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Solo vista previa — estas casillas muestran la selección de CPU, no se pueden pulsar. Elija una máscara en 'Máscara de núcleos pendiente' más arriba para preparar una selección distinta (las máscaras se crean en la pestaña Máscaras de CPU).</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Abra la pestaña Máscaras CPU para crear una nueva máscara personalizada</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">Muestra si Hyper-Threading (Intel) o SMT (AMD) está presente y activo en este sistema.</sys:String>
 

--- a/Locales/fr-FR.xaml
+++ b/Locales/fr-FR.xaml
@@ -265,7 +265,7 @@
     <sys:String x:Key="ProcessView_SetPowerPlan">Définir le plan d'alimentation</sys:String>
     <sys:String x:Key="ProcessView_SetPowerPlanTooltip">Activer le plan d'alimentation Windows sélectionné</sys:String>
 
-    <sys:String x:Key="ProcessView_PendingCoreMask">Masque de base en attente</sys:String>
+    <sys:String x:Key="ProcessView_PendingCoreMask">Masque de cœurs en attente</sys:String>
     <sys:String x:Key="ProcessView_StageMaskTooltip">Sélectionnez un masque à préparer. Rien ne change avant Appliquer l’affectation CPU.</sys:String>
     <sys:String x:Key="ProcessView_ApplyAffinity">Appliquer l’affectation CPU</sys:String>
     <sys:String x:Key="ProcessView_ApplyAffinityTooltip">Applique la sélection CPU avec le mode choisi et vérifie l’état Windows</sys:String>
@@ -290,6 +290,7 @@
     <sys:String x:Key="ProcessView_LoadProfile">Charger le profil</sys:String>
     <sys:String x:Key="ProcessView_LoadProfileTooltip">Charger un profil précédemment enregistré</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">Enregistrer les paramètres actuels en tant que règle</sys:String>
+    <sys:String x:Key="ProcessView_SaveRuleTooltip">Enregistre une règle propre au processus que ThreadPilot réapplique automatiquement au prochain démarrage de ce processus, tant que la surveillance de l'automatisation est activée. Ces règles sont distinctes de l'onglet Règles, qui gère les associations entre processus et modes d'alimentation.</sys:String>
 
     <sys:String x:Key="ProcessView_LastAction">Dernière action ThreadPilot :</sys:String>
     <sys:String x:Key="ProcessView_Refresh">Actualiser</sys:String>
@@ -310,7 +311,8 @@
 
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">Sélection CPU préparée dans l’interface. Elle est appliquée uniquement via Appliquer l’affectation CPU.</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Affinité actuellement signalée par Windows pour le processus sélectionné</sys:String>
-    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Aperçu en lecture seule de la sélection CPU actuelle ou en attente</sys:String>
+    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Aperçu en lecture seule de la sélection CPU — modifiez-la via 'Masque de cœurs en attente'.</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Aperçu uniquement — ces cases indiquent la sélection CPU, elles ne sont pas cliquables. Choisissez un masque dans 'Masque de cœurs en attente' ci-dessus pour préparer une autre sélection (créez les masques dans l'onglet Masques CPU).</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Ouvrez l'onglet CPU Masques pour créer un nouveau masque personnalisé.</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">Indique si Hyper-Threading (Intel) ou SMT (AMD) est présent et actif sur ce système</sys:String>
 

--- a/Locales/fr-FR.xaml
+++ b/Locales/fr-FR.xaml
@@ -312,7 +312,10 @@
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">Sélection CPU préparée dans l’interface. Elle est appliquée uniquement via Appliquer l’affectation CPU.</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Affinité actuellement signalée par Windows pour le processus sélectionné</sys:String>
     <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Aperçu en lecture seule de la sélection CPU — modifiez-la via 'Masque de cœurs en attente'.</sys:String>
-    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Aperçu uniquement — ces cases indiquent la sélection CPU, elles ne sont pas cliquables. Choisissez un masque dans 'Masque de cœurs en attente' ci-dessus pour préparer une autre sélection (créez les masques dans l'onglet Masques CPU).</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Aperçu uniquement — ces étiquettes indiquent les CPU sélectionnés, elles ne sont pas cliquables. Choisissez un masque dans 'Masque de cœurs en attente' ci-dessus pour préparer une autre sélection (créez les masques dans l'onglet Masques CPU).</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreSelected">Sélectionné</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreNotSelected">Non sélectionné</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreUnavailable">Indisponible</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Ouvrez l'onglet CPU Masques pour créer un nouveau masque personnalisé.</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">Indique si Hyper-Threading (Intel) ou SMT (AMD) est présent et actif sur ce système</sys:String>
 
@@ -578,6 +581,8 @@
     <sys:String x:Key="SystemTweak_GpuMsiMode_Name">Mode MSI du GPU</sys:String>
     <sys:String x:Key="SystemTweak_GpuMsiMode_Desc">Contrôle MSI uniquement si le pilote graphique expose déjà MSISupported. Redémarrage requis.</sys:String>
     <sys:String x:Key="SystemTweaks_OpenSettings">Ouvrir les paramètres</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOn">OUI</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOff">NON</sys:String>
     <sys:String x:Key="SystemTweaks_StatusManagedByWindows">Géré par Windows</sys:String>
     <sys:String x:Key="SystemTweaks_StatusOpenSettingsFailed">Impossible d'ouvrir les paramètres Windows</sys:String>
     <sys:String x:Key="SystemTweaks_StatusSettingsOpenedFormat">Paramètres ouverts pour {0}</sys:String>

--- a/Locales/it-IT.xaml
+++ b/Locales/it-IT.xaml
@@ -312,7 +312,10 @@
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">Selezione CPU preparata nell’interfaccia. Viene applicata solo tramite Applica assegnazione CPU.</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Affinità attualmente segnalata da Windows per il processo selezionato</sys:String>
     <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Anteprima di sola lettura della selezione CPU — scegli una maschera in 'Maschera core in sospeso' per modificarla.</sys:String>
-    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Solo anteprima — queste caselle mostrano la selezione CPU, non sono cliccabili. Scegli una maschera in 'Maschera core in sospeso' qui sopra per preparare una selezione diversa (le maschere si creano nella scheda Maschere CPU).</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Solo anteprima — queste etichette mostrano quali CPU sono selezionate, non sono cliccabili. Scegli una maschera in 'Maschera core in sospeso' qui sopra per preparare una selezione diversa (le maschere si creano nella scheda Maschere CPU).</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreSelected">Selezionata</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreNotSelected">Non selezionata</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreUnavailable">Non disponibile</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Apri la scheda CPU Maschere per creare una nuova maschera personalizzata</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">Mostra se Hyper-Threading (Intel) o SMT (AMD) è presente e attivo su questo sistema</sys:String>
 
@@ -578,6 +581,8 @@
     <sys:String x:Key="SystemTweak_GpuMsiMode_Name">Modalità MSI GPU</sys:String>
     <sys:String x:Key="SystemTweak_GpuMsiMode_Desc">Controlla MSI solo se il driver video espone già MSISupported. È necessario riavviare.</sys:String>
     <sys:String x:Key="SystemTweaks_OpenSettings">Apri impostazioni</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOn">ON</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOff">OFF</sys:String>
     <sys:String x:Key="SystemTweaks_StatusManagedByWindows">Gestito da Windows</sys:String>
     <sys:String x:Key="SystemTweaks_StatusOpenSettingsFailed">Impossibile aprire le impostazioni di Windows</sys:String>
     <sys:String x:Key="SystemTweaks_StatusSettingsOpenedFormat">Impostazioni aperte per {0}</sys:String>

--- a/Locales/it-IT.xaml
+++ b/Locales/it-IT.xaml
@@ -265,7 +265,7 @@
     <sys:String x:Key="ProcessView_SetPowerPlan">Imposta il piano di risparmio energia</sys:String>
     <sys:String x:Key="ProcessView_SetPowerPlanTooltip">Attiva il piano di risparmio energia Windows selezionato</sys:String>
 
-    <sys:String x:Key="ProcessView_PendingCoreMask">Maschera centrale in sospeso</sys:String>
+    <sys:String x:Key="ProcessView_PendingCoreMask">Maschera core in sospeso</sys:String>
     <sys:String x:Key="ProcessView_StageMaskTooltip">Seleziona una maschera da preparare. Nulla cambia finché non fai clic su Applica assegnazione CPU.</sys:String>
     <sys:String x:Key="ProcessView_ApplyAffinity">Applica assegnazione CPU</sys:String>
     <sys:String x:Key="ProcessView_ApplyAffinityTooltip">Applica la selezione CPU con la modalità scelta e verifica lo stato di Windows</sys:String>
@@ -290,6 +290,7 @@
     <sys:String x:Key="ProcessView_LoadProfile">Carica profilo</sys:String>
     <sys:String x:Key="ProcessView_LoadProfileTooltip">Carica un profilo salvato in precedenza</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">Salva le impostazioni correnti come regola</sys:String>
+    <sys:String x:Key="ProcessView_SaveRuleTooltip">Salva una regola per processo che ThreadPilot riapplica automaticamente al successivo avvio di questo processo, finché il monitoraggio dell'automazione è attivo. Queste regole sono separate dalla scheda Regole, che gestisce le associazioni tra processi e combinazioni di risparmio energia.</sys:String>
 
     <sys:String x:Key="ProcessView_LastAction">Ultima azione ThreadPilot:</sys:String>
     <sys:String x:Key="ProcessView_Refresh">Aggiorna</sys:String>
@@ -310,7 +311,8 @@
 
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">Selezione CPU preparata nell’interfaccia. Viene applicata solo tramite Applica assegnazione CPU.</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Affinità attualmente segnalata da Windows per il processo selezionato</sys:String>
-    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Anteprima di sola lettura della selezione CPU corrente o in sospeso</sys:String>
+    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Anteprima di sola lettura della selezione CPU — scegli una maschera in 'Maschera core in sospeso' per modificarla.</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Solo anteprima — queste caselle mostrano la selezione CPU, non sono cliccabili. Scegli una maschera in 'Maschera core in sospeso' qui sopra per preparare una selezione diversa (le maschere si creano nella scheda Maschere CPU).</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Apri la scheda CPU Maschere per creare una nuova maschera personalizzata</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">Mostra se Hyper-Threading (Intel) o SMT (AMD) è presente e attivo su questo sistema</sys:String>
 

--- a/Locales/ru-RU.xaml
+++ b/Locales/ru-RU.xaml
@@ -312,7 +312,10 @@
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">Выбор ЦП подготовлен и применяется только командой «Применить назначение ЦП».</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Текущая привязка выбранного процесса по данным Windows</sys:String>
     <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Предварительный просмотр выбора ЦП только для чтения — измените его в списке 'Ожидающая маска ядер'.</sys:String>
-    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Только предварительный просмотр — эти флажки показывают выбор ЦП и не нажимаются. Выберите маску в списке 'Ожидающая маска ядер' выше, чтобы подготовить другой выбор (маски создаются на вкладке Маски CPU).</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Только предварительный просмотр — эти метки показывают выбранные ЦП и не нажимаются. Выберите маску в списке 'Ожидающая маска ядер' выше, чтобы подготовить другой выбор (маски создаются на вкладке Маски CPU).</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreSelected">Выбрано</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreNotSelected">Не выбрано</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreUnavailable">Недоступно</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Откройте вкладку «Маски» CPU, чтобы создать новую пользовательскую маску.</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">Показывает, присутствует ли и активен ли Hyper-Threading (Intel) или SMT (AMD) в этой системе.</sys:String>
 
@@ -578,6 +581,8 @@
     <sys:String x:Key="SystemTweak_GpuMsiMode_Name">Режим MSI для GPU</sys:String>
     <sys:String x:Key="SystemTweak_GpuMsiMode_Desc">Управляет MSI, только если видеодрайвер уже предоставляет MSISupported. Требуется перезагрузка.</sys:String>
     <sys:String x:Key="SystemTweaks_OpenSettings">Открыть параметры</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOn">ВКЛ</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOff">ВЫКЛ</sys:String>
     <sys:String x:Key="SystemTweaks_StatusManagedByWindows">Управляется Windows</sys:String>
     <sys:String x:Key="SystemTweaks_StatusOpenSettingsFailed">Не удалось открыть параметры Windows</sys:String>
     <sys:String x:Key="SystemTweaks_StatusSettingsOpenedFormat">Открыты параметры для {0}</sys:String>

--- a/Locales/ru-RU.xaml
+++ b/Locales/ru-RU.xaml
@@ -265,7 +265,7 @@
     <sys:String x:Key="ProcessView_SetPowerPlan">Установить план электропитания</sys:String>
     <sys:String x:Key="ProcessView_SetPowerPlanTooltip">Активируйте выбранный план электропитания Windows.</sys:String>
 
-    <sys:String x:Key="ProcessView_PendingCoreMask">Ожидаемая основная маска</sys:String>
+    <sys:String x:Key="ProcessView_PendingCoreMask">Ожидающая маска ядер</sys:String>
     <sys:String x:Key="ProcessView_StageMaskTooltip">Подготовьте маску. Изменения вступят в силу только после нажатия «Применить назначение ЦП».</sys:String>
     <sys:String x:Key="ProcessView_ApplyAffinity">Применить назначение ЦП</sys:String>
     <sys:String x:Key="ProcessView_ApplyAffinityTooltip">Применяет выбор ЦП в выбранном режиме и проверяет состояние Windows.</sys:String>
@@ -290,6 +290,7 @@
     <sys:String x:Key="ProcessView_LoadProfile">Загрузить профиль</sys:String>
     <sys:String x:Key="ProcessView_LoadProfileTooltip">Загрузите ранее сохраненный профиль</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">Сохранить текущие настройки как правило</sys:String>
+    <sys:String x:Key="ProcessView_SaveRuleTooltip">Сохраняет правило для этого процесса, которое ThreadPilot автоматически применяет снова при следующем запуске процесса, пока включён мониторинг автоматизации. Эти правила не связаны с вкладкой Правила, где настраиваются сопоставления процессов и схем электропитания.</sys:String>
 
     <sys:String x:Key="ProcessView_LastAction">Последнее действие ThreadPilot:</sys:String>
     <sys:String x:Key="ProcessView_Refresh">Обновить</sys:String>
@@ -310,7 +311,8 @@
 
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">Выбор ЦП подготовлен и применяется только командой «Применить назначение ЦП».</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Текущая привязка выбранного процесса по данным Windows</sys:String>
-    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Предварительный просмотр текущего или ожидающего выбора CPU только для чтения</sys:String>
+    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">Предварительный просмотр выбора ЦП только для чтения — измените его в списке 'Ожидающая маска ядер'.</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">Только предварительный просмотр — эти флажки показывают выбор ЦП и не нажимаются. Выберите маску в списке 'Ожидающая маска ядер' выше, чтобы подготовить другой выбор (маски создаются на вкладке Маски CPU).</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">Откройте вкладку «Маски» CPU, чтобы создать новую пользовательскую маску.</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">Показывает, присутствует ли и активен ли Hyper-Threading (Intel) или SMT (AMD) в этой системе.</sys:String>
 

--- a/Locales/zh-CN.xaml
+++ b/Locales/zh-CN.xaml
@@ -312,7 +312,10 @@
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">CPU 选择已暂存，仅通过“应用 CPU 分配”应用。</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Windows 当前报告的所选进程的关联性</sys:String>
     <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">CPU 选择的只读预览 — 请在“待处理的核心掩码”中更改。</sys:String>
-    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">仅供预览 — 这些复选框显示 CPU 选择，不可点击。请在上方的“待处理的核心掩码”中选择一个掩码以准备其他选择（掩码在“CPU 掩码”选项卡中创建）。</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">仅供预览 — 这些标签显示已选中的 CPU，不可点击。请在上方的“待处理的核心掩码”中选择一个掩码以准备其他选择（掩码在“CPU 掩码”选项卡中创建）。</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreSelected">已选中</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreNotSelected">未选中</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoreUnavailable">不可用</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">打开 CPU 掩码选项卡以创建新的自定义掩码</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">显示此系统上是否具有并启用了超线程 (Intel) 或 SMT (AMD)</sys:String>
     
@@ -578,6 +581,8 @@
     <sys:String x:Key="SystemTweak_GpuMsiMode_Name">GPU MSI 模式</sys:String>
     <sys:String x:Key="SystemTweak_GpuMsiMode_Desc">仅当显示驱动已公开 MSISupported 时控制 MSI。需要重启。</sys:String>
     <sys:String x:Key="SystemTweaks_OpenSettings">打开设置</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOn">开</sys:String>
+    <sys:String x:Key="SystemTweaks_ToggleOff">关</sys:String>
     <sys:String x:Key="SystemTweaks_StatusManagedByWindows">由 Windows 管理</sys:String>
     <sys:String x:Key="SystemTweaks_StatusOpenSettingsFailed">无法打开 Windows 设置</sys:String>
     <sys:String x:Key="SystemTweaks_StatusSettingsOpenedFormat">已打开 {0} 的设置</sys:String>

--- a/Locales/zh-CN.xaml
+++ b/Locales/zh-CN.xaml
@@ -290,6 +290,7 @@
     <sys:String x:Key="ProcessView_LoadProfile">加载配置文件</sys:String>
     <sys:String x:Key="ProcessView_LoadProfileTooltip">加载以前保存的配置文件</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">保存当前设置为规则</sys:String>
+    <sys:String x:Key="ProcessView_SaveRuleTooltip">保存针对该进程的规则；只要启用了自动化监视，ThreadPilot 会在此进程下次启动时自动重新应用它。这些规则与“自动化规则”选项卡相互独立，后者管理进程与电源计划的关联。</sys:String>
     
     <sys:String x:Key="ProcessView_LastAction">最后一次 ThreadPilot 操作:</sys:String>
     <sys:String x:Key="ProcessView_Refresh">刷新</sys:String>
@@ -310,7 +311,8 @@
     
     <sys:String x:Key="ProcessView_AffinityStagedTooltip">CPU 选择已暂存，仅通过“应用 CPU 分配”应用。</sys:String>
     <sys:String x:Key="ProcessView_AffinityCurrentTooltip">Windows 当前报告的所选进程的关联性</sys:String>
-    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">当前或待处理 CPU 选择的只读预览</sys:String>
+    <sys:String x:Key="ProcessView_CpuSelectionPreviewTooltip">CPU 选择的只读预览 — 请在“待处理的核心掩码”中更改。</sys:String>
+    <sys:String x:Key="ProcessView_CpuCoresReadOnlyHint">仅供预览 — 这些复选框显示 CPU 选择，不可点击。请在上方的“待处理的核心掩码”中选择一个掩码以准备其他选择（掩码在“CPU 掩码”选项卡中创建）。</sys:String>
     <sys:String x:Key="ProcessView_OpenMasksTabTooltip">打开 CPU 掩码选项卡以创建新的自定义掩码</sys:String>
     <sys:String x:Key="ProcessView_HyperThreadingTooltip">显示此系统上是否具有并启用了超线程 (Intel) 或 SMT (AMD)</sys:String>
     

--- a/Models/ApplicationSettingsModel.cs
+++ b/Models/ApplicationSettingsModel.cs
@@ -160,7 +160,7 @@ namespace ThreadPilot.Models
         private bool enableAutomationMonitoring = true;
 
         [ObservableProperty]
-        private CpuAssignmentMode defaultCpuAssignmentMode = CpuAssignmentMode.Automatic;
+        private CpuAssignmentMode defaultCpuAssignmentMode = CpuAssignmentMode.AffinityMask;
 
         // Advanced Settings
         [ObservableProperty]

--- a/Platforms/Windows/CpuSetMapping.cs
+++ b/Platforms/Windows/CpuSetMapping.cs
@@ -67,18 +67,31 @@ namespace ThreadPilot.Platforms.Windows
         {
             ArgumentNullException.ThrowIfNull(selection);
 
-            if (selection.CpuSetIds.Count > 0)
+            // Logical processor coordinates survive a topology change; the raw CPU Set IDs stored
+            // with a saved rule do not - after a reboot or a CPU change the same opaque ID can name
+            // a different processor. Resolve coordinates against the current mapping whenever we
+            // have them, and require every one to resolve so a stale selection surfaces as an
+            // invalid topology instead of silently pinning a subset of the wrong CPUs.
+            if (selection.LogicalProcessors.Count > 0)
             {
-                return selection.CpuSetIds
+                var resolved = new List<uint>(selection.LogicalProcessors.Count);
+                foreach (var processor in selection.LogicalProcessors)
+                {
+                    if (!this.TryGetCpuSetId(processor, out var cpuSetId))
+                    {
+                        return [];
+                    }
+
+                    resolved.Add(cpuSetId);
+                }
+
+                return resolved
                     .Distinct()
                     .OrderBy(cpuSetId => cpuSetId)
                     .ToList();
             }
 
-            return selection.LogicalProcessors
-                .Select(processor => this.TryGetCpuSetId(processor, out var cpuSetId) ? (uint?)cpuSetId : null)
-                .Where(cpuSetId => cpuSetId.HasValue)
-                .Select(cpuSetId => cpuSetId!.Value)
+            return selection.CpuSetIds
                 .Distinct()
                 .OrderBy(cpuSetId => cpuSetId)
                 .ToList();

--- a/Services/AffinityApplyService.cs
+++ b/Services/AffinityApplyService.cs
@@ -98,7 +98,7 @@ namespace ThreadPilot.Services
             Succeeded(requestedMask, verifiedMask) with
             {
                 UsedLegacyAffinity = true,
-                TechnicalMessage = $"CPU Sets failed; legacy affinity 0x{requestedMask:X} applied and verified as 0x{verifiedMask:X}.",
+                TechnicalMessage = $"CPU Sets not used; legacy affinity 0x{requestedMask:X} applied and verified as 0x{verifiedMask:X}.",
             };
 
         public static AffinityApplyResult Failed(
@@ -222,7 +222,14 @@ namespace ThreadPilot.Services
                     failureReason: AffinityApplyFailureReason.InvalidMask);
             }
 
-            var cpuSetsResult = this.TryApplyCpuSets(process, selection);
+            // A pre-existing hard affinity defeats CPU Sets: Windows never schedules the process
+            // outside that mask, whatever default CPU Sets we install, yet the CPU Set read-back
+            // still "verifies" and we would report success on an assignment that cannot take
+            // effect. When the selection is expressible as a legacy mask, go straight to the hard
+            // affinity path, which can actually replace the existing restriction.
+            var cpuSetsResult = CpuSetsWouldBeDefeatedByHardAffinity(process, selection)
+                ? null
+                : this.TryApplyCpuSets(process, selection);
             if (cpuSetsResult != null)
             {
                 return cpuSetsResult;
@@ -231,7 +238,7 @@ namespace ThreadPilot.Services
             this.cpuSetFailureCallback?.Invoke(process);
 
             var legacyMask = CpuSelection.ToLegacyAffinityMaskOrNull(selection);
-            if (!legacyMask.HasValue || legacyMask.Value <= 0)
+            if (!legacyMask.HasValue || legacyMask.Value == 0)
             {
                 this.Audit(process, success: false);
                 return AffinityApplyResult.Failed(
@@ -348,6 +355,24 @@ namespace ThreadPilot.Services
                     process.ProcessId);
                 return null;
             }
+        }
+
+        private static bool CpuSetsWouldBeDefeatedByHardAffinity(ProcessModel process, CpuSelection selection)
+        {
+            // ponytail: trusts ProcessModel.ProcessorAffinity rather than re-reading the live
+            // mask. A stale zero just falls back to the previous CPU-Sets-first behaviour; re-read
+            // through IProcessService here if that turns out to matter.
+            if (process.ProcessorAffinity == 0)
+            {
+                return false;
+            }
+
+            // Null for multi-group or beyond-CPU-63 selections, where CPU Sets are the only option.
+            // Compare bit patterns, not magnitudes: a mask including CPU 63 is a negative long.
+            var desiredMask = CpuSelection.ToLegacyAffinityMaskOrNull(selection);
+            return desiredMask.HasValue &&
+                desiredMask.Value != 0 &&
+                (desiredMask.Value & ~process.ProcessorAffinity) != 0;
         }
 
         private void Audit(ProcessModel process, bool success) =>
@@ -572,7 +597,7 @@ namespace ThreadPilot.Services
             }
 
             var legacyMask = CpuSelection.ToLegacyAffinityMaskOrNull(selection);
-            if (legacyMask is > 0 && selection.LogicalProcessors.All(processor => processor.Group == 0))
+            if (legacyMask is not (null or 0) && selection.LogicalProcessors.All(processor => processor.Group == 0))
             {
                 return this.ApplyClassicAffinityOnlyAsync(process, legacyMask.Value);
             }
@@ -666,7 +691,7 @@ namespace ThreadPilot.Services
 
         private static bool HasConflictingHardAffinity(ProcessModel process, CpuSelection selection)
         {
-            if (process.ProcessorAffinity <= 0 || selection.LogicalProcessors.Count == 0)
+            if (process.ProcessorAffinity == 0 || selection.LogicalProcessors.Count == 0)
             {
                 return false;
             }

--- a/Services/AffinityApplyService.cs
+++ b/Services/AffinityApplyService.cs
@@ -88,7 +88,7 @@ namespace ThreadPilot.Services
                 Success = true,
                 FailureReason = AffinityApplyFailureReason.None,
                 ErrorCode = AffinityApplyErrorCodes.None,
-                UserMessage = "Affinity applied successfully.",
+                UserMessage = ProcessOperationUserMessages.CpuSetsApplied,
                 TechnicalMessage = technicalMessage,
                 UsedCpuSets = true,
                 EffectiveMode = CpuAssignmentMode.CpuSets,

--- a/Services/ProcessOperationUserMessages.cs
+++ b/Services/ProcessOperationUserMessages.cs
@@ -22,6 +22,9 @@ namespace ThreadPilot.Services
         public const string ProcessExited =
             "The process exited before ThreadPilot could apply the change.";
 
+        public const string CpuSetsApplied =
+            "CPU Sets assignment applied. This is a soft scheduling preference: the affinity mask shown in Task Manager stays unchanged. Use the Affinity Mask mode for a hard, visible restriction.";
+
         public const string CpuSetsUnavailable =
             "Windows CPU Sets are unavailable or rejected this selection. ThreadPilot will use a safe fallback only when possible.";
 

--- a/Services/ProcessService.cs
+++ b/Services/ProcessService.cs
@@ -429,30 +429,11 @@ namespace ThreadPilot.Services
                         throw new InvalidOperationException("Affinity mask cannot be zero.");
                     }
 
-                    // Try using CPU Sets first (Windows 10+)
-                    if (this.useCpuSets)
-                    {
-                        bool cpuSetSuccess = this.TrySetAffinityViaCpuSets(process, affinityMask);
-                        if (cpuSetSuccess)
-                        {
-                            this.logger?.LogInformation(
-                                "Successfully applied CPU Sets affinity 0x{AffinityMask:X} to process {ProcessName} (PID: {ProcessId})",
-                                affinityMask, process.Name, process.ProcessId);
-
-                            // Update the model with the new affinity
-                            process.ProcessorAffinity = affinityMask;
-                            this.AuditProcessOperation("SetProcessAffinity", process.Name, success: true);
-                            return;
-                        }
-                        else
-                        {
-                            this.logger?.LogDebug(
-                                "CPU Sets failed for process {ProcessName} (PID: {ProcessId}), falling back to classic ProcessorAffinity",
-                                process.Name, process.ProcessId);
-                        }
-                    }
-
-                    // Fallback to classic ProcessorAffinity method
+                    // This overload means "hard affinity mask": callers verify the result against
+                    // GetProcessAffinityMask. CPU Sets (SetProcessDefaultCpuSets) are only a soft
+                    // scheduling hint and leave that mask untouched, so applying them here made every
+                    // caller report a VerificationMismatch failure. Soft assignment keeps its own
+                    // entry points (CpuAssignmentMode.CpuSets / CpuSelectionAffinityApplier).
                     using var targetProcess = Process.GetProcessById(process.ProcessId);
 
                     targetProcess.ProcessorAffinity = new IntPtr(affinityMask);
@@ -525,47 +506,6 @@ namespace ThreadPilot.Services
             }
 
             return await this.cpuSelectionAffinityApplier.ApplyAsync(process, selection).ConfigureAwait(false);
-        }
-
-        private bool TrySetAffinityViaCpuSets(ProcessModel process, long affinityMask)
-        {
-            try
-            {
-                // Get or create CPU Set handler for this process
-                var handler = this.GetOrCreateCpuSetHandler(process);
-
-                // Check if handler is valid
-                if (!handler.IsValid)
-                {
-                    this.logger?.LogDebug(
-                        "CPU Set handler for process {ProcessName} (PID: {ProcessId}) is invalid",
-                        process.Name, process.ProcessId);
-
-                    // Remove invalid handler
-                    this.cpuSetHandlers.TryRemove(process.ProcessId, out _);
-                    return false;
-                }
-
-                // Apply the CPU Set mask
-                bool success = handler.ApplyCpuSetMask(affinityMask, clearMask: false);
-
-                if (!success)
-                {
-                    // Remove failed handler so we can try again later if needed
-                    this.cpuSetHandlers.TryRemove(process.ProcessId, out _);
-                }
-
-                return success;
-            }
-            catch (Exception ex)
-            {
-                this.logger?.LogWarning(ex, "Exception while applying CPU Sets to process {ProcessName} (PID: {ProcessId})",
-                    process.Name, process.ProcessId);
-
-                // Remove handler on exception
-                this.cpuSetHandlers.TryRemove(process.ProcessId, out _);
-                return false;
-            }
         }
 
         private IProcessCpuSetHandler GetOrCreateCpuSetHandler(ProcessModel process) =>

--- a/Tests/ThreadPilot.Core.Tests/AffinityApplyServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/AffinityApplyServiceTests.cs
@@ -394,6 +394,79 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
+        public async Task CpuSelectionApply_WhenHardAffinityWouldDefeatCpuSets_UsesHardAffinityInstead()
+        {
+            // The process is already pinned to CPUs 0-1, so default CPU Sets naming CPUs 2-3 would
+            // read back as applied while Windows keeps refusing to schedule it there.
+            var process = new ProcessModel { ProcessId = 42, Name = "Game", ProcessorAffinity = 0x3 };
+            var cpuSets = new FakeCpuSetHandler { ApplyCpuSelectionResult = true };
+            var legacy = new RecordingLegacyAffinityApplier();
+            var service = CreateCpuSelectionApplier(cpuSets, legacy);
+            var selection = CreateSelection(new ProcessorRef(0, 2, 2), new ProcessorRef(0, 3, 3));
+
+            var result = await service.ApplyAsync(process, selection);
+
+            Assert.True(result.Success);
+            Assert.False(result.UsedCpuSets);
+            Assert.True(result.UsedLegacyAffinity);
+            Assert.Equal(0, cpuSets.ApplyCpuSelectionCalls);
+            Assert.Equal(0xC, legacy.LastMask);
+        }
+
+        [Fact]
+        public async Task CpuSelectionApply_WhenMasksUseBit63_StillDetectsTheHardAffinityConflict()
+        {
+            // CPU 63 sets the sign bit, so these masks are negative longs. Comparing them as
+            // magnitudes ("> 0") silently skipped the guard on 64-CPU single-group systems.
+            var process = new ProcessModel { ProcessId = 42, Name = "Game", ProcessorAffinity = 1L << 62 };
+            var cpuSets = new FakeCpuSetHandler { ApplyCpuSelectionResult = true };
+            var legacy = new RecordingLegacyAffinityApplier();
+            var service = CreateCpuSelectionApplier(cpuSets, legacy);
+            var selection = CreateSelection(new ProcessorRef(0, 63, 63));
+
+            var result = await service.ApplyAsync(process, selection);
+
+            Assert.True(result.Success);
+            Assert.False(result.UsedCpuSets);
+            Assert.True(result.UsedLegacyAffinity);
+            Assert.Equal(0, cpuSets.ApplyCpuSelectionCalls);
+            Assert.Equal(1L << 63, legacy.LastMask);
+        }
+
+        [Fact]
+        public async Task CpuSelectionApply_WhenModelAffinityIsUnknown_KeepsPreferringCpuSets()
+        {
+            // A ProcessModel whose affinity could not be read reports 0; the guard must not treat
+            // that as "everything conflicts" and force hard affinity on every apply.
+            var process = new ProcessModel { ProcessId = 42, Name = "Game", ProcessorAffinity = 0 };
+            var cpuSets = new FakeCpuSetHandler { ApplyCpuSelectionResult = true };
+            var legacy = new RecordingLegacyAffinityApplier();
+            var service = CreateCpuSelectionApplier(cpuSets, legacy);
+            var selection = CreateSelection(new ProcessorRef(0, 2, 2));
+
+            var result = await service.ApplyAsync(process, selection);
+
+            Assert.True(result.UsedCpuSets);
+            Assert.Equal(0, legacy.CallCount);
+        }
+
+        [Fact]
+        public async Task CpuSelectionApply_WhenSelectionFitsInsideExistingHardAffinity_StillUsesCpuSets()
+        {
+            var process = new ProcessModel { ProcessId = 42, Name = "Game", ProcessorAffinity = 0xF };
+            var cpuSets = new FakeCpuSetHandler { ApplyCpuSelectionResult = true };
+            var legacy = new RecordingLegacyAffinityApplier();
+            var service = CreateCpuSelectionApplier(cpuSets, legacy);
+            var selection = CreateSelection(new ProcessorRef(0, 2, 2), new ProcessorRef(0, 3, 3));
+
+            var result = await service.ApplyAsync(process, selection);
+
+            Assert.True(result.Success);
+            Assert.True(result.UsedCpuSets);
+            Assert.Equal(0, legacy.CallCount);
+        }
+
+        [Fact]
         public async Task CpuSelectionApply_WhenCpuSetsThrowAccessDenied_ReturnsAccessDenied()
         {
             var process = new ProcessModel { ProcessId = 42, Name = "Game" };

--- a/Tests/ThreadPilot.Core.Tests/ApplicationSettingsModelTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ApplicationSettingsModelTests.cs
@@ -18,7 +18,7 @@ namespace ThreadPilot.Core.Tests
             Assert.True(settings.EnableAutomaticUpdateChecks);
             Assert.False(settings.IncludePrereleaseUpdates);
             Assert.Null(settings.LastUpdateCheckUtc);
-            Assert.Equal(CpuAssignmentMode.Automatic, settings.DefaultCpuAssignmentMode);
+            Assert.Equal(CpuAssignmentMode.AffinityMask, settings.DefaultCpuAssignmentMode);
         }
 
         [Fact]

--- a/Tests/ThreadPilot.Core.Tests/ApplicationSettingsServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ApplicationSettingsServiceTests.cs
@@ -40,7 +40,7 @@ namespace ThreadPilot.Core.Tests
             await service.LoadSettingsAsync();
 
             Assert.True(service.Settings.EnableAutomationMonitoring);
-            Assert.Equal(CpuAssignmentMode.Automatic, service.Settings.DefaultCpuAssignmentMode);
+            Assert.Equal(CpuAssignmentMode.AffinityMask, service.Settings.DefaultCpuAssignmentMode);
         }
 
         [Fact]

--- a/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
@@ -4,8 +4,8 @@ namespace ThreadPilot.Core.Tests
 
     public sealed partial class PackagingMetadataTests
     {
-        private const string ReleaseVersion = "1.7.0";
-        private const string ReleaseAssemblyVersion = "1.7.0.0";
+        private const string ReleaseVersion = "1.7.1";
+        private const string ReleaseAssemblyVersion = "1.7.1.0";
 
         [Fact]
         public void InnoInstallers_UseStableDisplayNameAndSeparateVersionMetadata()
@@ -120,7 +120,7 @@ namespace ThreadPilot.Core.Tests
             throw new InvalidOperationException("Repository root could not be located.");
         }
 
-        [GeneratedRegex("#define MyAppVersion \"1\\.7\\.0\"", RegexOptions.CultureInvariant)]
+        [GeneratedRegex("#define MyAppVersion \"1\\.7\\.1\"", RegexOptions.CultureInvariant)]
         private static partial Regex MyAppVersionRegex();
     }
 }

--- a/Tests/ThreadPilot.Core.Tests/ProcessCpuSetHandlerTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessCpuSetHandlerTests.cs
@@ -55,8 +55,10 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
-        public void CpuSetMapping_ResolveSelection_UsesExplicitCpuSetIds()
+        public void CpuSetMapping_ResolveSelection_PrefersCurrentTopologyOverSavedCpuSetIds()
         {
+            // 300 is a CPU Set ID captured when the rule was saved and no longer present in the
+            // current mapping. Applying it would pin the process to whatever CPU now owns that ID.
             var mapping = CpuSetMapping.Create(new Dictionary<ProcessorRef, uint>
             {
                 [new ProcessorRef(0, 0, 0)] = 100,
@@ -69,7 +71,26 @@ namespace ThreadPilot.Core.Tests
 
             var cpuSetIds = mapping.ResolveCpuSetIds(selection);
 
-            Assert.Equal([100U, 300U], cpuSetIds);
+            Assert.Equal([100U], cpuSetIds);
+        }
+
+        [Fact]
+        public void CpuSetMapping_ResolveSelection_ReturnsEmptyWhenAProcessorNoLongerExists()
+        {
+            var mapping = CpuSetMapping.Create(new Dictionary<ProcessorRef, uint>
+            {
+                [new ProcessorRef(0, 0, 0)] = 100,
+            });
+            var selection = new CpuSelection
+            {
+                CpuSetIds = [100, 101],
+                LogicalProcessors = [new ProcessorRef(0, 0, 0), new ProcessorRef(0, 1, 1)],
+            };
+
+            var cpuSetIds = mapping.ResolveCpuSetIds(selection);
+
+            // Better an InvalidTopology error the user can act on than silently pinning a subset.
+            Assert.Empty(cpuSetIds);
         }
 
         [Fact]

--- a/Tests/ThreadPilot.Core.Tests/ProcessServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessServiceTests.cs
@@ -15,6 +15,48 @@ namespace ThreadPilot.Core.Tests
     public sealed class ProcessServiceTests
     {
         [Fact]
+        public async Task SetProcessorAffinity_ActuallyChangesTheHardAffinityMask()
+        {
+            // Regression guard: this overload must write the mask Windows reports back through
+            // GetProcessAffinityMask. Applying CPU Sets here instead is a soft scheduling hint that
+            // leaves the mask untouched, which made every caller report a VerificationMismatch.
+            if (Environment.ProcessorCount < 2)
+            {
+                return;
+            }
+
+            using var child = Process.Start(new ProcessStartInfo("cmd.exe", "/c pause")
+            {
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            })!;
+
+            try
+            {
+                var model = new ProcessModel
+                {
+                    ProcessId = child.Id,
+                    Name = child.ProcessName,
+                    ProcessorAffinity = (long)child.ProcessorAffinity,
+                };
+
+                var service = new ProcessService(Mock.Of<ILogger<ProcessService>>());
+
+                await service.SetProcessorAffinity(model, 0x3);
+
+                child.Refresh();
+                Assert.Equal(0x3, (long)child.ProcessorAffinity);
+                Assert.Equal(0x3, model.ProcessorAffinity);
+            }
+            finally
+            {
+                child.Kill();
+            }
+        }
+
+        [Fact]
         public async Task SaveProcessProfile_WritesExpectedJson()
         {
             var profilesDirectory = CreateTemporaryDirectory();

--- a/Tests/ThreadPilot.Core.Tests/ProcessViewXamlBindingTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessViewXamlBindingTests.cs
@@ -298,13 +298,40 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
-        public void LegacyActionSidePanel_IsNotPersistentPrimaryUi()
+        public void LegacyActionSidePanel_IsGoneAndItsControlsLiveInTheVisiblePicker()
         {
+            // The legacy side panel was Visibility="Collapsed" from v1.2.0 onwards, so the CPU
+            // assignment mode picker and Apply button that v1.6.0 added to it were never on screen.
+            // They now live in the Advanced Affinity Picker; nothing may be parked in a hidden pane.
             var document = XDocument.Load(ProcessViewPath, LoadOptions.PreserveWhitespace);
             var serialized = document.ToString(SaveOptions.DisableFormatting);
 
-            Assert.Contains("Grid.Column=\"2\" Visibility=\"Collapsed\"", serialized, StringComparison.Ordinal);
-            Assert.Contains("ProcessView_AdvancedAffinityPicker", serialized, StringComparison.Ordinal);
+            var picker = Assert.Single(
+                document.Descendants(),
+                element => element.Name.LocalName == "Expander" &&
+                    element.Attributes().Any(attribute =>
+                        attribute.Value.Contains("ProcessView_AdvancedAffinityPicker", StringComparison.Ordinal)));
+            var pickerXml = picker.ToString(SaveOptions.DisableFormatting);
+
+            // The picker now holds the primary apply action, so it must start open.
+            Assert.Equal("True", picker.Attribute("IsExpanded")?.Value);
+            Assert.Contains("SelectedCpuAssignmentMode", pickerXml, StringComparison.Ordinal);
+            Assert.Contains("SetAffinityCommand", pickerXml, StringComparison.Ordinal);
+            Assert.Contains("ProcessView_CpuCoresReadOnlyHint", pickerXml, StringComparison.Ordinal);
+
+            // No control a user clicks may be parked in a statically collapsed container again.
+            // ControlTemplate parts are exempt: a template child collapsed by default and revealed
+            // by a trigger is normal WPF, and its Visibility says nothing about what is on screen.
+            var hiddenCommands = document
+                .Descendants()
+                .Where(element => element.Attribute("Command") != null)
+                .Where(element => !element.Ancestors().Any(ancestor => ancestor.Name.LocalName == "ControlTemplate"))
+                .Where(element => element.AncestorsAndSelf().Any(ancestor =>
+                    ancestor.Attribute("Visibility")?.Value == "Collapsed"))
+                .Select(element => element.Attribute("Command")!.Value)
+                .ToList();
+
+            Assert.Empty(hiddenCommands);
         }
 
         private static string GetRepositoryRoot()

--- a/Tests/ThreadPilot.Core.Tests/SystemTweaksStartupAndStyleTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/SystemTweaksStartupAndStyleTests.cs
@@ -17,14 +17,44 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
-        public void TweaksView_UsesNativeFluentToggleSwitch()
+        public void TweaksView_UsesLabelledPillToggle()
         {
+            // The native ui:ToggleSwitch is 40x20 with no text, too quiet to read as a control on
+            // this list. The pill states ON/OFF inside the track and is sized to be obvious.
             var document = XDocument.Load(GetRepositoryFilePath("Views", "SystemTweaksView.xaml"));
             var serialized = document.ToString(SaveOptions.DisableFormatting);
 
-            Assert.Contains("ToggleSwitch", serialized, StringComparison.Ordinal);
+            Assert.Contains("PillToggleButtonStyle", serialized, StringComparison.Ordinal);
             Assert.Contains("AutomationProperties.Name=\"{Binding Name}\"", serialized, StringComparison.Ordinal);
-            Assert.DoesNotContain("PillToggleButtonStyle", serialized, StringComparison.Ordinal);
+            Assert.Contains("SystemTweaks_ToggleOn", serialized, StringComparison.Ordinal);
+            Assert.Contains("SystemTweaks_ToggleOff", serialized, StringComparison.Ordinal);
+
+            // The label and the thumb must be docked rather than stacked: a long localized label
+            // (ru "ВЫКЛ") has to widen the pill, not slide underneath the thumb.
+            var track = Assert.Single(
+                document.Descendants(),
+                element => element.Name.LocalName == "Border" &&
+                    element.Attributes().Any(attribute =>
+                        attribute.Name.LocalName == "Name" && attribute.Value == "Track"));
+            Assert.Single(track.Descendants(), element => element.Name.LocalName == "DockPanel");
+
+            var pill = Assert.Single(
+                document.Descendants(),
+                element => element.Name.LocalName == "Style" &&
+                    element.Attributes().Any(attribute =>
+                        attribute.Name.LocalName == "Key" && attribute.Value == "PillToggleButtonStyle"));
+            var setters = pill
+                .Elements()
+                .Where(element => element.Name.LocalName == "Setter")
+                .ToDictionary(
+                    element => element.Attribute("Property")!.Value,
+                    element => element.Attribute("Value")?.Value,
+                    StringComparer.Ordinal);
+
+            // MinWidth, never Width: a fixed track clips the wider locales.
+            Assert.Equal("56", setters["MinWidth"]);
+            Assert.Equal("28", setters["Height"]);
+            Assert.False(setters.ContainsKey("Width"));
         }
 
         [Fact]

--- a/ThreadPilot.csproj
+++ b/ThreadPilot.csproj
@@ -16,10 +16,10 @@
     <TrimMode>link</TrimMode>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1998;CS0067;CS0414;WFAC010;IL3000;MVVMTK0034</NoWarn>
-    <Version>1.7.0</Version>
-    <AssemblyVersion>1.7.0.0</AssemblyVersion>
-    <FileVersion>1.7.0.0</FileVersion>
-    <InformationalVersion>1.7.0</InformationalVersion>
+    <Version>1.7.1</Version>
+    <AssemblyVersion>1.7.1.0</AssemblyVersion>
+    <FileVersion>1.7.1.0</FileVersion>
+    <InformationalVersion>1.7.1</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ViewModels/ProcessViewModel.Behaviors.partial.cs
+++ b/ViewModels/ProcessViewModel.Behaviors.partial.cs
@@ -810,7 +810,10 @@ namespace ThreadPilot.ViewModels
 
             await this.UpdateSelectedProcessSummaryAsync(targetProcess);
 
-            var currentCoreSelection = this.HasPendingAffinityEdits && this.CpuCores.Count > 0
+            // Capture what the core checkboxes currently show, not only staged edits: soft modes
+            // (CPU Sets / Ideal Processor) leave ProcessorAffinity untouched, so falling back to it
+            // saved a rule pinned to every CPU - a rule that does nothing when applied.
+            var currentCoreSelection = this.CpuCores.Count > 0
                 ? this.GetPendingCoreSelectionMask()
                 : null;
             var result = await this.processRuleCreationService.SaveCurrentSettingsAsRuleAsync(

--- a/ViewModels/ProcessViewModel.Behaviors.partial.cs
+++ b/ViewModels/ProcessViewModel.Behaviors.partial.cs
@@ -1140,62 +1140,6 @@ namespace ThreadPilot.ViewModels
             UpdateCoreSelectionsFromMask(newValue);
         }
 
-        private async Task ApplyCoreMaskToProcessAsync(CoreMask mask)
-        {
-            var selectedProcess = this.SelectedProcess;
-            if (selectedProcess == null || mask == null)
-            {
-                return;
-            }
-
-            this.IsBusy = true;
-            try
-            {
-                this.Logger.LogInformation(
-                    "Applying mask '{MaskName}' to process {ProcessName} (PID: {ProcessId})",
-                    mask.Name, selectedProcess.Name, selectedProcess.ProcessId);
-
-                var result = await this.processAffinityApplyCoordinator.ApplyCoreMaskAsync(selectedProcess, mask);
-
-                System.Windows.Application.Current.Dispatcher.Invoke(() =>
-                {
-                    selectedProcess.ForceNotifyProcessorAffinityChanged();
-                    if (!result.UsedCpuSets)
-                    {
-                        this.UpdateCoreSelections(selectedProcess.ProcessorAffinity, true);
-                    }
-
-                    this.OnPropertyChanged(nameof(this.SelectedProcess));
-                });
-
-                if (!result.Success)
-                {
-                    this.SetStatus(result.Message);
-                    this.Logger.LogWarning(
-                        "Failed to apply mask '{MaskName}' to process {ProcessName}: {Message}",
-                        mask.Name,
-                        selectedProcess.Name,
-                        result.Message);
-                    return;
-                }
-
-                this.HasPendingAffinityEdits = false;
-                this.UpdateAffinityDisplayState();
-                this.SetStatus($"Applied mask '{mask.Name}' to {selectedProcess.Name}");
-                this.Logger.LogInformation("Successfully applied mask '{MaskName}' to {ProcessName}", mask.Name, selectedProcess.Name);
-            }
-            catch (Exception ex)
-            {
-                this.Logger.LogError(ex, "Failed to apply mask '{MaskName}' to process {ProcessName}",
-                    mask.Name, selectedProcess.Name);
-                this.SetStatus($"Error applying mask: {ex.Message}");
-            }
-            finally
-            {
-                this.IsBusy = false;
-            }
-        }
-
         private void UpdateCoreSelectionsFromMask(CoreMask mask)
         {
             if (mask == null || this.CpuCores.Count == 0)

--- a/Views/ProcessView.xaml
+++ b/Views/ProcessView.xaml
@@ -5,7 +5,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:converters="clr-namespace:ThreadPilot.Converters"
              xmlns:models="clr-namespace:ThreadPilot.Models"
-             xmlns:Diagnostics="clr-namespace:System.Diagnostics;assembly=System.Diagnostics.Process"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
              mc:Ignorable="d"
@@ -163,13 +162,8 @@
         </StackPanel>
 
         <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="0"/>
-                <ColumnDefinition Width="0"/>
-            </Grid.ColumnDefinitions>
 
-            <Grid Grid.Column="0">
+            <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
@@ -514,7 +508,7 @@
                         </WrapPanel>
 
                         <Expander Header="{DynamicResource ProcessView_AdvancedAffinityPicker}"
-                                  IsExpanded="False"
+                                  IsExpanded="True"
                                   Margin="0,10,0,0">
                             <StackPanel Margin="0,8,0,0">
                                 <Grid Margin="0,0,0,8">
@@ -604,6 +598,30 @@
                                            Foreground="{DynamicResource TextSecondaryBrush}"
                                            TextWrapping="Wrap"
                                            Margin="0,6,0,0"/>
+                                <DockPanel Margin="0,10,0,4">
+                                    <TextBlock Text="{DynamicResource ProcessView_CpuAssignmentMode}" FontSize="{StaticResource ProcessFontSmall}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                    <TextBlock Text="ⓘ"
+                                               Margin="8,0,0,0"
+                                               ToolTip="{DynamicResource ProcessView_CpuAssignmentModeTooltip}"
+                                               AutomationProperties.Name="{DynamicResource SettingsView_CpuAssignmentInfo}"
+                                               AutomationProperties.HelpText="{DynamicResource ProcessView_CpuAssignmentModeTooltip}"/>
+                                </DockPanel>
+                                <ComboBox SelectedValue="{Binding SelectedCpuAssignmentMode, Mode=TwoWay}"
+                                          SelectedValuePath="Tag"
+                                          IsEnabled="{Binding SelectedProcess, Converter={StaticResource NullToBoolConverter}}"
+                                          Margin="0,0,0,10">
+                                    <ComboBoxItem Content="{DynamicResource CpuAssignmentMode_AffinityMask}" Tag="{x:Static models:CpuAssignmentMode.AffinityMask}" ToolTip="{DynamicResource CpuAssignmentMode_AffinityMaskTooltip}"/>
+                                    <ComboBoxItem Content="{DynamicResource CpuAssignmentMode_IdealProcessor}" Tag="{x:Static models:CpuAssignmentMode.IdealProcessor}" ToolTip="{DynamicResource CpuAssignmentMode_IdealProcessorTooltip}"/>
+                                    <ComboBoxItem Content="{DynamicResource CpuAssignmentMode_CpuSets}" Tag="{x:Static models:CpuAssignmentMode.CpuSets}" ToolTip="{DynamicResource CpuAssignmentMode_CpuSetsTooltip}"/>
+                                    <ComboBoxItem Content="{DynamicResource CpuAssignmentMode_Automatic}" Tag="{x:Static models:CpuAssignmentMode.Automatic}" ToolTip="{DynamicResource CpuAssignmentMode_AutomaticTooltip}"/>
+                                </ComboBox>
+
+                                <Button Command="{Binding SetAffinityCommand}"
+                                        Content="{DynamicResource ProcessView_ApplyAffinity}"
+                                        Padding="10,6"
+                                        HorizontalAlignment="Stretch"
+                                        IsEnabled="{Binding SelectedProcess, Converter={StaticResource NullToBoolConverter}}"
+                                        ToolTip="{DynamicResource ProcessView_ApplyAffinityTooltip}"/>
                             </StackPanel>
                         </Expander>
                     </StackPanel>
@@ -627,333 +645,6 @@
                                TextAlignment="Center"/>
                 </Border>
             </Grid>
-
-            <Border Grid.Column="2"
-                    Visibility="Collapsed"
-                    Background="{DynamicResource CardSurfaceBrush}"
-                    BorderBrush="{DynamicResource BorderSubtleBrush}"
-                    BorderThickness="1"
-                    CornerRadius="8">
-                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                    <StackPanel Margin="14">
-                        <TextBlock Text="{DynamicResource ProcessView_SelectedProcess}"
-                                   FontSize="{StaticResource ProcessFontMedium}"
-                                   FontWeight="SemiBold"
-                                   Margin="0,0,0,8"/>
-
-                        <Border Padding="10"
-                                CornerRadius="{DynamicResource StandardCardCornerRadius}"
-                                BorderBrush="{DynamicResource BorderSubtleBrush}"
-                                BorderThickness="1"
-                                Background="{DynamicResource QuietRowBackgroundBrush}"
-                                Margin="0,0,0,12">
-                            <StackPanel>
-                                <TextBlock Text="{DynamicResource ProcessView_NoProcessSelected}"
-                                           FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextSecondaryBrush}"
-                                           TextWrapping="Wrap">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding SelectedProcess}" Value="{x:Null}">
-                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                                <TextBlock Text="{DynamicResource ProcessView_SelectProcessTip}"
-                                           FontSize="{StaticResource ProcessFontSmall}"
-                                           Foreground="{DynamicResource TextSecondaryBrush}"
-                                           TextWrapping="Wrap"
-                                           Margin="0,4,0,0">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding SelectedProcess}" Value="{x:Null}">
-                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                                <StackPanel>
-                                    <StackPanel.Style>
-                                        <Style TargetType="StackPanel">
-                                            <Setter Property="Visibility" Value="Visible"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding SelectedProcess}" Value="{x:Null}">
-                                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </StackPanel.Style>
-                                    <TextBlock Text="{Binding SelectedProcess.Name}"
-                                               FontWeight="SemiBold"
-                                               TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock FontSize="{StaticResource ProcessFontSmall}" Foreground="{DynamicResource TextSecondaryBrush}">
-                                        <Run Text="PID "/>
-                                        <Run Text="{Binding SelectedProcess.ProcessId}"/>
-                                        <Run Text="{DynamicResource ProcessView_PriorityInlineLabel}"/>
-                                        <Run Text="{Binding SelectedProcess.Priority}"/>
-                                    </TextBlock>
-                                    <TextBlock Text="{Binding SelectedProcess.MainWindowTitle, TargetNullValue=No visible window title}"
-                                               FontSize="{StaticResource ProcessFontSmall}"
-                                               Foreground="{DynamicResource TextSecondaryBrush}"
-                                               TextWrapping="Wrap"
-                                               Margin="0,4,0,0"/>
-                                </StackPanel>
-                            </StackPanel>
-                        </Border>
-
-                        <GroupBox Header="{DynamicResource ProcessView_Affinity}" Margin="0,0,0,12">
-                            <StackPanel Margin="8">
-                                <TextBlock Text="{Binding CurrentAffinityText}"
-                                           FontSize="{StaticResource ProcessFontSmall}"
-                                           Foreground="{DynamicResource TextSecondaryBrush}"
-                                           TextWrapping="Wrap"
-                                           ToolTip="{DynamicResource ProcessView_AffinityCurrentTooltip}"/>
-                                <TextBlock Text="{Binding PendingAffinityText}"
-                                           FontSize="{StaticResource ProcessFontSmall}"
-                                           Foreground="{DynamicResource TextSecondaryBrush}"
-                                           TextWrapping="Wrap"
-                                           Margin="0,3,0,0"
-                                           ToolTip="{DynamicResource ProcessView_AffinityStagedTooltip}"/>
-                                <TextBlock Text="{Binding AffinityEditStateText}"
-                                           FontSize="{StaticResource ProcessFontSmall}"
-                                           Foreground="{DynamicResource WarningTextBrush}"
-                                           TextWrapping="Wrap"
-                                           Margin="0,3,0,10"/>
-
-                                <TextBlock Text="{DynamicResource ProcessView_PendingCoreMask}" FontSize="{StaticResource ProcessFontSmall}" FontWeight="SemiBold" Margin="0,0,0,4"/>
-                                <ComboBox ItemsSource="{Binding AvailableCoreMasks}"
-                                          SelectedItem="{Binding SelectedCoreMask, Mode=TwoWay}"
-                                          IsEnabled="{Binding SelectedProcess, Converter={StaticResource NullToBoolConverter}}"
-                                          Margin="0,0,0,8"
-                                          ToolTip="{DynamicResource ProcessView_StageMaskTooltip}">
-                                    <ComboBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Margin="0,0,8,0"/>
-                                                <TextBlock Text="{Binding SelectedCoreCount, StringFormat='({0} CPUs)'}"
-                                                           FontSize="{StaticResource ProcessFontSmall}"
-                                                           Foreground="{DynamicResource TextSecondaryBrush}"
-                                                           VerticalAlignment="Center"/>
-                                            </StackPanel>
-                                        </DataTemplate>
-                                    </ComboBox.ItemTemplate>
-                                </ComboBox>
-
-                                <DockPanel Margin="0,0,0,4">
-                                    <TextBlock Text="{DynamicResource ProcessView_CpuAssignmentMode}" FontSize="{StaticResource ProcessFontSmall}" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                    <TextBlock Text="ⓘ"
-                                               Margin="8,0,0,0"
-                                               ToolTip="{DynamicResource ProcessView_CpuAssignmentModeTooltip}"
-                                               AutomationProperties.Name="{DynamicResource SettingsView_CpuAssignmentInfo}"
-                                               AutomationProperties.HelpText="{DynamicResource ProcessView_CpuAssignmentModeTooltip}"/>
-                                </DockPanel>
-                                <ComboBox SelectedValue="{Binding SelectedCpuAssignmentMode, Mode=TwoWay}"
-                                          SelectedValuePath="Tag"
-                                          IsEnabled="{Binding SelectedProcess, Converter={StaticResource NullToBoolConverter}}"
-                                          Margin="0,0,0,8">
-                                    <ComboBoxItem Content="{DynamicResource CpuAssignmentMode_AffinityMask}" Tag="{x:Static models:CpuAssignmentMode.AffinityMask}" ToolTip="{DynamicResource CpuAssignmentMode_AffinityMaskTooltip}"/>
-                                    <ComboBoxItem Content="{DynamicResource CpuAssignmentMode_IdealProcessor}" Tag="{x:Static models:CpuAssignmentMode.IdealProcessor}" ToolTip="{DynamicResource CpuAssignmentMode_IdealProcessorTooltip}"/>
-                                    <ComboBoxItem Content="{DynamicResource CpuAssignmentMode_CpuSets}" Tag="{x:Static models:CpuAssignmentMode.CpuSets}" ToolTip="{DynamicResource CpuAssignmentMode_CpuSetsTooltip}"/>
-                                    <ComboBoxItem Content="{DynamicResource CpuAssignmentMode_Automatic}" Tag="{x:Static models:CpuAssignmentMode.Automatic}" ToolTip="{DynamicResource CpuAssignmentMode_AutomaticTooltip}"/>
-                                </ComboBox>
-
-                                <TextBlock Text="{Binding TopologyStatus}"
-                                           FontSize="{StaticResource ProcessFontSmall}"
-                                           Foreground="{Binding IsTopologyDetectionSuccessful, Converter={StaticResource BoolToColorConverter}}"/>
-                                <TextBlock Text="{Binding HyperThreadingStatusText}"
-                                           FontSize="{StaticResource ProcessFontSmall}"
-                                           Margin="0,2,0,6"
-                                           Foreground="{Binding IsHyperThreadingActive, Converter={StaticResource BoolToColorConverter}}"
-                                           ToolTip="{DynamicResource ProcessView_HyperThreadingTooltip}"/>
-
-                                <ScrollViewer MaxHeight="92"
-                                              VerticalScrollBarVisibility="Auto"
-                                              HorizontalScrollBarVisibility="Disabled"
-                                              Margin="0,0,0,8">
-                                    <ItemsControl ItemsSource="{Binding CpuCores}">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <WrapPanel Orientation="Horizontal"/>
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <CheckBox Content="{Binding Label}"
-                                                          IsChecked="{Binding IsSelected, Mode=OneWay}"
-                                                          IsHitTestVisible="False"
-                                                          Focusable="False"
-                                                          IsEnabled="{Binding IsEnabled}"
-                                                          Margin="2"
-                                                          FontSize="{StaticResource ProcessFontSmall}"
-                                                          Foreground="{DynamicResource TextPrimaryBrush}"
-                                                          ToolTip="{DynamicResource ProcessView_CpuSelectionPreviewTooltip}"/>
-                                            </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
-                                </ScrollViewer>
-
-
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="8"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                    </Grid.ColumnDefinitions>
-                                    <Button Grid.Column="0"
-                                            Command="{Binding SetAffinityCommand}"
-                                            Content="{DynamicResource ProcessView_ApplyAffinity}"
-                                            Padding="10,6"
-                                            IsEnabled="{Binding SelectedProcess, Converter={StaticResource NullToBoolConverter}}"
-                                            ToolTip="{DynamicResource ProcessView_ApplyAffinityTooltip}"/>
-                                    <Button Grid.Column="2"
-                                            Command="{Binding CreateCustomMaskCommand}"
-                                            Padding="8,6"
-                                            ToolTip="{DynamicResource ProcessView_OpenMasksTabTooltip}">
-                                        <StackPanel Orientation="Horizontal">
-                                            <ui:SymbolIcon Symbol="Add12" Margin="0,0,6,0" VerticalAlignment="Center"/>
-                                            <TextBlock Text="{DynamicResource ProcessView_PriorityCustom}" FontSize="{StaticResource ProcessFontMediumSmall}" VerticalAlignment="Center"/>
-                                        </StackPanel>
-                                    </Button>
-                                </Grid>
-                            </StackPanel>
-                        </GroupBox>
-
-                        <GroupBox Header="{DynamicResource ProcessView_Priority}" Margin="0,0,0,12">
-                            <StackPanel Margin="8">
-                                <ComboBox x:Name="PriorityComboBox"
-                                          SelectedValue="{Binding SelectedProcess.Priority, Mode=TwoWay}"
-                                          SelectedValuePath="Tag"
-                                          Margin="0,0,0,6"
-                                          IsEnabled="{Binding SelectedProcess, Converter={StaticResource NullToBoolConverter}}">
-                                    <ComboBoxItem Content="{DynamicResource ProcessView_PriorityRealtime}" Tag="{x:Static Diagnostics:ProcessPriorityClass.RealTime}"/>
-                                    <ComboBoxItem Content="{DynamicResource ProcessView_PriorityHigh}" Tag="{x:Static Diagnostics:ProcessPriorityClass.High}"/>
-                                    <ComboBoxItem Content="{DynamicResource ProcessView_PriorityAboveNormal}" Tag="{x:Static Diagnostics:ProcessPriorityClass.AboveNormal}"/>
-                                    <ComboBoxItem Content="{DynamicResource ProcessView_PriorityNormal}" Tag="{x:Static Diagnostics:ProcessPriorityClass.Normal}"/>
-                                    <ComboBoxItem Content="{DynamicResource ProcessView_PriorityBelowNormal}" Tag="{x:Static Diagnostics:ProcessPriorityClass.BelowNormal}"/>
-                                    <ComboBoxItem Content="{DynamicResource ProcessView_PriorityIdle}" Tag="{x:Static Diagnostics:ProcessPriorityClass.Idle}"/>
-                                </ComboBox>
-                                <Button Command="{Binding SetPriorityCommand}"
-                                        CommandParameter="{Binding ElementName=PriorityComboBox, Path=SelectedValue}"
-                                        Content="{DynamicResource ProcessView_SetPriority}"
-                                        Padding="10,6"
-                                        Margin="0,0,0,8"
-                                        IsEnabled="{Binding SelectedProcess, Converter={StaticResource NullToBoolConverter}}"
-                                        ToolTip="{DynamicResource ProcessView_ApplyPriorityTooltip}"/>
-                                <CheckBox Content="{DynamicResource ProcessView_EnforcePriorityRegistry}"
-                                          IsChecked="{Binding IsRegistryPriorityEnabled}"
-                                          IsEnabled="{Binding SelectedProcess, Converter={StaticResource NullToBoolConverter}}"
-                                          Margin="0,0,0,6"
-                                          ToolTip="{DynamicResource ProcessView_EnforcePriorityRegistryTooltip}"/>
-                                <CheckBox Content="{DynamicResource ProcessView_DisableIdleServer}"
-                                          IsChecked="{Binding IsIdleServerDisabled}"
-                                          IsEnabled="{Binding SelectedProcess, Converter={StaticResource NullToBoolConverter}}"
-                                          ToolTip="{DynamicResource ProcessView_DisableIdleServerTooltip}"/>
-                            </StackPanel>
-                        </GroupBox>
-
-                        <GroupBox Header="{DynamicResource ProcessView_PowerPlanPending}" Margin="0,0,0,12">
-                            <StackPanel Margin="8">
-                                <TextBlock Text="{DynamicResource ProcessView_SelectedPowerPlan}"
-                                           FontSize="{StaticResource ProcessFontSmall}"
-                                           FontWeight="SemiBold"
-                                           Margin="0,0,0,4"/>
-                                <ComboBox ItemsSource="{Binding PowerPlans}"
-                                          SelectedItem="{Binding SelectedPowerPlan, Mode=TwoWay}"
-                                          DisplayMemberPath="Name"
-                                          Margin="0,0,0,8"
-                                          ToolTip="{DynamicResource ProcessView_PowerPlanTooltip}"/>
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="8"/>
-                                        <ColumnDefinition Width="*"/>
-                                    </Grid.ColumnDefinitions>
-                                    <Button Grid.Column="0"
-                                            Command="{Binding SetPowerPlanCommand}"
-                                            Content="{DynamicResource ProcessView_SetPowerPlan}"
-                                            Padding="10,6"
-                                            ToolTip="{DynamicResource ProcessView_SetPowerPlanTooltip}"/>
-                                    <Button Grid.Column="2"
-                                            Command="{Binding QuickApplyAffinityAndPowerPlanCommand}"
-                                            Content="{DynamicResource ProcessView_ApplyPendingSettings}"
-                                            Padding="10,6"
-                                            IsEnabled="{Binding SelectedProcess, Converter={StaticResource NullToBoolConverter}}"
-                                            ToolTip="{DynamicResource ProcessView_ApplyPendingSettingsTooltip}"/>
-                                </Grid>
-                            </StackPanel>
-                        </GroupBox>
-
-                        <GroupBox Header="{DynamicResource ProcessView_ProfileRule}" Margin="0,0,0,12">
-                            <StackPanel Margin="8">
-                                <TextBox Text="{Binding ProfileName, UpdateSourceTrigger=PropertyChanged}"
-                                         Margin="0,0,0,8"
-                                         ToolTip="{DynamicResource ProcessView_ProfileNamePlaceholder}"/>
-                                <Grid Margin="0,0,0,8">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="8"/>
-                                        <ColumnDefinition Width="*"/>
-                                    </Grid.ColumnDefinitions>
-                                    <Button Grid.Column="0"
-                                            Command="{Binding SaveProfileCommand}"
-                                            Content="{DynamicResource ProcessView_SaveProfile}"
-                                            Padding="10,6"
-                                            ToolTip="{DynamicResource ProcessView_SaveProfileTooltip}"/>
-                                    <Button Grid.Column="2"
-                                            Command="{Binding LoadProfileCommand}"
-                                            Content="{DynamicResource ProcessView_LoadProfile}"
-                                            Padding="10,6"
-                                            ToolTip="{DynamicResource ProcessView_LoadProfileTooltip}"/>
-                                </Grid>
-                                <Button Command="{Binding SaveCurrentAsAssociationCommand}"
-                                        Content="{DynamicResource ProcessView_SaveAsRule}"
-                                        Padding="10,6"
-                                        FontWeight="SemiBold"
-                                        IsEnabled="{Binding SelectedProcess, Converter={StaticResource NullToBoolConverter}}"
-                                        ToolTip="{DynamicResource ProcessView_ApplyAffinitySaveRuleTooltip}"/>
-                            </StackPanel>
-                        </GroupBox>
-
-                        <Border Padding="10,7"
-                                CornerRadius="6"
-                                BorderThickness="1"
-                                Opacity="{Binding StatusOpacity}"
-                                Visibility="{Binding StatusMessage, Converter={x:Static converters:StringToVisibilityConverter.Instance}}">
-                            <Border.Style>
-                                <Style TargetType="Border">
-                                    <Setter Property="Background" Value="{DynamicResource SuccessBackgroundBrush}"/>
-                                    <Setter Property="BorderBrush" Value="{DynamicResource SuccessBorderBrush}"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding HasError}" Value="True">
-                                            <Setter Property="Background" Value="{DynamicResource ErrorBackgroundBrush}"/>
-                                            <Setter Property="BorderBrush" Value="{DynamicResource ErrorBorderBrush}"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Border.Style>
-                            <TextBlock Text="{Binding StatusMessage}" TextWrapping="Wrap">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="Foreground" Value="{DynamicResource SuccessTextBrush}"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding HasError}" Value="True">
-                                                <Setter Property="Foreground" Value="{DynamicResource ErrorTextBrush}"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
-                        </Border>
-                    </StackPanel>
-                </ScrollViewer>
-            </Border>
         </Grid>
     </Grid>
 </UserControl>

--- a/Views/ProcessView.xaml
+++ b/Views/ProcessView.xaml
@@ -579,15 +579,49 @@
                                         </ItemsControl.ItemsPanel>
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <CheckBox Content="{Binding Label}"
-                                                          IsChecked="{Binding IsSelected, Mode=OneWay}"
-                                                          IsHitTestVisible="False"
-                                                          Focusable="False"
-                                                          IsEnabled="{Binding IsEnabled}"
-                                                          Margin="2"
-                                                          FontSize="{StaticResource ProcessFontSmall}"
-                                                          Foreground="{DynamicResource TextPrimaryBrush}"
-                                                          ToolTip="{DynamicResource ProcessView_CpuSelectionPreviewTooltip}"/>
+                                                <Border Margin="2"
+                                                        Padding="7,3"
+                                                        CornerRadius="4"
+                                                        IsHitTestVisible="False"
+                                                        IsEnabled="{Binding IsEnabled}"
+                                                        AutomationProperties.Name="{Binding Label}"
+                                                        AutomationProperties.HelpText="{DynamicResource ProcessView_CpuCoresReadOnlyHint}"
+                                                        ToolTip="{DynamicResource ProcessView_CpuSelectionPreviewTooltip}">
+                                                    <Border.Style>
+                                                        <Style TargetType="Border">
+                                                            <Setter Property="AutomationProperties.ItemStatus" Value="{DynamicResource ProcessView_CpuCoreNotSelected}"/>
+                                                            <Setter Property="Background" Value="{DynamicResource QuietRowBackgroundBrush}"/>
+                                                            <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}"/>
+                                                            <Setter Property="BorderThickness" Value="1"/>
+                                                            <Setter Property="Opacity" Value="1"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                                    <Setter Property="Background" Value="{DynamicResource MaskSelectedBackgroundBrush}"/>
+                                                                    <Setter Property="BorderBrush" Value="{DynamicResource MaskSelectedBorderBrush}"/>
+                                                                    <Setter Property="AutomationProperties.ItemStatus" Value="{DynamicResource ProcessView_CpuCoreSelected}"/>
+                                                                </DataTrigger>
+                                                                <DataTrigger Binding="{Binding IsEnabled}" Value="False">
+                                                                    <Setter Property="Opacity" Value="0.45"/>
+                                                                    <Setter Property="AutomationProperties.ItemStatus" Value="{DynamicResource ProcessView_CpuCoreUnavailable}"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </Border.Style>
+                                                    <TextBlock Text="{Binding Label}"
+                                                               FontSize="{StaticResource ProcessFontSmall}">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                                        <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                                        <Setter Property="FontWeight" Value="SemiBold"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Border>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>

--- a/Views/ProcessView.xaml
+++ b/Views/ProcessView.xaml
@@ -298,10 +298,12 @@
                                                       Header="{DynamicResource ProcessView_Rules}">
                                                 <MenuItem Style="{StaticResource ProcessContextMenuItemStyle}"
                                                           Header="{DynamicResource ProcessView_SaveCurrentRule}"
+                                                          ToolTip="{DynamicResource ProcessView_SaveRuleTooltip}"
                                                           Command="{Binding SaveCurrentSettingsAsRuleCommand}"
                                                           CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                                 <MenuItem Style="{StaticResource ProcessContextMenuItemStyle}"
                                                           Header="{DynamicResource ProcessView_ApplyAffinitySaveRule}"
+                                                          ToolTip="{DynamicResource ProcessView_SaveRuleTooltip}"
                                                           Command="{Binding ApplyAffinityAndSaveAsRuleCommand}"
                                                           CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                             </MenuItem>
@@ -573,7 +575,8 @@
 
                                 <ScrollViewer MaxHeight="88"
                                               VerticalScrollBarVisibility="Auto"
-                                              HorizontalScrollBarVisibility="Disabled">
+                                              HorizontalScrollBarVisibility="Disabled"
+                                              ToolTip="{DynamicResource ProcessView_CpuCoresReadOnlyHint}">
                                     <ItemsControl ItemsSource="{Binding CpuCores}">
                                         <ItemsControl.ItemsPanel>
                                             <ItemsPanelTemplate>
@@ -589,11 +592,18 @@
                                                           IsEnabled="{Binding IsEnabled}"
                                                           Margin="2"
                                                           FontSize="{StaticResource ProcessFontSmall}"
-                                                          Foreground="{DynamicResource TextPrimaryBrush}"/>
+                                                          Foreground="{DynamicResource TextPrimaryBrush}"
+                                                          ToolTip="{DynamicResource ProcessView_CpuSelectionPreviewTooltip}"/>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
                                 </ScrollViewer>
+
+                                <TextBlock Text="{DynamicResource ProcessView_CpuCoresReadOnlyHint}"
+                                           FontSize="{StaticResource ProcessFontSmall}"
+                                           Foreground="{DynamicResource TextSecondaryBrush}"
+                                           TextWrapping="Wrap"
+                                           Margin="0,6,0,0"/>
                             </StackPanel>
                         </Expander>
                     </StackPanel>
@@ -788,6 +798,7 @@
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
                                 </ScrollViewer>
+
 
                                 <Grid>
                                     <Grid.ColumnDefinitions>

--- a/Views/SystemTweaksView.xaml
+++ b/Views/SystemTweaksView.xaml
@@ -7,6 +7,69 @@
              mc:Ignorable="d"
              d:DesignHeight="600" d:DesignWidth="800">
 
+    <UserControl.Resources>
+        <!-- Larger, labelled pill toggle. The native ui:ToggleSwitch is 40x20 with no text,
+             which reads as a decoration rather than a switch on this dense list. -->
+        <Style x:Key="PillToggleButtonStyle" TargetType="ToggleButton">
+            <Setter Property="MinWidth" Value="56"/>
+            <Setter Property="Height" Value="28"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="HorizontalAlignment" Value="Right"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ToggleButton">
+                        <Border x:Name="Track"
+                                Background="{DynamicResource ControlFillColorSecondaryBrush}"
+                                BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="14"
+                                Padding="3"
+                                SnapsToDevicePixels="True">
+                            <!-- Thumb and label are docked, never stacked, so a long localized
+                                 label (ru "ВЫКЛ") pushes the pill wider instead of colliding with
+                                 the thumb. MinWidth keeps the common case at the intended size. -->
+                            <DockPanel LastChildFill="True">
+                                <Ellipse x:Name="Thumb"
+                                         DockPanel.Dock="Left"
+                                         Width="20"
+                                         Height="20"
+                                         Fill="{DynamicResource TextSecondaryBrush}"/>
+                                <TextBlock x:Name="StateLabel"
+                                           Text="{DynamicResource SystemTweaks_ToggleOff}"
+                                           FontSize="10"
+                                           FontWeight="SemiBold"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Center"
+                                           Margin="3,0,4,0"
+                                           Foreground="{DynamicResource TextSecondaryBrush}"/>
+                            </DockPanel>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="Track" Property="Background" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+                                <Setter TargetName="Track" Property="BorderBrush" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+                                <Setter TargetName="Thumb" Property="DockPanel.Dock" Value="Right"/>
+                                <Setter TargetName="Thumb" Property="Fill" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}"/>
+                                <Setter TargetName="StateLabel" Property="Text" Value="{DynamicResource SystemTweaks_ToggleOn}"/>
+                                <Setter TargetName="StateLabel" Property="Margin" Value="4,0,3,0"/>
+                                <Setter TargetName="StateLabel" Property="Foreground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}"/>
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Track" Property="BorderBrush" Value="{DynamicResource SoftSelectionBorderBrush}"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Track" Property="Background" Value="{DynamicResource ControlFillColorDisabledBrush}"/>
+                                <Setter TargetName="Track" Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}"/>
+                                <Setter TargetName="Track" Property="Opacity" Value="0.6"/>
+                                <Setter TargetName="Thumb" Property="Fill" Value="{DynamicResource TextSecondaryBrush}"/>
+                                <Setter TargetName="StateLabel" Property="Foreground" Value="{DynamicResource TextSecondaryBrush}"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -133,18 +196,18 @@
                                                    VerticalAlignment="Center"/>
                                     </StackPanel>
 
-                                    <ui:ToggleSwitch Grid.Column="1"
-                                                     IsChecked="{Binding IsEnabled, Mode=OneWay}"
-                                                     IsEnabled="{Binding IsAvailable}"
-                                                     Command="{Binding ToggleCommand}"
-                                                     CommandParameter="{Binding}"
-                                                     VerticalAlignment="Center"
-                                                     HorizontalAlignment="Right"
-                                                     Margin="10,0,0,0"
-                                                     AutomationProperties.Name="{Binding Name}"
-                                                     ToolTip="{DynamicResource SystemTweaksView_TweakTooltip}">
-                                        <ui:ToggleSwitch.Style>
-                                            <Style TargetType="ui:ToggleSwitch">
+                                    <ToggleButton Grid.Column="1"
+                                                  IsChecked="{Binding IsEnabled, Mode=OneWay}"
+                                                  IsEnabled="{Binding IsAvailable}"
+                                                  Command="{Binding ToggleCommand}"
+                                                  CommandParameter="{Binding}"
+                                                  VerticalAlignment="Center"
+                                                  HorizontalAlignment="Right"
+                                                  Margin="10,0,0,0"
+                                                  AutomationProperties.Name="{Binding Name}"
+                                                  ToolTip="{DynamicResource SystemTweaksView_TweakTooltip}">
+                                        <ToggleButton.Style>
+                                            <Style TargetType="ToggleButton" BasedOn="{StaticResource PillToggleButtonStyle}">
                                                 <Setter Property="Visibility" Value="Visible"/>
                                                 <Style.Triggers>
                                                     <DataTrigger Binding="{Binding IsGuidedAction}" Value="True">
@@ -152,8 +215,8 @@
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>
-                                        </ui:ToggleSwitch.Style>
-                                    </ui:ToggleSwitch>
+                                        </ToggleButton.Style>
+                                    </ToggleButton>
 
                                     <Button Grid.Column="1"
                                             Content="{DynamicResource SystemTweaks_OpenSettings}"

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.7.0.0" name="ThreadPilot.app"/>
+  <assemblyIdentity version="1.7.1.0" name="ThreadPilot.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.7.0",
+    [string]$Version = "1.7.1",
     [string]$Configuration = "Release",
     [switch]$SkipPublish
 )

--- a/build/build-release.ps1
+++ b/build/build-release.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.7.0",
+    [string]$Version = "1.7.1",
     [string]$Configuration = "Release",
     [string]$Runtime = "win-x64"
 )

--- a/build/package-release-zips.ps1
+++ b/build/package-release-zips.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.7.0"
+    [string]$Version = "1.7.1"
 )
 
 $ErrorActionPreference = "Stop"

--- a/chocolatey/threadpilot.nuspec
+++ b/chocolatey/threadpilot.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>threadpilot</id>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
     <title>ThreadPilot</title>
     <authors>Prime Build</authors>
     <projectUrl>https://github.com/PrimeBuild-pc/ThreadPilot</projectUrl>
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Advanced Windows process and power plan manager with rules automation and performance controls.</description>
     <summary>ThreadPilot process and power plan manager.</summary>
-    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.7.0</releaseNotes>
+    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.7.1</releaseNotes>
     <tags>threadpilot process powerplan performance windows</tags>
   </metadata>
   <files>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project are documented in this file.
 
+## v1.7.1 - CPU affinity apply fixes
+
+### Fixed
+
+- Applying a saved rule or a Rules-tab core mask now changes the CPU affinity Windows actually enforces. `SetProcessorAffinity` substituted a CPU Sets hint for the hard affinity write, so the caller's read-back never matched and every apply reported a verification failure while the affinity was left untouched.
+- The default CPU assignment mode is now `Affinity Mask`. The previous `ThreadPilot automatic` default applied only CPU Sets, a soft scheduling preference that leaves the affinity mask in Task Manager unchanged, and reported it as "Affinity applied successfully".
+- A CPU Sets result no longer claims an affinity was applied. It states that the assignment is a soft preference and that the Task Manager affinity mask is unchanged.
+- "Save Current Settings as Rule" no longer saves a rule pinned to every CPU. It captured the core selection only while edits were staged, otherwise falling back to a process affinity that the soft modes never changed.
+- `Automatic` mode no longer installs CPU Sets that a pre-existing hard affinity prevents Windows from honouring. It applies the hard affinity instead, which can actually replace the restriction.
+- Saved rules resolve CPU Sets from the current topology instead of trusting the CPU Set IDs stored when the rule was created. A stale rule now reports an invalid topology rather than silently pinning the wrong CPUs.
+- Affinity masks that include CPU 63 are no longer discarded. They are negative as signed 64-bit values and were rejected by magnitude comparisons.
+
+### Changed
+
+- The CPU assignment mode picker and the Apply CPU Assignment button are now on screen. They were added to a side panel that has been collapsed since v1.2.0, so neither had ever been reachable; the only way to apply affinity was the process context menu. Both now live in the Advanced Affinity Picker, which starts expanded.
+- The per-CPU cells in the Advanced Affinity Picker are read-only chips rather than checkboxes, with a hint explaining that a selection is staged through the pending core mask. They were never clickable; they only looked it.
+- System tweak toggles are larger and state ON or OFF inside the track, replacing the unlabelled 40x20 switch.
+- Saving a rule from the process context menu explains that the rule is re-applied automatically on process start and is separate from the Rules tab.
+- Removed the collapsed legacy side panel, an unreachable Process tab command, and an unused XML namespace.
+
+### Localization
+
+- Fixed "core mask" mistranslations in the Italian, Spanish, French and Russian locales, and German phrasing for the Rules tab and power plans.
+
 ## v1.7.0 - Gaming and device tuning
 
 ### Added

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -10,4 +10,4 @@ ThreadPilot does not transmit the local process list, executable paths, hardware
 
 The Power Plans and Settings pages contain links to Discord and GitHub Issues. ThreadPilot opens these links only after an explicit user click; the destination then receives ordinary connection information under its own privacy terms. ThreadPilot does not automatically download community power plans.
 
-This policy describes ThreadPilot 1.7.0. Material changes to data collection or network behavior will be documented before release.
+This policy describes ThreadPilot 1.7.1. Material changes to data collection or network behavior will be documented before release.

--- a/docs/release/RELEASE_NOTES.md
+++ b/docs/release/RELEASE_NOTES.md
@@ -1,42 +1,44 @@
-## ThreadPilot v1.7.0
+## ThreadPilot v1.7.1
 
-ThreadPilot 1.7.0 expands Windows gaming and device controls, adds persistent per-process I/O and power behavior, and prepares the release pipeline for trusted Authenticode signing.
+A patch release that makes the CPU affinity feature do what its name says. A user reported that applying a rule did nothing to a process's affinity. They were right, for several independent reasons.
 
-### Highlights
+### The headline fix
 
-- Control Game Mode, CPU Core Parking, supported CPU C-State behavior, USB selective suspend, pointer precision, supported Ethernet power-saving properties, interrupt moderation, and GPU MSI Mode.
-- Open the correct Windows pages for Memory Integrity, HAGS, and windowed-game optimizations without silently weakening Windows security.
-- Set memory and I/O priority per process and preserve them in persistent rules.
-- Prevent system sleep while a selected process is running through a Windows power request that is released automatically.
-- Restore backed-up device-driver values when supported tweaks are turned off.
-- Open community power-plan and support links on demand, or report a problem directly through GitHub Issues.
-- Use every new control and support action in all seven supported languages: English, Italian, German, Spanish, French, Russian, and Simplified Chinese.
+Applying a saved rule, or a core mask from the Rules tab, now changes the affinity mask Windows actually enforces.
 
-### Power-plan distribution change
+Two defects combined to hide this. `SetProcessorAffinity` silently substituted a Windows CPU Sets hint for the hard affinity write it was asked to perform, while the caller read the affinity back and compared it — so the apply always reported a verification failure and the affinity was never changed. Separately, the shipped default assignment mode was `ThreadPilot automatic`, which applies only CPU Sets: a soft scheduling preference that leaves the affinity mask in Task Manager untouched, reported to the user as "Affinity applied successfully".
 
-ThreadPilot no longer bundles the 89 third-party `.pow` files previously shipped with the application. Those files were publicly available, but no reliable per-file license or redistribution permission could be verified. Removing them keeps the signed release payload compatible with the SignPath Foundation requirement that distributed components have clear open-source redistribution rights.
+The default is now `Affinity Mask`, and a CPU Sets result says plainly that it is a soft preference and that Task Manager will not reflect it. Rules saved before this release keep the mode they were saved with; open the rule and pick `Affinity Mask` if you want a hard, visible restriction.
 
-This does not remove functionality or user data:
+### The controls were not on screen
 
-- Power plans already imported into Windows remain installed and active.
-- An upgrade does not delete `.pow` files left by an earlier ThreadPilot installation.
-- Manual `.pow` import remains available.
-- The new **More plans?** action opens the ThreadPilot community Discord only when the user clicks it; no plan is downloaded automatically or included in the signed package.
+The CPU assignment mode picker and the Apply CPU Assignment button, both added in v1.6.0, were placed in a side panel that had been collapsed since v1.2.0. Neither had ever been reachable in a shipped build: the only way to apply affinity was the process-list context menu, and the only way to change the assignment mode was the default in Settings. That is why the reporting user had no way to reach the control that would have fixed their problem.
 
-### Compatibility and safety
+Both now live in the Advanced Affinity Picker, which opens expanded. The collapsed legacy panel is removed.
 
-- Existing rules remain compatible; all new persistent options default to off.
-- Ethernet and GPU controls only modify properties already exposed by the installed driver and require administrator privileges.
-- Hardware and driver behavior varies. GPU MSI Mode and some Windows graphics or security changes may require a restart.
-- Memory Integrity remains a user-controlled Windows Security setting.
+### Also fixed
 
-### Validation
+- "Save Current Settings as Rule" no longer saves a rule pinned to every CPU. It captured the core selection only while edits were staged, and otherwise fell back to a process affinity that the soft modes never changed.
+- `Automatic` mode no longer installs CPU Sets that a pre-existing hard affinity prevents Windows from honouring. Windows never schedules a process outside its affinity mask, whatever CPU Sets are set, yet the read-back still verified. It now applies the hard affinity, which can replace the restriction.
+- Saved rules resolve CPU Sets against the current topology instead of trusting the CPU Set IDs stored when the rule was created. Those IDs are opaque and can name a different processor after a hardware change; a stale rule now reports an invalid topology instead of silently pinning the wrong CPUs.
+- Affinity masks that include CPU 63 are no longer discarded. They are negative as signed 64-bit values and were being rejected by magnitude comparisons.
 
-- 701 automated Release tests pass, including XAML compilation and localization-key coverage for all seven languages.
-- The final portable and installer artifacts contain zero `.pow` files.
-- A Windows 11 Hyper-V gate passed portable launch, clean install, normal launch, system-tweak apply/restore, upgrade, and uninstall checks without ThreadPilot application errors.
-- A real 1.6.0 to 1.7.0 installer upgrade preserved all 89 legacy `.pow` files byte-for-byte and did not change the active Windows power plan.
+### Interface
 
-### Signing status
+- The per-CPU cells in the Advanced Affinity Picker are read-only chips instead of checkboxes, with a hint explaining that a selection is staged through the pending core mask. They were never clickable; they only looked it. The chips keep their accessible name and report selected, not selected, or unavailable.
+- System tweak toggles are larger and state ON or OFF inside the track, replacing the unlabelled 40x20 switch. The label is localized and widens the control rather than being clipped.
+- Saving a rule from the process context menu now explains that the rule is re-applied automatically when the process next starts, and that these rules are separate from the Rules tab, which manages process-to-power-plan associations.
 
-Release artifacts remain unsigned while the SignPath Foundation application is pending. The automated build, test, packaging, checksum, SBOM, and publishing flow remains in place, including its existing optional Authenticode path. The SignPath-specific integration will be added and tested separately after approval.
+### Localization
+
+- Corrected "core mask" mistranslations in the Italian, Spanish, French and Russian locales, and German phrasing for the Rules tab and power plans.
+
+### Notes
+
+- Memory Integrity, hardware-accelerated GPU scheduling, and windowed-game optimizations still show a link to the relevant Windows page instead of a toggle. They are deliberately left to Windows.
+- Applying affinity to a process protected by anti-cheat still fails, by design. ThreadPilot reports it and does not attempt to bypass protection.
+
+### Verification
+
+- 707 unit tests, including new regression tests that fail against the previous implementation.
+- The affinity fix was verified end to end against a live process: requesting cores 0-1 now moves the process from `0xFFFF` to `0x3`, where it previously reported a failure and stayed at `0xFFFF`.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=threadpilot
 sonar.projectName=ThreadPilot
-sonar.projectVersion=1.7.0
+sonar.projectVersion=1.7.1
 
 sonar.sourceEncoding=UTF-8
 sonar.sources=.


### PR DESCRIPTION
A Discord user reported that ThreadPilot's CPU affinity feature did nothing when they applied a rule. They were right, for several independent reasons.

## Root causes

**The hard affinity write was replaced by a soft hint.** `ProcessService.SetProcessorAffinity(process, long)` called `SetProcessDefaultCpuSets` instead of writing the affinity mask. CPU Sets are a scheduling preference and leave the mask returned by `GetProcessAffinityMask` untouched, while the only caller reads that mask back and compares it — so every apply reported `VerificationMismatch` and the affinity never changed. Reproduced on a 16-CPU machine: requesting `0x3` left the process at `0xFFFF` and returned a failure.

**The controls were not on screen.** The CPU assignment mode picker and the Apply CPU Assignment button, both added in v1.6.0, were placed inside a side panel that has been `Visibility="Collapsed"` since 91287c9 (v1.2.0). Neither had ever been reachable in a shipped build. The only way to apply affinity was the process context menu, and the only way to change the mode was the default in Settings — which was `Automatic`, i.e. CPU Sets only.

## Changes

- `SetProcessorAffinity(process, long)` writes the affinity mask it is asked for. Soft assignment keeps its own entry points.
- Default assignment mode is now `Affinity Mask`. A CPU Sets result says it is a soft preference and that Task Manager will not reflect it.
- "Save Current Settings as Rule" no longer saves a rule pinned to every CPU.
- `Automatic` no longer installs CPU Sets that an existing hard affinity prevents Windows from honouring.
- Saved rules resolve CPU Sets against the current topology instead of trusting stored CPU Set IDs.
- Affinity masks including CPU 63 are no longer discarded as negative signed values.
- The mode picker and Apply button moved into the visible Advanced Affinity Picker; the 326-line collapsed panel is deleted.
- The per-CPU cells are read-only chips rather than checkboxes, keeping their accessible name and state.
- System tweak toggles are larger and labelled ON/OFF, localized, and widen rather than clip.
- Corrected "core mask" mistranslations in it/es/fr/ru and German phrasing.

## Verification

707 unit tests, including new regression tests that fail against the previous implementation. The affinity fix was verified end to end against a live process, and the UI changes were verified by rendering the real templates in both themes and in the widest-label locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhS1xyuMPFvxrojERQ4NuY