### PR TITLE
Migrate upgraded profiles off Automatic and announce it (1.7.2)

### DIFF
--- a/Helpers/CpuAssignmentModeMigrationPolicy.cs
+++ b/Helpers/CpuAssignmentModeMigrationPolicy.cs
@@ -1,0 +1,57 @@
+namespace ThreadPilot.Helpers
+{
+    using System;
+    using ThreadPilot.Models;
+
+    /// <summary>
+    /// v1.7.1 changed the shipped default CPU assignment mode from <see cref="CpuAssignmentMode.Automatic"/>
+    /// to <see cref="CpuAssignmentMode.AffinityMask"/>, because Automatic applies only Windows CPU Sets:
+    /// a soft scheduling preference that leaves the affinity mask shown in Task Manager unchanged.
+    /// A persisted setting always wins over a new default, so everyone upgrading kept the mode that
+    /// made the affinity feature look like it did nothing. Move them once, and tell them it happened.
+    /// </summary>
+    public static class CpuAssignmentModeMigrationPolicy
+    {
+        /// <summary>
+        /// Runs the one-time migration. Returns true when the profile was modified and must be
+        /// persisted - including the case where only the completion flags changed. Persisting those
+        /// matters: without them a profile is migrated again on the next launch, which would undo a
+        /// deliberate return to <see cref="CpuAssignmentMode.Automatic"/>.
+        /// </summary>
+        public static bool Apply(ApplicationSettingsModel settings)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+
+            if (settings.HasMigratedCpuAssignmentModeDefault)
+            {
+                return false;
+            }
+
+            settings.HasMigratedCpuAssignmentModeDefault = true;
+
+            if (settings.DefaultCpuAssignmentMode != CpuAssignmentMode.Automatic)
+            {
+                // Nothing changed for this user, so there is nothing to tell them about - but the
+                // completion flags still have to reach disk.
+                settings.HasSeenCpuAssignmentModeChangeNotice = true;
+                return true;
+            }
+
+            settings.DefaultCpuAssignmentMode = CpuAssignmentMode.AffinityMask;
+            settings.HasSeenCpuAssignmentModeChangeNotice = false;
+            return true;
+        }
+
+        /// <summary>
+        /// True while the migration has moved this profile but the user has not acknowledged it yet.
+        /// Surviving a restart matters here: the notice is the only thing telling them their mode changed.
+        /// </summary>
+        public static bool ShouldShowNotice(ApplicationSettingsModel settings)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+
+            return settings.HasMigratedCpuAssignmentModeDefault
+                && !settings.HasSeenCpuAssignmentModeChangeNotice;
+        }
+    }
+}

--- a/Installer/Installer.iss
+++ b/Installer/Installer.iss
@@ -5,7 +5,7 @@
 #define MyAppPublisher "ThreadPilot"
 #define MyAppURL "https://github.com/"
 #define MyAppExeName "ThreadPilot.exe"
-#define MyAppVersion "1.7.1"
+#define MyAppVersion "1.7.2"
 
 #ifndef MyWizardStyle
   #define MyWizardStyle "modern dynamic windows11"

--- a/Installer/ThreadPilot.wxs
+++ b/Installer/ThreadPilot.wxs
@@ -7,7 +7,7 @@
   <Package
       Name="ThreadPilot"
       Manufacturer="Prime Build"
-      Version="1.7.1.0"
+      Version="1.7.2.0"
       UpgradeCode="PUT-GENERATED-UPGRADE-CODE-HERE"
       Language="1033">
     <SummaryInformation Description="ThreadPilot MSI template" />

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -11,7 +11,7 @@
 #endif
 
 #ifndef MyAppVersion
-	#define MyAppVersion "1.7.1"
+	#define MyAppVersion "1.7.2"
 #endif
 
 #ifndef MyAppSourceDir

--- a/Locales/de-DE.xaml
+++ b/Locales/de-DE.xaml
@@ -26,6 +26,10 @@
 
     <!-- MainWindow Overlays -->
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionTitle">Start minimiert</sys:String>
+    <sys:String x:Key="MainWindow_WhatsNew">Neuerungen</sys:String>
+    <sys:String x:Key="MainWindow_GotIt">Verstanden</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedTitle">Ihr CPU-Zuweisungsmodus wurde geändert</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedDescription">Sie haben „ThreadPilot automatisch“ verwendet. Dieser Modus setzt Windows-CPU-Sets: eine Planungspräferenz, die die Affinitätsmaske im Task-Manager unverändert lässt. ThreadPilot hat auf „Affinitätsmaske“ umgestellt, was eine echte, sichtbare Affinität setzt. Sie können dies jederzeit in den Einstellungen zurückstellen.</sys:String>
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionDescription">Aktivieren Sie „Start minimiert“, wenn ThreadPilot bei zukünftigen Windows-Anmeldungen automatisch in der Taskleiste gestartet werden soll.</sys:String>
     <sys:String x:Key="MainWindow_Recommended">Empfohlen</sys:String>
     <sys:String x:Key="MainWindow_DontShowAgain">Nicht mehr anzeigen</sys:String>

--- a/Locales/en-US.xaml
+++ b/Locales/en-US.xaml
@@ -26,6 +26,10 @@
     
     <!-- MainWindow Overlays -->
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionTitle">Startup minimized</sys:String>
+    <sys:String x:Key="MainWindow_WhatsNew">What's new</sys:String>
+    <sys:String x:Key="MainWindow_GotIt">Got it</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedTitle">Your CPU assignment mode changed</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedDescription">You were using “ThreadPilot automatic”, which applies Windows CPU Sets: a scheduling preference that leaves the affinity mask in Task Manager unchanged. ThreadPilot has switched you to “Affinity Mask”, which sets a real, visible affinity. You can change this back at any time in Settings.</sys:String>
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionDescription">Enable Startup minimized when you want ThreadPilot to start silently in the tray on future Windows sign-ins.</sys:String>
     <sys:String x:Key="MainWindow_Recommended">Recommended</sys:String>
     <sys:String x:Key="MainWindow_DontShowAgain">Don't show again</sys:String>

--- a/Locales/es-ES.xaml
+++ b/Locales/es-ES.xaml
@@ -26,6 +26,10 @@
 
     <!-- MainWindow Overlays -->
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionTitle">Inicio minimizado</sys:String>
+    <sys:String x:Key="MainWindow_WhatsNew">Novedades</sys:String>
+    <sys:String x:Key="MainWindow_GotIt">Entendido</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedTitle">Ha cambiado su modo de asignación de CPU</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedDescription">Estaba usando “ThreadPilot automático”, que aplica CPU Sets de Windows: una preferencia de planificación que deja sin cambios la máscara de afinidad del Administrador de tareas. ThreadPilot ha cambiado a “Máscara de afinidad”, que establece una afinidad real y visible. Puede volver a cambiarlo cuando quiera en Configuración.</sys:String>
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionDescription">Habilite Inicio minimizado cuando desee que ThreadPilot se inicie silenciosamente en la bandeja en futuros inicios de sesión de Windows.</sys:String>
     <sys:String x:Key="MainWindow_Recommended">Recomendado</sys:String>
     <sys:String x:Key="MainWindow_DontShowAgain">No volver a mostrar</sys:String>

--- a/Locales/fr-FR.xaml
+++ b/Locales/fr-FR.xaml
@@ -26,6 +26,10 @@
 
     <!-- MainWindow Overlays -->
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionTitle">Démarrage minimisé</sys:String>
+    <sys:String x:Key="MainWindow_WhatsNew">Nouveautés</sys:String>
+    <sys:String x:Key="MainWindow_GotIt">J’ai compris</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedTitle">Votre mode d’affectation CPU a changé</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedDescription">Vous utilisiez « ThreadPilot automatique », qui applique les CPU Sets de Windows : une préférence de planification qui laisse inchangé le masque d’affinité du Gestionnaire des tâches. ThreadPilot est passé à « Masque d’affinité », qui définit une affinité réelle et visible. Vous pouvez revenir en arrière à tout moment dans les Paramètres.</sys:String>
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionDescription">Activez le démarrage réduit lorsque vous souhaitez que ThreadPilot démarre silencieusement dans la barre d'état lors des futures connexions Windows.</sys:String>
     <sys:String x:Key="MainWindow_Recommended">Recommandé</sys:String>
     <sys:String x:Key="MainWindow_DontShowAgain">Ne plus montrer</sys:String>

--- a/Locales/it-IT.xaml
+++ b/Locales/it-IT.xaml
@@ -26,6 +26,10 @@
 
     <!-- MainWindow Overlays -->
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionTitle">Avvio ridotto a icona</sys:String>
+    <sys:String x:Key="MainWindow_WhatsNew">Novità</sys:String>
+    <sys:String x:Key="MainWindow_GotIt">Ho capito</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedTitle">La modalità di assegnazione CPU è cambiata</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedDescription">Stavi usando “ThreadPilot automatico”, che applica i CPU Sets di Windows: una preferenza di scheduling che lascia invariata la maschera di affinità in Gestione attività. ThreadPilot è passato a “Maschera di affinità”, che imposta un’affinità reale e visibile. Puoi tornare indietro quando vuoi dalle Impostazioni.</sys:String>
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionDescription">Abilita Avvio ridotto a icona quando desideri che ThreadPilot venga avviato in modalità silenziosa nella barra delle applicazioni agli accessi futuri di Windows.</sys:String>
     <sys:String x:Key="MainWindow_Recommended">Consigliato</sys:String>
     <sys:String x:Key="MainWindow_DontShowAgain">Non mostrare più</sys:String>

--- a/Locales/ru-RU.xaml
+++ b/Locales/ru-RU.xaml
@@ -26,6 +26,10 @@
 
     <!-- MainWindow Overlays -->
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionTitle">Запуск свернут</sys:String>
+    <sys:String x:Key="MainWindow_WhatsNew">Что нового</sys:String>
+    <sys:String x:Key="MainWindow_GotIt">Понятно</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedTitle">Режим назначения ЦП изменён</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedDescription">Вы использовали режим «ThreadPilot автоматически», который применяет CPU Sets Windows: это предпочтение планировщика, которое не меняет маску привязки в Диспетчере задач. ThreadPilot переключил вас на «Маску привязки», которая задаёт реальную и видимую привязку. Вернуть прежний режим можно в Настройках.</sys:String>
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionDescription">Включите свертывание запуска, если вы хотите, чтобы ThreadPilot автоматически запускался в области уведомлений при последующих входах в систему Windows.</sys:String>
     <sys:String x:Key="MainWindow_Recommended">Рекомендуется</sys:String>
     <sys:String x:Key="MainWindow_DontShowAgain">Больше не показывать</sys:String>

--- a/Locales/zh-CN.xaml
+++ b/Locales/zh-CN.xaml
@@ -26,6 +26,10 @@
     
     <!-- MainWindow Overlays -->
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionTitle">启动时最小化</sys:String>
+    <sys:String x:Key="MainWindow_WhatsNew">新功能</sys:String>
+    <sys:String x:Key="MainWindow_GotIt">知道了</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedTitle">您的 CPU 分配模式已更改</sys:String>
+    <sys:String x:Key="MainWindow_CpuAssignmentModeChangedDescription">您之前使用的是“ThreadPilot 自动”，它应用 Windows CPU Sets：这是一种调度偏好，不会改变任务管理器中的关联掩码。ThreadPilot 已为您切换到“关联掩码”，它会设置真实且可见的关联。您可以随时在设置中改回。</sys:String>
     <sys:String x:Key="MainWindow_StartupMinimizedSuggestionDescription">开启此项后，ThreadPilot 会在 Windows 登录时静默启动至系统托盘。</sys:String>
     <sys:String x:Key="MainWindow_Recommended">推荐</sys:String>
     <sys:String x:Key="MainWindow_DontShowAgain">不再显示</sys:String>

--- a/MainWindow.Behaviors.partial.cs
+++ b/MainWindow.Behaviors.partial.cs
@@ -289,6 +289,7 @@ namespace ThreadPilot
                         // Show elevation warning if needed
                         this.TryShowElevationWarning();
                         this.TryShowStartupMinimizedSuggestion();
+                        this.TryShowCpuAssignmentModeChangedNotice();
                     };
                     fadeOutAnimation.Begin();
                 }
@@ -308,6 +309,7 @@ namespace ThreadPilot
                     // Show elevation warning if needed
                     this.TryShowElevationWarning();
                     this.TryShowStartupMinimizedSuggestion();
+                    this.TryShowCpuAssignmentModeChangedNotice();
                 }
             }
             catch (Exception ex)
@@ -328,6 +330,7 @@ namespace ThreadPilot
                     // Show elevation warning if needed
                     this.TryShowElevationWarning();
                     this.TryShowStartupMinimizedSuggestion();
+                    this.TryShowCpuAssignmentModeChangedNotice();
                 }
                 catch (Exception fallbackEx)
                 {
@@ -1650,6 +1653,73 @@ namespace ThreadPilot
             }
         }
 
+        private void TryShowCpuAssignmentModeChangedNotice()
+        {
+            if (this.isSilentStartupMode
+                || !this.isInitializationComplete
+                || this.isElevationWarningVisible
+
+                // One blocking overlay at a time. The startup suggestion sits below this one, so
+                // stacking them would hide it behind a card the user did not ask for; it queues
+                // this notice again when it is dismissed.
+                || this.StartupMinimizedSuggestionOverlay.Visibility == Visibility.Visible)
+            {
+                return;
+            }
+
+            try
+            {
+                if (!CpuAssignmentModeMigrationPolicy.ShouldShowNotice(this.settingsService.Settings))
+                {
+                    return;
+                }
+
+                this.CpuAssignmentModeChangedOverlay.Visibility = Visibility.Visible;
+                this.CpuAssignmentModeChangedGotItButton.Focus();
+            }
+            catch (Exception ex)
+            {
+                this.LogDebug($"Failed to show CPU assignment mode change notice: {ex.Message}");
+            }
+        }
+
+        private async Task PersistCpuAssignmentModeNoticeSeenAsync()
+        {
+            try
+            {
+                var settings = this.settingsService.Settings;
+                if (settings.HasSeenCpuAssignmentModeChangeNotice)
+                {
+                    return;
+                }
+
+                settings.HasSeenCpuAssignmentModeChangeNotice = true;
+                await this.settingsService.UpdateSettingsAsync(settings);
+            }
+            catch (Exception ex)
+            {
+                this.LogDebug($"Failed to persist CPU assignment mode notice state: {ex.Message}");
+            }
+        }
+
+        private void HideCpuAssignmentModeChangedNotice()
+        {
+            this.CpuAssignmentModeChangedOverlay.Visibility = Visibility.Collapsed;
+        }
+
+        private async void CpuAssignmentModeChangedOpenSettings_Click(object sender, RoutedEventArgs e)
+        {
+            await this.PersistCpuAssignmentModeNoticeSeenAsync();
+            this.HideCpuAssignmentModeChangedNotice();
+            this.SelectMainTab("Settings");
+        }
+
+        private async void CpuAssignmentModeChangedGotIt_Click(object sender, RoutedEventArgs e)
+        {
+            await this.PersistCpuAssignmentModeNoticeSeenAsync();
+            this.HideCpuAssignmentModeChangedNotice();
+        }
+
         private void TryShowStartupMinimizedSuggestion()
         {
             if (!this.showStartupMinimizedSuggestionOnReady
@@ -1707,12 +1777,14 @@ namespace ThreadPilot
             await this.PersistStartupMinimizedSuggestionSeenAsync();
             this.HideStartupMinimizedSuggestion();
             this.SelectMainTab("Settings");
+            this.TryShowCpuAssignmentModeChangedNotice();
         }
 
         private async void StartupSuggestionDontShowAgain_Click(object sender, RoutedEventArgs e)
         {
             await this.PersistStartupMinimizedSuggestionSeenAsync();
             this.HideStartupMinimizedSuggestion();
+            this.TryShowCpuAssignmentModeChangedNotice();
         }
 
         private void HidePerformanceIntro()
@@ -1855,6 +1927,7 @@ namespace ThreadPilot
             }
 
             this.TryShowStartupMinimizedSuggestion();
+            this.TryShowCpuAssignmentModeChangedNotice();
         }
 
         private void ElevationWarningDismiss_Click(object sender, RoutedEventArgs e)

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -423,6 +423,65 @@
                 </Border>
             </Grid>
 
+            <Grid x:Name="CpuAssignmentModeChangedOverlay"
+                  Visibility="Collapsed"
+                  Panel.ZIndex="956"
+                  Background="{DynamicResource OverlayBrush}"
+                  AutomationProperties.Name="{DynamicResource MainWindow_CpuAssignmentModeChangedTitle}">
+                <Border Background="{DynamicResource CardSurfaceBrush}"
+                        BorderBrush="{DynamicResource BorderSubtleBrush}"
+                        BorderThickness="1"
+                        CornerRadius="{DynamicResource StandardCardCornerRadius}"
+                        Padding="20"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Top"
+                        Margin="0,56,0,0"
+                        MinWidth="420"
+                        MaxWidth="560"
+                        IsHitTestVisible="True">
+                    <Border.Effect>
+                        <DropShadowEffect BlurRadius="12" ShadowDepth="0" Opacity="0.16"/>
+                    </Border.Effect>
+                    <StackPanel>
+                        <Border Background="{DynamicResource StatusPillBackgroundBrush}"
+                                BorderBrush="{DynamicResource StatusPillBorderBrush}"
+                                BorderThickness="1"
+                                CornerRadius="{DynamicResource StandardCardCornerRadius}"
+                                Padding="8,3"
+                                HorizontalAlignment="Left"
+                                Margin="0,0,0,10">
+                            <TextBlock Text="{DynamicResource MainWindow_WhatsNew}"
+                                       FontSize="{DynamicResource CaptionFontSize}"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                        </Border>
+                        <TextBlock Text="{DynamicResource MainWindow_CpuAssignmentModeChangedTitle}"
+                                   FontSize="20"
+                                   FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                   Margin="0,0,0,8"/>
+                        <TextBlock Text="{DynamicResource MainWindow_CpuAssignmentModeChangedDescription}"
+                                   TextWrapping="Wrap"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                   Margin="0,0,0,16"/>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                            <Button x:Name="CpuAssignmentModeChangedGotItButton"
+                                    Content="{DynamicResource MainWindow_GotIt}"
+                                    Click="CpuAssignmentModeChangedGotIt_Click"
+                                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                    Padding="14,7"
+                                    Margin="0,0,10,0"/>
+                            <Button Content="{DynamicResource MainWindow_OpenSettings}"
+                                    Click="CpuAssignmentModeChangedOpenSettings_Click"
+                                    Background="{DynamicResource ControlFillColorTertiaryBrush}"
+                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                    Padding="14,7"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </Grid>
+
             <Grid x:Name="UnsavedSettingsOverlay"
                   Visibility="Collapsed"
                   Panel.ZIndex="960"

--- a/Models/ApplicationSettingsModel.cs
+++ b/Models/ApplicationSettingsModel.cs
@@ -162,6 +162,14 @@ namespace ThreadPilot.Models
         [ObservableProperty]
         private CpuAssignmentMode defaultCpuAssignmentMode = CpuAssignmentMode.AffinityMask;
 
+        // Set on a profile that has been through CpuAssignmentModeMigrationPolicy, so the one-time
+        // move off Automatic never runs twice and never overrides a later deliberate choice.
+        [ObservableProperty]
+        private bool hasMigratedCpuAssignmentModeDefault;
+
+        [ObservableProperty]
+        private bool hasSeenCpuAssignmentModeChangeNotice;
+
         // Advanced Settings
         [ObservableProperty]
         private bool enableDebugLogging = false;
@@ -250,9 +258,11 @@ namespace ThreadPilot.Models
             this.EnableFallbackPolling = other.EnableFallbackPolling;
             this.ApplyPersistentRulesOnProcessStart = other.ApplyPersistentRulesOnProcessStart;
             this.EnableAutomationMonitoring = other.EnableAutomationMonitoring;
+            // Repair to the shipped default, not to Automatic: a corrupt value is not a choice the
+            // user made, and treating it as one would tell them their Automatic setting was changed.
             this.DefaultCpuAssignmentMode = Enum.IsDefined(other.DefaultCpuAssignmentMode)
                 ? other.DefaultCpuAssignmentMode
-                : CpuAssignmentMode.Automatic;
+                : CpuAssignmentMode.AffinityMask;
 
             // Advanced Settings
             this.EnableDebugLogging = other.EnableDebugLogging;
@@ -260,6 +270,8 @@ namespace ThreadPilot.Models
             this.HasSeenPerformanceIntro = other.HasSeenPerformanceIntro;
             this.HasSeenElevationWarning = other.HasSeenElevationWarning;
             this.HasSeenStartupMinimizedSuggestion = other.HasSeenStartupMinimizedSuggestion;
+            this.HasMigratedCpuAssignmentModeDefault = other.HasMigratedCpuAssignmentModeDefault;
+            this.HasSeenCpuAssignmentModeChangeNotice = other.HasSeenCpuAssignmentModeChangeNotice;
             this.EnableSelfLowImpactMode = other.EnableSelfLowImpactMode;
             this.EnableSelfAffinityLimit = other.EnableSelfAffinityLimit;
             this.MaxLogFileSizeMb = other.MaxLogFileSizeMb;

--- a/Services/ApplicationSettingsService.cs
+++ b/Services/ApplicationSettingsService.cs
@@ -7,6 +7,7 @@ namespace ThreadPilot.Services
     using System.Text.Json;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
+    using ThreadPilot.Helpers;
     using ThreadPilot.Models;
     using ThreadPilot.Services.Abstractions;
 
@@ -130,9 +131,26 @@ namespace ThreadPilot.Services
                     this.settings.CopyFrom(loadedSettings);
                     this.ValidateAndFixSettings();
 
-                    if (requiresLanguageRepair)
+                    var migrationChangedSettings = CpuAssignmentModeMigrationPolicy.Apply(this.settings);
+                    if (CpuAssignmentModeMigrationPolicy.ShouldShowNotice(this.settings))
                     {
-                        await this.SaveSettingsAsync();
+                        this.logger.LogInformation(
+                            "Migrated the default CPU assignment mode from Automatic to AffinityMask. Automatic applies CPU Sets only, which does not change the affinity mask Windows enforces.");
+                    }
+
+                    if (requiresLanguageRepair || migrationChangedSettings)
+                    {
+                        try
+                        {
+                            await this.SaveSettingsAsync();
+                        }
+                        catch (Exception ex)
+                        {
+                            // Losing the write is recoverable - it is retried on the next launch.
+                            // Falling into the outer catch is not: it would replace the profile we
+                            // just loaded with defaults and swallow the pending migration notice.
+                            this.logger.LogWarning(ex, "Could not persist repaired or migrated settings; keeping the loaded profile for this session");
+                        }
                     }
 
                     this.logger.LogInformation("Settings loaded successfully");
@@ -276,7 +294,8 @@ namespace ThreadPilot.Services
 
             if (!Enum.IsDefined(this.settings.DefaultCpuAssignmentMode))
             {
-                this.settings.DefaultCpuAssignmentMode = CpuAssignmentMode.Automatic;
+                // Repair to the shipped default rather than Automatic; see CopyFrom.
+                this.settings.DefaultCpuAssignmentMode = CpuAssignmentMode.AffinityMask;
             }
         }
 
@@ -357,6 +376,11 @@ namespace ThreadPilot.Services
             var defaults = new ApplicationSettingsModel
             {
                 Language = LocalizationService.ResolveSystemLanguage(this.systemUiCultureProvider()),
+
+                // A brand new profile already ships with AffinityMask, so there is nothing to
+                // migrate and nothing to announce.
+                HasMigratedCpuAssignmentModeDefault = true,
+                HasSeenCpuAssignmentModeChangeNotice = true,
             };
             return defaults;
         }

--- a/Tests/ThreadPilot.Core.Tests/ApplicationSettingsServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ApplicationSettingsServiceTests.cs
@@ -44,6 +44,114 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
+        public async Task LoadSettingsAsync_PersistsCompletionForANonAutomaticProfile()
+        {
+            // Without this the policy re-runs on every launch, and a later deliberate switch back
+            // to Automatic would be silently undone by a second migration.
+            var storage = new FakeSettingsStorage();
+            storage.Files[TestPaths.SettingsFilePath] =
+                "{\"defaultCpuAssignmentMode\": 3, \"language\": \"en-US\"}";
+            var service = CreateService(storage);
+
+            await service.LoadSettingsAsync();
+
+            Assert.Equal(CpuAssignmentMode.CpuSets, service.Settings.DefaultCpuAssignmentMode);
+            Assert.True(service.Settings.HasMigratedCpuAssignmentModeDefault);
+            Assert.True(service.Settings.HasSeenCpuAssignmentModeChangeNotice);
+            Assert.True(storage.Writes.ContainsKey(TestPaths.SettingsFilePath));
+
+            var reloaded = CreateService(storage);
+            await reloaded.LoadSettingsAsync();
+            Assert.Equal(CpuAssignmentMode.CpuSets, reloaded.Settings.DefaultCpuAssignmentMode);
+            Assert.True(reloaded.Settings.HasMigratedCpuAssignmentModeDefault);
+        }
+
+        [Fact]
+        public async Task LoadSettingsAsync_RepairsACorruptModeWithoutAnnouncingAChange()
+        {
+            // A value out of the enum range is not a choice the user made, so telling them their
+            // Automatic setting was changed would be a lie.
+            var storage = new FakeSettingsStorage();
+            storage.Files[TestPaths.SettingsFilePath] =
+                "{\"defaultCpuAssignmentMode\": 99, \"language\": \"en-US\"}";
+            var service = CreateService(storage);
+
+            await service.LoadSettingsAsync();
+
+            Assert.Equal(CpuAssignmentMode.AffinityMask, service.Settings.DefaultCpuAssignmentMode);
+            Assert.True(service.Settings.HasSeenCpuAssignmentModeChangeNotice);
+        }
+
+        [Fact]
+        public async Task LoadSettingsAsync_KeepsTheMigratedProfileWhenPersistingItFails()
+        {
+            // Falling into the outer catch would replace everything the user configured with
+            // defaults and mark the notice seen, hiding the change entirely.
+            var storage = new FakeSettingsStorage { FailWrites = true };
+            storage.Files[TestPaths.SettingsFilePath] =
+                "{\"defaultCpuAssignmentMode\": 0, \"maxNotificationHistoryItems\": 42, \"language\": \"en-US\"}";
+            var service = CreateService(storage);
+
+            await service.LoadSettingsAsync();
+
+            Assert.Equal(CpuAssignmentMode.AffinityMask, service.Settings.DefaultCpuAssignmentMode);
+            Assert.Equal(42, service.Settings.MaxNotificationHistoryItems);
+            Assert.False(service.Settings.HasSeenCpuAssignmentModeChangeNotice);
+        }
+
+        [Fact]
+        public async Task LoadSettingsAsync_MigratesAnUpgradedProfileOffAutomaticAndPersistsIt()
+        {
+            // A profile written by 1.7.0 or earlier: Automatic was the shipped default then, and the
+            // persisted value kept winning over the new one after the 1.7.1 upgrade.
+            var storage = new FakeSettingsStorage();
+            storage.Files[TestPaths.SettingsFilePath] =
+                "{\"defaultCpuAssignmentMode\": 0, \"language\": \"en-US\"}";
+            var service = CreateService(storage);
+
+            await service.LoadSettingsAsync();
+
+            Assert.Equal(CpuAssignmentMode.AffinityMask, service.Settings.DefaultCpuAssignmentMode);
+            Assert.True(service.Settings.HasMigratedCpuAssignmentModeDefault);
+            Assert.False(service.Settings.HasSeenCpuAssignmentModeChangeNotice);
+
+            // Must be written back, or the migration would run again on every launch.
+            Assert.True(storage.Writes.ContainsKey(TestPaths.SettingsFilePath));
+            var reloaded = CreateService(storage);
+            await reloaded.LoadSettingsAsync();
+            Assert.Equal(CpuAssignmentMode.AffinityMask, reloaded.Settings.DefaultCpuAssignmentMode);
+            Assert.True(reloaded.Settings.HasMigratedCpuAssignmentModeDefault);
+            Assert.False(reloaded.Settings.HasSeenCpuAssignmentModeChangeNotice);
+        }
+
+        [Fact]
+        public async Task LoadSettingsAsync_DoesNotAnnounceAnythingToAFreshProfile()
+        {
+            var storage = new FakeSettingsStorage();
+            var service = CreateService(storage);
+
+            await service.LoadSettingsAsync();
+
+            Assert.Equal(CpuAssignmentMode.AffinityMask, service.Settings.DefaultCpuAssignmentMode);
+            Assert.True(service.Settings.HasMigratedCpuAssignmentModeDefault);
+            Assert.True(service.Settings.HasSeenCpuAssignmentModeChangeNotice);
+        }
+
+        [Fact]
+        public async Task LoadSettingsAsync_KeepsAutomaticChosenAfterTheMigration()
+        {
+            var storage = new FakeSettingsStorage();
+            storage.Files[TestPaths.SettingsFilePath] =
+                "{\"defaultCpuAssignmentMode\": 0, \"hasMigratedCpuAssignmentModeDefault\": true, " +
+                "\"hasSeenCpuAssignmentModeChangeNotice\": true, \"language\": \"en-US\"}";
+            var service = CreateService(storage);
+
+            await service.LoadSettingsAsync();
+
+            Assert.Equal(CpuAssignmentMode.Automatic, service.Settings.DefaultCpuAssignmentMode);
+        }
+
+        [Fact]
         public async Task UpdateSettingsAsync_RoundTripsDefaultCpuAssignmentMode()
         {
             var storage = new FakeSettingsStorage();
@@ -391,8 +499,15 @@ namespace ThreadPilot.Core.Tests
                 return Task.FromResult<string?>(content);
             }
 
+            public bool FailWrites { get; init; }
+
             public Task WriteAsync(string path, string content)
             {
+                if (this.FailWrites)
+                {
+                    throw new IOException("Simulated write failure.");
+                }
+
                 this.Files[path] = content;
                 this.Writes[path] = content;
                 return Task.CompletedTask;

--- a/Tests/ThreadPilot.Core.Tests/CpuAssignmentModeMigrationPolicyTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/CpuAssignmentModeMigrationPolicyTests.cs
@@ -1,0 +1,115 @@
+namespace ThreadPilot.Core.Tests
+{
+    using ThreadPilot.Helpers;
+    using ThreadPilot.Models;
+
+    public sealed class CpuAssignmentModeMigrationPolicyTests
+    {
+        [Fact]
+        public void Apply_MovesAnUpgradedProfileOffAutomatic()
+        {
+            // The case that shipped broken: 1.7.1 changed the default, but a persisted Automatic
+            // won over it, so upgrading users kept soft CPU Sets and saw no affinity change.
+            var settings = new ApplicationSettingsModel
+            {
+                DefaultCpuAssignmentMode = CpuAssignmentMode.Automatic,
+                HasMigratedCpuAssignmentModeDefault = false,
+                HasSeenCpuAssignmentModeChangeNotice = false,
+            };
+
+            var changed = CpuAssignmentModeMigrationPolicy.Apply(settings);
+
+            Assert.True(changed);
+            Assert.Equal(CpuAssignmentMode.AffinityMask, settings.DefaultCpuAssignmentMode);
+            Assert.True(settings.HasMigratedCpuAssignmentModeDefault);
+            Assert.False(settings.HasSeenCpuAssignmentModeChangeNotice);
+            Assert.True(CpuAssignmentModeMigrationPolicy.ShouldShowNotice(settings));
+        }
+
+        [Theory]
+        [InlineData(CpuAssignmentMode.AffinityMask)]
+        [InlineData(CpuAssignmentMode.IdealProcessor)]
+        [InlineData(CpuAssignmentMode.CpuSets)]
+        public void Apply_LeavesAnyOtherModeAloneButStillRecordsCompletion(CpuAssignmentMode mode)
+        {
+            var settings = new ApplicationSettingsModel
+            {
+                DefaultCpuAssignmentMode = mode,
+                HasMigratedCpuAssignmentModeDefault = false,
+                HasSeenCpuAssignmentModeChangeNotice = false,
+            };
+
+            var changed = CpuAssignmentModeMigrationPolicy.Apply(settings);
+
+            // True because the completion flags changed: they have to be persisted, or the policy
+            // re-runs next launch and would undo a later deliberate switch to Automatic.
+            Assert.True(changed);
+            Assert.Equal(mode, settings.DefaultCpuAssignmentMode);
+            Assert.True(settings.HasMigratedCpuAssignmentModeDefault);
+            Assert.False(CpuAssignmentModeMigrationPolicy.ShouldShowNotice(settings));
+        }
+
+        [Fact]
+        public void Apply_DoesNotOverrideAutomaticChosenAfterTheMigration()
+        {
+            // Someone who read the notice and deliberately went back to Automatic must stay there.
+            var settings = new ApplicationSettingsModel
+            {
+                DefaultCpuAssignmentMode = CpuAssignmentMode.Automatic,
+                HasMigratedCpuAssignmentModeDefault = true,
+                HasSeenCpuAssignmentModeChangeNotice = true,
+            };
+
+            var changed = CpuAssignmentModeMigrationPolicy.Apply(settings);
+
+            Assert.False(changed);
+            Assert.Equal(CpuAssignmentMode.Automatic, settings.DefaultCpuAssignmentMode);
+            Assert.False(CpuAssignmentModeMigrationPolicy.ShouldShowNotice(settings));
+        }
+
+        [Fact]
+        public void Apply_IsIdempotent()
+        {
+            var settings = new ApplicationSettingsModel
+            {
+                DefaultCpuAssignmentMode = CpuAssignmentMode.Automatic,
+            };
+
+            Assert.True(CpuAssignmentModeMigrationPolicy.Apply(settings));
+            Assert.False(CpuAssignmentModeMigrationPolicy.Apply(settings));
+            Assert.Equal(CpuAssignmentMode.AffinityMask, settings.DefaultCpuAssignmentMode);
+        }
+
+        [Fact]
+        public void ShouldShowNotice_StaysTrueUntilAcknowledged()
+        {
+            // The notice is the only thing telling the user their mode moved, so a restart before
+            // they dismiss it must not swallow it.
+            var settings = new ApplicationSettingsModel { DefaultCpuAssignmentMode = CpuAssignmentMode.Automatic };
+            CpuAssignmentModeMigrationPolicy.Apply(settings);
+
+            Assert.True(CpuAssignmentModeMigrationPolicy.ShouldShowNotice(settings));
+            CpuAssignmentModeMigrationPolicy.Apply(settings);
+            Assert.True(CpuAssignmentModeMigrationPolicy.ShouldShowNotice(settings));
+
+            settings.HasSeenCpuAssignmentModeChangeNotice = true;
+            Assert.False(CpuAssignmentModeMigrationPolicy.ShouldShowNotice(settings));
+        }
+
+        [Fact]
+        public void CopyFrom_CarriesBothFlags()
+        {
+            var source = new ApplicationSettingsModel
+            {
+                HasMigratedCpuAssignmentModeDefault = true,
+                HasSeenCpuAssignmentModeChangeNotice = true,
+            };
+            var target = new ApplicationSettingsModel();
+
+            target.CopyFrom(source);
+
+            Assert.True(target.HasMigratedCpuAssignmentModeDefault);
+            Assert.True(target.HasSeenCpuAssignmentModeChangeNotice);
+        }
+    }
+}

--- a/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
@@ -4,8 +4,8 @@ namespace ThreadPilot.Core.Tests
 
     public sealed partial class PackagingMetadataTests
     {
-        private const string ReleaseVersion = "1.7.1";
-        private const string ReleaseAssemblyVersion = "1.7.1.0";
+        private const string ReleaseVersion = "1.7.2";
+        private const string ReleaseAssemblyVersion = "1.7.2.0";
 
         [Fact]
         public void InnoInstallers_UseStableDisplayNameAndSeparateVersionMetadata()
@@ -120,7 +120,7 @@ namespace ThreadPilot.Core.Tests
             throw new InvalidOperationException("Repository root could not be located.");
         }
 
-        [GeneratedRegex("#define MyAppVersion \"1\\.7\\.1\"", RegexOptions.CultureInvariant)]
+        [GeneratedRegex("#define MyAppVersion \"1\\.7\\.2\"", RegexOptions.CultureInvariant)]
         private static partial Regex MyAppVersionRegex();
     }
 }

--- a/ThreadPilot.csproj
+++ b/ThreadPilot.csproj
@@ -16,10 +16,10 @@
     <TrimMode>link</TrimMode>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1998;CS0067;CS0414;WFAC010;IL3000;MVVMTK0034</NoWarn>
-    <Version>1.7.1</Version>
-    <AssemblyVersion>1.7.1.0</AssemblyVersion>
-    <FileVersion>1.7.1.0</FileVersion>
-    <InformationalVersion>1.7.1</InformationalVersion>
+    <Version>1.7.2</Version>
+    <AssemblyVersion>1.7.2.0</AssemblyVersion>
+    <FileVersion>1.7.2.0</FileVersion>
+    <InformationalVersion>1.7.2</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.7.1.0" name="ThreadPilot.app"/>
+  <assemblyIdentity version="1.7.2.0" name="ThreadPilot.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.7.1",
+    [string]$Version = "1.7.2",
     [string]$Configuration = "Release",
     [switch]$SkipPublish
 )

--- a/build/build-release.ps1
+++ b/build/build-release.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.7.1",
+    [string]$Version = "1.7.2",
     [string]$Configuration = "Release",
     [string]$Runtime = "win-x64"
 )

--- a/build/package-release-zips.ps1
+++ b/build/package-release-zips.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.7.1"
+    [string]$Version = "1.7.2"
 )
 
 $ErrorActionPreference = "Stop"

--- a/chocolatey/threadpilot.nuspec
+++ b/chocolatey/threadpilot.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>threadpilot</id>
-    <version>1.7.1</version>
+    <version>1.7.2</version>
     <title>ThreadPilot</title>
     <authors>Prime Build</authors>
     <projectUrl>https://github.com/PrimeBuild-pc/ThreadPilot</projectUrl>
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Advanced Windows process and power plan manager with rules automation and performance controls.</description>
     <summary>ThreadPilot process and power plan manager.</summary>
-    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.7.1</releaseNotes>
+    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.7.2</releaseNotes>
     <tags>threadpilot process powerplan performance windows</tags>
   </metadata>
   <files>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project are documented in this file.
 
+## v1.7.2 - CPU assignment mode migration
+
+### Fixed
+
+- Upgrading now actually moves you off `ThreadPilot automatic`. v1.7.1 changed the shipped default to `Affinity Mask`, but a persisted setting always wins over a new default, so everyone upgrading kept the mode that made the affinity feature look like it did nothing. A one-time migration moves a stored `Automatic` to `Affinity Mask`.
+
+### Added
+
+- A one-time notice, in the app's own style and in the selected language, tells you that your CPU assignment mode was changed and why, with a shortcut to Settings if you want it back. It is shown only to profiles the migration actually moved, and only until you acknowledge it.
+
+### Notes
+
+- The migration runs once per profile and is recorded, so choosing `ThreadPilot automatic` again afterwards is respected and never overridden.
+- Fresh installations are unaffected: they already ship with `Affinity Mask` and see no notice.
+
 ## v1.7.1 - CPU affinity apply fixes
 
 ### Fixed

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -10,4 +10,4 @@ ThreadPilot does not transmit the local process list, executable paths, hardware
 
 The Power Plans and Settings pages contain links to Discord and GitHub Issues. ThreadPilot opens these links only after an explicit user click; the destination then receives ordinary connection information under its own privacy terms. ThreadPilot does not automatically download community power plans.
 
-This policy describes ThreadPilot 1.7.1. Material changes to data collection or network behavior will be documented before release.
+This policy describes ThreadPilot 1.7.2. Material changes to data collection or network behavior will be documented before release.

--- a/docs/release/RELEASE_NOTES.md
+++ b/docs/release/RELEASE_NOTES.md
@@ -1,44 +1,20 @@
-## ThreadPilot v1.7.1
+## ThreadPilot v1.7.2
 
-A patch release that makes the CPU affinity feature do what its name says. A user reported that applying a rule did nothing to a process's affinity. They were right, for several independent reasons.
+A follow-up to v1.7.1 that closes the gap which stopped that release reaching the people who needed it.
 
-### The headline fix
+### What was still wrong
 
-Applying a saved rule, or a core mask from the Rules tab, now changes the affinity mask Windows actually enforces.
+v1.7.1 changed the shipped default CPU assignment mode from `ThreadPilot automatic` to `Affinity Mask`, because Automatic applies only Windows CPU Sets: a soft scheduling preference that leaves the affinity mask in Task Manager unchanged.
 
-Two defects combined to hide this. `SetProcessorAffinity` silently substituted a Windows CPU Sets hint for the hard affinity write it was asked to perform, while the caller read the affinity back and compared it — so the apply always reported a verification failure and the affinity was never changed. Separately, the shipped default assignment mode was `ThreadPilot automatic`, which applies only CPU Sets: a soft scheduling preference that leaves the affinity mask in Task Manager untouched, reported to the user as "Affinity applied successfully".
+A new default only applies to a profile that has no stored value. Everyone upgrading had one, so they kept `Automatic` and kept seeing an affinity feature that appeared to do nothing. Verified against the published 1.7.1 build: a fresh profile started on `Affinity Mask`, an existing profile stayed on `Automatic`.
 
-The default is now `Affinity Mask`, and a CPU Sets result says plainly that it is a soft preference and that Task Manager will not reflect it. Rules saved before this release keep the mode they were saved with; open the rule and pick `Affinity Mask` if you want a hard, visible restriction.
+### What 1.7.2 does
 
-### The controls were not on screen
-
-The CPU assignment mode picker and the Apply CPU Assignment button, both added in v1.6.0, were placed in a side panel that had been collapsed since v1.2.0. Neither had ever been reachable in a shipped build: the only way to apply affinity was the process-list context menu, and the only way to change the assignment mode was the default in Settings. That is why the reporting user had no way to reach the control that would have fixed their problem.
-
-Both now live in the Advanced Affinity Picker, which opens expanded. The collapsed legacy panel is removed.
-
-### Also fixed
-
-- "Save Current Settings as Rule" no longer saves a rule pinned to every CPU. It captured the core selection only while edits were staged, and otherwise fell back to a process affinity that the soft modes never changed.
-- `Automatic` mode no longer installs CPU Sets that a pre-existing hard affinity prevents Windows from honouring. Windows never schedules a process outside its affinity mask, whatever CPU Sets are set, yet the read-back still verified. It now applies the hard affinity, which can replace the restriction.
-- Saved rules resolve CPU Sets against the current topology instead of trusting the CPU Set IDs stored when the rule was created. Those IDs are opaque and can name a different processor after a hardware change; a stale rule now reports an invalid topology instead of silently pinning the wrong CPUs.
-- Affinity masks that include CPU 63 are no longer discarded. They are negative as signed 64-bit values and were being rejected by magnitude comparisons.
-
-### Interface
-
-- The per-CPU cells in the Advanced Affinity Picker are read-only chips instead of checkboxes, with a hint explaining that a selection is staged through the pending core mask. They were never clickable; they only looked it. The chips keep their accessible name and report selected, not selected, or unavailable.
-- System tweak toggles are larger and state ON or OFF inside the track, replacing the unlabelled 40x20 switch. The label is localized and widens the control rather than being clipped.
-- Saving a rule from the process context menu now explains that the rule is re-applied automatically when the process next starts, and that these rules are separate from the Rules tab, which manages process-to-power-plan associations.
-
-### Localization
-
-- Corrected "core mask" mistranslations in the Italian, Spanish, French and Russian locales, and German phrasing for the Rules tab and power plans.
-
-### Notes
-
-- Memory Integrity, hardware-accelerated GPU scheduling, and windowed-game optimizations still show a link to the relevant Windows page instead of a toggle. They are deliberately left to Windows.
-- Applying affinity to a process protected by anti-cheat still fails, by design. ThreadPilot reports it and does not attempt to bypass protection.
+- **A one-time migration** moves a stored `Automatic` to `Affinity Mask` on first launch, and records that it ran.
+- **A one-time notice**, styled like the rest of the app and shown in the selected language, explains that the mode changed and why, and offers a shortcut to Settings. It appears only for profiles the migration actually moved, and only until acknowledged.
+- Choosing `ThreadPilot automatic` again afterwards is respected. The migration never runs twice and never overrides a later deliberate choice.
+- Fresh installations already ship with `Affinity Mask`, so they migrate nothing and see no notice.
 
 ### Verification
 
-- 707 unit tests, including new regression tests that fail against the previous implementation.
-- The affinity fix was verified end to end against a live process: requesting cores 0-1 now moves the process from `0xFFFF` to `0x3`, where it previously reported a failure and stayed at `0xFFFF`.
+718 unit tests, including migration coverage for an upgraded profile, a fresh profile, every non-Automatic mode, idempotency, and a deliberate return to Automatic after the notice.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=threadpilot
 sonar.projectName=ThreadPilot
-sonar.projectVersion=1.7.1
+sonar.projectVersion=1.7.2
 
 sonar.sourceEncoding=UTF-8
 sonar.sources=.


### PR DESCRIPTION
Follow-up to #53. That release changed the shipped default CPU assignment mode to `Affinity Mask`, but the change never reached the people who needed it.

## The gap

A new default only applies to a profile with no stored value. Everyone upgrading had one, so they kept `Automatic` — which applies only Windows CPU Sets, a soft scheduling preference that leaves the affinity mask in Task Manager unchanged.

Confirmed against the published 1.7.1 build:

```
existing profile (settings.json present) -> DefaultCpuAssignmentMode = 0 (Automatic)
fresh profile    (settings.json absent)  -> DefaultCpuAssignmentMode = 1 (AffinityMask)
```

The user who reported the original bug would have upgraded and seen no change.

## Changes

- `CpuAssignmentModeMigrationPolicy` moves a stored `Automatic` to `Affinity Mask` once per profile and records that it ran.
- Two persisted flags, not one. Without the "seen" flag, closing the app before acknowledging the change would hide it forever; without the "migrated" flag, a later deliberate return to `Automatic` would be undone on the next launch. Both are covered by tests.
- A one-time overlay, modelled on the existing startup suggestion so it is the app's own dialog rather than a system message box, explains what changed and offers a shortcut to Settings. Translated into all seven languages.
- The notice is queued behind the startup suggestion rather than stacked on top of it, and takes keyboard focus when shown.
- A failed settings write no longer falls into the load handler's catch, which would have replaced the freshly loaded profile with defaults and swallowed the notice. It is retried on the next launch.
- An out-of-range stored mode repairs to the shipped default instead of `Automatic`, so corrupt data is not reported back to the user as a choice they made.

## Verification

721 unit tests. The full chain was also driven against a real build through UI Automation on a seeded 1.7.0 profile: migration applied, notice queued behind the startup suggestion, revealed on dismissal, acknowledged, persisted, and absent on the next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhS1xyuMPFvxrojERQ4NuY