### PR TITLE
ThreadPilot 1.7.3 — saved rules that work, and buttons that do what they say

### DIFF
--- a/Helpers/CpuAssignmentModeMigrationPolicy.cs
+++ b/Helpers/CpuAssignmentModeMigrationPolicy.cs
@@ -1,6 +1,7 @@
 namespace ThreadPilot.Helpers
 {
     using System;
+    using System.Collections.Generic;
     using ThreadPilot.Models;
 
     /// <summary>
@@ -41,6 +42,48 @@ namespace ThreadPilot.Helpers
             settings.HasSeenCpuAssignmentModeChangeNotice = false;
             return true;
         }
+
+        /// <summary>
+        /// The profile migration above does not reach rules already written to persistent_rules.json:
+        /// a rule stores the mode it was saved with, so a rule captured before 1.7.1 keeps applying
+        /// CPU Sets on every process start - invisible in Task Manager, and indistinguishable from a
+        /// rule that never runs. Move those once too. Only rules carrying a CpuSelection are affected;
+        /// with a legacy mask, Automatic already applies a real affinity.
+        /// Returns the migrated rules, or null when nothing needed changing.
+        /// </summary>
+        public static IReadOnlyList<PersistentProcessRule>? ApplyToRules(
+            IReadOnlyList<PersistentProcessRule> rules)
+        {
+            ArgumentNullException.ThrowIfNull(rules);
+
+            var migrated = new List<PersistentProcessRule>(rules.Count);
+            var changed = false;
+            var now = DateTime.UtcNow;
+
+            foreach (var rule in rules)
+            {
+                if (rule.CpuAssignmentMode != CpuAssignmentMode.Automatic ||
+                    !rule.ApplyAffinityOnStart ||
+                    !HasSelection(rule.CpuSelection))
+                {
+                    migrated.Add(rule);
+                    continue;
+                }
+
+                migrated.Add(rule with
+                {
+                    CpuAssignmentMode = CpuAssignmentMode.AffinityMask,
+                    UpdatedAt = now,
+                });
+                changed = true;
+            }
+
+            return changed ? migrated : null;
+        }
+
+        private static bool HasSelection(CpuSelection? selection) =>
+            selection != null &&
+            (selection.CpuSetIds.Count > 0 || selection.LogicalProcessors.Count > 0);
 
         /// <summary>
         /// True while the migration has moved this profile but the user has not acknowledged it yet.

--- a/Helpers/WindowPlacementHelper.cs
+++ b/Helpers/WindowPlacementHelper.cs
@@ -34,11 +34,17 @@ namespace ThreadPilot.Helpers
         private const double DefaultWindowWidth = 1280;
         private const double DefaultWindowHeight = 864;
         private const double MinimumVisibleAreaRatio = 0.25;
+
+        // A window this close to filling its monitor's working area is treated as having no
+        // usable windowed bounds (e.g. restored from maximised without a smaller size to go back to).
+        private const double FillsWorkingAreaRatio = 0.98;
+        private const double FallbackWorkingAreaRatio = 0.9;
         private const double Epsilon = 0.001;
 
         public static WindowPlacementCorrection CorrectWindowBounds(
             WindowBounds currentBounds,
-            IReadOnlyCollection<MonitorWorkingArea> workingAreas)
+            IReadOnlyCollection<MonitorWorkingArea> workingAreas,
+            bool shrinkWhenFillingWorkingArea = false)
         {
             var validWorkingAreas = workingAreas
                 .Where(IsValidWorkingArea)
@@ -56,6 +62,20 @@ namespace ThreadPilot.Helpers
             }
 
             var targetArea = SelectTargetWorkingArea(currentBounds, validWorkingAreas);
+
+            // The target monitor is resolved from the original bounds first, so the fallback size
+            // stays centred on the monitor the window was already on.
+            if (shrinkWhenFillingWorkingArea && FillsWorkingArea(currentBounds, targetArea))
+            {
+                currentBounds = currentBounds with
+                {
+                    Left = double.NaN,
+                    Top = double.NaN,
+                    Width = Math.Min(DefaultWindowWidth, targetArea.Width * FallbackWorkingAreaRatio),
+                    Height = Math.Min(DefaultWindowHeight, targetArea.Height * FallbackWorkingAreaRatio),
+                };
+            }
+
             var correctedWidth = Math.Min(ResolveDimension(currentBounds.Width, DefaultWindowWidth), targetArea.Width);
             var correctedHeight = Math.Min(ResolveDimension(currentBounds.Height, DefaultWindowHeight), targetArea.Height);
             var sanitizedBounds = new WindowBounds(
@@ -88,7 +108,7 @@ namespace ThreadPilot.Helpers
             return new WindowPlacementCorrection(correctedBounds, !BoundsAreEquivalent(currentBounds, correctedBounds));
         }
 
-        public static bool TryCorrectWindowPlacement(Window window)
+        public static bool TryCorrectWindowPlacement(Window window, bool shrinkWhenFillingWorkingArea = false)
         {
             ArgumentNullException.ThrowIfNull(window);
 
@@ -106,7 +126,7 @@ namespace ThreadPilot.Helpers
                     ResolveWindowDimension(window.ActualWidth, window.Width, DefaultWindowWidth),
                     ResolveWindowDimension(window.ActualHeight, window.Height, DefaultWindowHeight));
 
-                var correction = CorrectWindowBounds(currentBounds, workingAreas);
+                var correction = CorrectWindowBounds(currentBounds, workingAreas, shrinkWhenFillingWorkingArea);
                 if (!correction.WasCorrected)
                 {
                     return false;
@@ -217,6 +237,14 @@ namespace ThreadPilot.Helpers
             var deltaY = y - nearestY;
 
             return (deltaX * deltaX) + (deltaY * deltaY);
+        }
+
+        private static bool FillsWorkingArea(WindowBounds bounds, MonitorWorkingArea area)
+        {
+            return IsFinite(bounds.Width)
+                && IsFinite(bounds.Height)
+                && bounds.Width >= area.Width * FillsWorkingAreaRatio
+                && bounds.Height >= area.Height * FillsWorkingAreaRatio;
         }
 
         private static bool HasSufficientIntersection(WindowBounds bounds, MonitorWorkingArea area)

--- a/Installer/Installer.iss
+++ b/Installer/Installer.iss
@@ -5,7 +5,7 @@
 #define MyAppPublisher "ThreadPilot"
 #define MyAppURL "https://github.com/"
 #define MyAppExeName "ThreadPilot.exe"
-#define MyAppVersion "1.7.2"
+#define MyAppVersion "1.7.3"
 
 #ifndef MyWizardStyle
   #define MyWizardStyle "modern dynamic windows11"

--- a/Installer/ThreadPilot.wxs
+++ b/Installer/ThreadPilot.wxs
@@ -7,7 +7,7 @@
   <Package
       Name="ThreadPilot"
       Manufacturer="Prime Build"
-      Version="1.7.2.0"
+      Version="1.7.3.0"
       UpgradeCode="PUT-GENERATED-UPGRADE-CODE-HERE"
       Language="1033">
     <SummaryInformation Description="ThreadPilot MSI template" />

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -11,7 +11,7 @@
 #endif
 
 #ifndef MyAppVersion
-	#define MyAppVersion "1.7.2"
+	#define MyAppVersion "1.7.3"
 #endif
 
 #ifndef MyAppSourceDir

--- a/Locales/de-DE.xaml
+++ b/Locales/de-DE.xaml
@@ -295,6 +295,8 @@
     <sys:String x:Key="ProcessView_LoadProfileTooltip">Laden Sie ein zuvor gespeichertes Profil</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">Aktuelle Einstellungen als Regel speichern</sys:String>
     <sys:String x:Key="ProcessView_SaveRuleTooltip">Speichert eine prozessbezogene Regel, die ThreadPilot beim nächsten Start dieses Prozesses automatisch erneut anwendet, solange die Automatisierungsüberwachung aktiviert ist. Diese Regeln sind unabhängig von der Registerkarte „Regeln“, der Zuordnungen von Prozessen zu Energiesparplänen verwaltet.</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRule">Gespeicherte Regel löschen</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRuleTooltip">Entfernt die gespeicherte Regel für diesen Prozess, damit ThreadPilot sie beim Start des Prozesses nicht mehr anwendet.</sys:String>
 
     <sys:String x:Key="ProcessView_LastAction">Letzte ThreadPilot-Aktion:</sys:String>
     <sys:String x:Key="ProcessView_Refresh">Aktualisieren</sys:String>
@@ -407,6 +409,8 @@
     <sys:String x:Key="SettingsView_MinimizeToTray">Auf das Fach minimieren</sys:String>
     <sys:String x:Key="SettingsView_CloseToTray">In der Nähe des Fachs (anstelle des Ausgangs)</sys:String>
     <sys:String x:Key="SettingsView_StartMinimized">Minimiert starten</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExit">Prozessänderungen beim Beenden zurücksetzen</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExitDescription">Stellt von ThreadPilot geänderte CPU-Zuweisungen und Prioritäten beim Beenden der App wieder her.</sys:String>
     <sys:String x:Key="SettingsView_QuickApply">Ausstehende Einstellungen aktivieren, die aus dem Fach übernommen werden</sys:String>
     <sys:String x:Key="SettingsView_MonitoringControl">Aktivieren Sie die Steuerelemente für die Automatisierungsüberwachung in der Taskleiste</sys:String>
     <sys:String x:Key="SettingsView_DetailedTooltips">Detaillierte Tooltips anzeigen</sys:String>

--- a/Locales/de-DE.xaml
+++ b/Locales/de-DE.xaml
@@ -245,6 +245,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">Modus</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Aktualisiert</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Löschen</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">Regel bearbeiten</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">CPU-Priorität</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">Speicherpriorität</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">E/A-Priorität</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">CPU-Zuweisungsmodus</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">System wach halten, solange dieser Prozess läuft</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Die Kerne, an die diese Regel bindet, werden auf der Registerkarte Prozesse bearbeitet, wo die Kernauswahl liegt.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">Änderungen speichern</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Noch keine gespeicherten Prozessregeln. Klicken Sie auf der Registerkarte Prozesse mit der rechten Maustaste auf einen Prozess und wählen Sie Regeln.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Ausführbar</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Energieplan</sys:String>
@@ -605,6 +613,7 @@
 
     <!-- SystemTweaksViewModel Messages -->
     <sys:String x:Key="SystemTweaks_StatusReady">Bereit</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDetectionFailed">ThreadPilot konnte diese Einstellung auf diesem System nicht lesen.</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshing">Erfrischende Systemoptimierungen...</sys:String>
     <sys:String x:Key="SystemTweaks_StatusLastRefreshedFormat">Letzte Aktualisierung: {0}</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshFailed">Systemoptimierungen konnten nicht aktualisiert werden</sys:String>

--- a/Locales/de-DE.xaml
+++ b/Locales/de-DE.xaml
@@ -238,6 +238,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_DescriptionLabel">Beschreibung:</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationService">Automatisierungsdienst</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_RulesHeader">Regeln</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesHeader">Gespeicherte Prozessregeln</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesDescription">Regeln, die auf der Registerkarte Prozesse gespeichert wurden. ThreadPilot wendet sie bei jedem Start des Prozesses erneut an, solange die Automatisierungsüberwachung aktiv ist. Sie sind getrennt von den Energieplanregeln oben, die den globalen Windows-Energieplan umschalten.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleProcess">Prozess</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplies">Wendet an</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">Modus</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Aktualisiert</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Löschen</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Noch keine gespeicherten Prozessregeln. Klicken Sie auf der Registerkarte Prozesse mit der rechten Maustaste auf einen Prozess und wählen Sie Regeln.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Ausführbar</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Energieplan</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_CpuMask">CPU Maske</sys:String>

--- a/Locales/en-US.xaml
+++ b/Locales/en-US.xaml
@@ -245,6 +245,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">Mode</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Updated</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Delete</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">Edit rule</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">CPU priority</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">Memory priority</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">I/O priority</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">CPU assignment mode</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">Keep the system awake while this process runs</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">The cores this rule pins to are edited from the Process tab, where the core picker lives.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">Save changes</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">No saved process rules yet. Right-click a process in the Process tab and choose Rules to save one.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Executable</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Power Plan</sys:String>
@@ -605,6 +613,7 @@
 
     <!-- SystemTweaksViewModel Messages -->
     <sys:String x:Key="SystemTweaks_StatusReady">Ready</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDetectionFailed">ThreadPilot could not read this setting on this system.</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshing">Refreshing system tweaks...</sys:String>
     <sys:String x:Key="SystemTweaks_StatusLastRefreshedFormat">Last refreshed: {0}</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshFailed">Failed to refresh system tweaks</sys:String>

--- a/Locales/en-US.xaml
+++ b/Locales/en-US.xaml
@@ -238,6 +238,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_DescriptionLabel">Description:</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationService">Automation Service</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_RulesHeader">Rules</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesHeader">Saved process rules</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesDescription">Rules saved from the Process tab. ThreadPilot re-applies them to that process every time it starts, while automation monitoring is on. These are separate from the power plan rules above, which switch the global Windows power plan.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleProcess">Process</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplies">Applies</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">Mode</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Updated</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Delete</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">No saved process rules yet. Right-click a process in the Process tab and choose Rules to save one.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Executable</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Power Plan</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_CpuMask">CPU Mask</sys:String>

--- a/Locales/en-US.xaml
+++ b/Locales/en-US.xaml
@@ -295,6 +295,8 @@
     <sys:String x:Key="ProcessView_LoadProfileTooltip">Load a previously saved profile</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">Save Current Settings as Rule</sys:String>
     <sys:String x:Key="ProcessView_SaveRuleTooltip">Saves a per-process rule that ThreadPilot re-applies automatically the next time this process starts, while automation monitoring is enabled. These rules are separate from the Rules tab, which manages process-to-power-plan associations.</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRule">Delete Saved Rule</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRuleTooltip">Removes the saved rule for this process, so ThreadPilot stops re-applying it when the process starts.</sys:String>
     
     <sys:String x:Key="ProcessView_LastAction">Last ThreadPilot action:</sys:String>
     <sys:String x:Key="ProcessView_Refresh">Refresh</sys:String>
@@ -407,6 +409,8 @@
     <sys:String x:Key="SettingsView_MinimizeToTray">Minimize to tray</sys:String>
     <sys:String x:Key="SettingsView_CloseToTray">Close to tray (instead of exit)</sys:String>
     <sys:String x:Key="SettingsView_StartMinimized">Start minimized</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExit">Reset process changes on exit</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExitDescription">Restores CPU assignments and priorities changed by ThreadPilot when the app exits.</sys:String>
     <sys:String x:Key="SettingsView_QuickApply">Enable pending settings apply from tray</sys:String>
     <sys:String x:Key="SettingsView_MonitoringControl">Enable automation monitoring controls from tray</sys:String>
     <sys:String x:Key="SettingsView_DetailedTooltips">Show detailed tooltips</sys:String>

--- a/Locales/es-ES.xaml
+++ b/Locales/es-ES.xaml
@@ -238,6 +238,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_DescriptionLabel">Descripción:</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationService">Servicio de automatización</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_RulesHeader">Reglas</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesHeader">Reglas de proceso guardadas</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesDescription">Reglas guardadas desde la pestaña Procesos. ThreadPilot las vuelve a aplicar a ese proceso cada vez que se inicia, si la supervisión automática está activada. Son distintas de las reglas de plan de energía de arriba, que cambian el plan de energía global de Windows.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleProcess">Proceso</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplies">Aplica</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">Modo</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Actualizada</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Eliminar</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Aún no hay reglas de proceso guardadas. Haz clic derecho en un proceso en la pestaña Procesos y elige Reglas para guardar una.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">ejecutable</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Plan de energía</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_CpuMask">Máscara de CPU</sys:String>

--- a/Locales/es-ES.xaml
+++ b/Locales/es-ES.xaml
@@ -295,6 +295,8 @@
     <sys:String x:Key="ProcessView_LoadProfileTooltip">Cargar un perfil previamente guardado</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">Guardar la configuración actual como regla</sys:String>
     <sys:String x:Key="ProcessView_SaveRuleTooltip">Guarda una regla por proceso que ThreadPilot vuelve a aplicar automáticamente la próxima vez que se inicie este proceso, mientras la supervisión de automatización esté activada. Estas reglas son independientes de la pestaña Reglas, que gestiona las asociaciones entre procesos y planes de energía.</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRule">Eliminar la regla guardada</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRuleTooltip">Elimina la regla guardada para este proceso, para que ThreadPilot deje de aplicarla cuando el proceso se inicia.</sys:String>
 
     <sys:String x:Key="ProcessView_LastAction">Última acción ThreadPilot:</sys:String>
     <sys:String x:Key="ProcessView_Refresh">Actualizar</sys:String>
@@ -407,6 +409,8 @@
     <sys:String x:Key="SettingsView_MinimizeToTray">Minimizar a bandeja</sys:String>
     <sys:String x:Key="SettingsView_CloseToTray">Cerca de la bandeja (en lugar de salir)</sys:String>
     <sys:String x:Key="SettingsView_StartMinimized">Empezar minimizado</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExit">Restablecer cambios de procesos al salir</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExitDescription">Restaura las asignaciones de CPU y prioridades modificadas por ThreadPilot al cerrar la aplicación.</sys:String>
     <sys:String x:Key="SettingsView_QuickApply">Habilitar configuración pendiente aplicar desde la bandeja</sys:String>
     <sys:String x:Key="SettingsView_MonitoringControl">Habilite los controles de monitoreo de automatización desde la bandeja</sys:String>
     <sys:String x:Key="SettingsView_DetailedTooltips">Mostrar información sobre herramientas detallada</sys:String>

--- a/Locales/es-ES.xaml
+++ b/Locales/es-ES.xaml
@@ -245,6 +245,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">Modo</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Actualizada</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Eliminar</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">Editar regla</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">Prioridad de CPU</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">Prioridad de memoria</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">Prioridad de E/S</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">Modo de asignación de CPU</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">Impedir la suspensión mientras este proceso se ejecuta</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Los núcleos a los que se fija esta regla se editan en la pestaña Procesos, donde está el selector de núcleos.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">Guardar cambios</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Aún no hay reglas de proceso guardadas. Haz clic derecho en un proceso en la pestaña Procesos y elige Reglas para guardar una.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">ejecutable</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Plan de energía</sys:String>
@@ -605,6 +613,7 @@
 
     <!-- SystemTweaksViewModel Messages -->
     <sys:String x:Key="SystemTweaks_StatusReady">Listo</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDetectionFailed">ThreadPilot no ha podido leer esta configuración en este sistema.</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshing">Actualizaciones en el sistema...</sys:String>
     <sys:String x:Key="SystemTweaks_StatusLastRefreshedFormat">Última actualización: {0}</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshFailed">No se pudieron actualizar los ajustes del sistema</sys:String>

--- a/Locales/fr-FR.xaml
+++ b/Locales/fr-FR.xaml
@@ -295,6 +295,8 @@
     <sys:String x:Key="ProcessView_LoadProfileTooltip">Charger un profil précédemment enregistré</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">Enregistrer les paramètres actuels en tant que règle</sys:String>
     <sys:String x:Key="ProcessView_SaveRuleTooltip">Enregistre une règle propre au processus que ThreadPilot réapplique automatiquement au prochain démarrage de ce processus, tant que la surveillance de l'automatisation est activée. Ces règles sont distinctes de l'onglet Règles, qui gère les associations entre processus et modes d'alimentation.</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRule">Supprimer la règle enregistrée</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRuleTooltip">Supprime la règle enregistrée pour ce processus, afin que ThreadPilot cesse de l'appliquer au démarrage du processus.</sys:String>
 
     <sys:String x:Key="ProcessView_LastAction">Dernière action ThreadPilot :</sys:String>
     <sys:String x:Key="ProcessView_Refresh">Actualiser</sys:String>
@@ -407,6 +409,8 @@
     <sys:String x:Key="SettingsView_MinimizeToTray">Réduire dans le bac</sys:String>
     <sys:String x:Key="SettingsView_CloseToTray">Près du plateau (au lieu de la sortie)</sys:String>
     <sys:String x:Key="SettingsView_StartMinimized">Démarrer réduit</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExit">Réinitialiser les modifications des processus à la fermeture</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExitDescription">Restaure les affectations CPU et les priorités modifiées par ThreadPilot à la fermeture de l'application.</sys:String>
     <sys:String x:Key="SettingsView_QuickApply">Activer l'application des paramètres en attente à partir du bac</sys:String>
     <sys:String x:Key="SettingsView_MonitoringControl">Activer les contrôles de surveillance de l'automatisation à partir du bac</sys:String>
     <sys:String x:Key="SettingsView_DetailedTooltips">Afficher des info-bulles détaillées</sys:String>

--- a/Locales/fr-FR.xaml
+++ b/Locales/fr-FR.xaml
@@ -245,6 +245,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">Mode</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Mise à jour</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Supprimer</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">Modifier la règle</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">Priorité CPU</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">Priorité mémoire</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">Priorité E/S</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">Mode d'affectation CPU</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">Empêcher la mise en veille pendant l'exécution de ce processus</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Les cœurs auxquels cette règle est liée se modifient dans l'onglet Processus, où se trouve le sélecteur de cœurs.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">Enregistrer les modifications</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Aucune règle de processus enregistrée. Faites un clic droit sur un processus dans l'onglet Processus et choisissez Règles pour en enregistrer une.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Exécutable</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Plan d'alimentation</sys:String>
@@ -605,6 +613,7 @@
 
     <!-- SystemTweaksViewModel Messages -->
     <sys:String x:Key="SystemTweaks_StatusReady">Prêt</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDetectionFailed">ThreadPilot n'a pas pu lire ce paramètre sur ce système.</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshing">Modifications rafraîchissantes du système...</sys:String>
     <sys:String x:Key="SystemTweaks_StatusLastRefreshedFormat">Dernière actualisation : {0}</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshFailed">Échec de l'actualisation des réglages du système</sys:String>

--- a/Locales/fr-FR.xaml
+++ b/Locales/fr-FR.xaml
@@ -238,6 +238,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_DescriptionLabel">Descriptif :</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationService">Service d'automatisation</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_RulesHeader">Règles</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesHeader">Règles de processus enregistrées</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesDescription">Règles enregistrées depuis l'onglet Processus. ThreadPilot les réapplique à ce processus à chaque démarrage, tant que la surveillance automatique est active. Elles sont distinctes des règles de mode d'alimentation ci-dessus, qui changent le mode d'alimentation global de Windows.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleProcess">Processus</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplies">Applique</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">Mode</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Mise à jour</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Supprimer</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Aucune règle de processus enregistrée. Faites un clic droit sur un processus dans l'onglet Processus et choisissez Règles pour en enregistrer une.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Exécutable</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Plan d'alimentation</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_CpuMask">CPU Masque</sys:String>

--- a/Locales/it-IT.xaml
+++ b/Locales/it-IT.xaml
@@ -238,6 +238,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_DescriptionLabel">Descrizione:</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationService">Servizio di automazione</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_RulesHeader">Regole</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesHeader">Regole di processo salvate</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesDescription">Regole salvate dalla scheda Processi. ThreadPilot le riapplica a quel processo a ogni avvio, se il monitoraggio automatico è attivo. Sono separate dalle regole dei profili energetici qui sopra, che cambiano il piano di alimentazione globale di Windows.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleProcess">Processo</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplies">Applica</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">Modalità</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Aggiornata</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Elimina</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Nessuna regola di processo salvata. Fai clic destro su un processo nella scheda Processi e scegli Regole per salvarne una.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Eseguibile</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Piano di alimentazione</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_CpuMask">CPU Maschera</sys:String>

--- a/Locales/it-IT.xaml
+++ b/Locales/it-IT.xaml
@@ -295,6 +295,8 @@
     <sys:String x:Key="ProcessView_LoadProfileTooltip">Carica un profilo salvato in precedenza</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">Salva le impostazioni correnti come regola</sys:String>
     <sys:String x:Key="ProcessView_SaveRuleTooltip">Salva una regola per processo che ThreadPilot riapplica automaticamente al successivo avvio di questo processo, finché il monitoraggio dell'automazione è attivo. Queste regole sono separate dalla scheda Regole, che gestisce le associazioni tra processi e combinazioni di risparmio energia.</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRule">Elimina la regola salvata</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRuleTooltip">Rimuove la regola salvata per questo processo, così ThreadPilot smette di riapplicarla all'avvio del processo.</sys:String>
 
     <sys:String x:Key="ProcessView_LastAction">Ultima azione ThreadPilot:</sys:String>
     <sys:String x:Key="ProcessView_Refresh">Aggiorna</sys:String>
@@ -407,6 +409,8 @@
     <sys:String x:Key="SettingsView_MinimizeToTray">Ridurre a icona nel vassoio</sys:String>
     <sys:String x:Key="SettingsView_CloseToTray">Vicino al vassoio (invece che all'uscita)</sys:String>
     <sys:String x:Key="SettingsView_StartMinimized">Inizia minimizzato</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExit">Ripristina le modifiche ai processi all'uscita</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExitDescription">Ripristina le assegnazioni CPU e le priorità modificate da ThreadPilot quando l'app viene chiusa.</sys:String>
     <sys:String x:Key="SettingsView_QuickApply">Abilita le impostazioni in sospeso applicate dal vassoio</sys:String>
     <sys:String x:Key="SettingsView_MonitoringControl">Abilita i controlli di monitoraggio dell'automazione dal vassoio</sys:String>
     <sys:String x:Key="SettingsView_DetailedTooltips">Mostra descrizioni comandi dettagliate</sys:String>

--- a/Locales/it-IT.xaml
+++ b/Locales/it-IT.xaml
@@ -245,6 +245,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">Modalità</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Aggiornata</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Elimina</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">Modifica regola</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">Priorità CPU</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">Priorità memoria</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">Priorità I/O</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">Modalità di assegnazione CPU</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">Impedisci la sospensione mentre il processo è in esecuzione</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">I core a cui questa regola vincola il processo si modificano dalla scheda Processi, dove c'è il selettore dei core.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">Salva modifiche</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Nessuna regola di processo salvata. Fai clic destro su un processo nella scheda Processi e scegli Regole per salvarne una.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Eseguibile</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">Piano di alimentazione</sys:String>
@@ -605,6 +613,7 @@
 
     <!-- SystemTweaksViewModel Messages -->
     <sys:String x:Key="SystemTweaks_StatusReady">Pronto</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDetectionFailed">ThreadPilot non è riuscito a leggere questa impostazione su questo sistema.</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshing">Aggiornamento delle modifiche al sistema...</sys:String>
     <sys:String x:Key="SystemTweaks_StatusLastRefreshedFormat">Ultimo aggiornamento: {0}</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshFailed">Impossibile aggiornare le modifiche al sistema</sys:String>

--- a/Locales/ru-RU.xaml
+++ b/Locales/ru-RU.xaml
@@ -245,6 +245,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">Режим</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Обновлено</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Удалить</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">Изменить правило</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">Приоритет ЦП</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">Приоритет памяти</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">Приоритет ввода-вывода</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">Режим назначения ЦП</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">Не давать системе засыпать, пока процесс работает</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Ядра, к которым привязано это правило, изменяются на вкладке «Процессы», где находится выбор ядер.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">Сохранить изменения</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Сохранённых правил процессов пока нет. Щёлкните процесс правой кнопкой на вкладке «Процессы» и выберите «Правила».</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Исполняемый файл</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">План электропитания</sys:String>
@@ -605,6 +613,7 @@
 
     <!-- SystemTweaksViewModel Messages -->
     <sys:String x:Key="SystemTweaks_StatusReady">Готово</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDetectionFailed">ThreadPilot не смог прочитать этот параметр в этой системе.</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshing">Обновление настроек системы...</sys:String>
     <sys:String x:Key="SystemTweaks_StatusLastRefreshedFormat">Последнее обновление: {0}</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshFailed">Не удалось обновить настройки системы.</sys:String>

--- a/Locales/ru-RU.xaml
+++ b/Locales/ru-RU.xaml
@@ -295,6 +295,8 @@
     <sys:String x:Key="ProcessView_LoadProfileTooltip">Загрузите ранее сохраненный профиль</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">Сохранить текущие настройки как правило</sys:String>
     <sys:String x:Key="ProcessView_SaveRuleTooltip">Сохраняет правило для этого процесса, которое ThreadPilot автоматически применяет снова при следующем запуске процесса, пока включён мониторинг автоматизации. Эти правила не связаны с вкладкой Правила, где настраиваются сопоставления процессов и схем электропитания.</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRule">Удалить сохранённое правило</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRuleTooltip">Удаляет сохранённое правило для этого процесса, чтобы ThreadPilot больше не применял его при запуске процесса.</sys:String>
 
     <sys:String x:Key="ProcessView_LastAction">Последнее действие ThreadPilot:</sys:String>
     <sys:String x:Key="ProcessView_Refresh">Обновить</sys:String>
@@ -407,6 +409,8 @@
     <sys:String x:Key="SettingsView_MinimizeToTray">Свернуть в трей</sys:String>
     <sys:String x:Key="SettingsView_CloseToTray">Рядом с лотком (вместо выхода)</sys:String>
     <sys:String x:Key="SettingsView_StartMinimized">Начать сворачивать</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExit">Сбрасывать изменения процессов при выходе</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExitDescription">Восстанавливает назначения ЦП и приоритеты, изменённые ThreadPilot, при закрытии приложения.</sys:String>
     <sys:String x:Key="SettingsView_QuickApply">Включить ожидающие настройки, применимые из трея</sys:String>
     <sys:String x:Key="SettingsView_MonitoringControl">Включить элементы управления мониторингом автоматизации из трея</sys:String>
     <sys:String x:Key="SettingsView_DetailedTooltips">Показать подробные подсказки</sys:String>

--- a/Locales/ru-RU.xaml
+++ b/Locales/ru-RU.xaml
@@ -238,6 +238,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_DescriptionLabel">Описание:</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationService">Служба автоматизации</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_RulesHeader">Правила</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesHeader">Сохранённые правила процессов</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesDescription">Правила, сохранённые на вкладке «Процессы». ThreadPilot применяет их к процессу при каждом запуске, пока включён автоматический мониторинг. Они отличаются от правил схем питания выше, которые переключают глобальную схему питания Windows.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleProcess">Процесс</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplies">Применяет</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">Режим</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Обновлено</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Удалить</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Сохранённых правил процессов пока нет. Щёлкните процесс правой кнопкой на вкладке «Процессы» и выберите «Правила».</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Исполняемый файл</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">План электропитания</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_CpuMask">CPU Маска</sys:String>

--- a/Locales/zh-CN.xaml
+++ b/Locales/zh-CN.xaml
@@ -245,6 +245,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">模式</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">更新时间</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">删除</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">编辑规则</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">CPU 优先级</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">内存优先级</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">I/O 优先级</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">CPU 分配模式</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">该进程运行时阻止系统休眠</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">此规则绑定的核心需在“进程”选项卡中修改，核心选择器在那里。</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">保存更改</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">尚无已保存的进程规则。在“进程”选项卡中右键点击某个进程并选择“规则”即可保存。</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">可执行文件</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">电源计划</sys:String>
@@ -605,6 +613,7 @@
 
     <!-- SystemTweaksViewModel Messages -->
     <sys:String x:Key="SystemTweaks_StatusReady">就绪</sys:String>
+    <sys:String x:Key="SystemTweaks_StatusDetectionFailed">ThreadPilot 无法在此系统上读取该设置。</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshing">正在刷新系统微调选项...</sys:String>
     <sys:String x:Key="SystemTweaks_StatusLastRefreshedFormat">上次刷新时间: {0}</sys:String>
     <sys:String x:Key="SystemTweaks_StatusRefreshFailed">刷新系统微调失败</sys:String>

--- a/Locales/zh-CN.xaml
+++ b/Locales/zh-CN.xaml
@@ -295,6 +295,8 @@
     <sys:String x:Key="ProcessView_LoadProfileTooltip">加载以前保存的配置文件</sys:String>
     <sys:String x:Key="ProcessView_SaveCurrentRule">保存当前设置为规则</sys:String>
     <sys:String x:Key="ProcessView_SaveRuleTooltip">保存针对该进程的规则；只要启用了自动化监视，ThreadPilot 会在此进程下次启动时自动重新应用它。这些规则与“自动化规则”选项卡相互独立，后者管理进程与电源计划的关联。</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRule">删除已保存的规则</sys:String>
+    <sys:String x:Key="ProcessView_DeleteSavedRuleTooltip">删除此进程的已保存规则，ThreadPilot 将不再在该进程启动时应用它。</sys:String>
     
     <sys:String x:Key="ProcessView_LastAction">最后一次 ThreadPilot 操作:</sys:String>
     <sys:String x:Key="ProcessView_Refresh">刷新</sys:String>
@@ -407,6 +409,8 @@
     <sys:String x:Key="SettingsView_MinimizeToTray">最小化到托盘</sys:String>
     <sys:String x:Key="SettingsView_CloseToTray">关闭主窗口时最小化到托盘</sys:String>
     <sys:String x:Key="SettingsView_StartMinimized">开机启动时最小化</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExit">退出时重置进程更改</sys:String>
+    <sys:String x:Key="SettingsView_ResetProcessChangesOnExitDescription">退出应用时恢复 ThreadPilot 更改的 CPU 分配和优先级。</sys:String>
     <sys:String x:Key="SettingsView_QuickApply">允许从托盘菜单应用待处理设置</sys:String>
     <sys:String x:Key="SettingsView_MonitoringControl">允许从托盘菜单控制自动化监控</sys:String>
     <sys:String x:Key="SettingsView_DetailedTooltips">托盘图标显示详细鼠标提示</sys:String>

--- a/Locales/zh-CN.xaml
+++ b/Locales/zh-CN.xaml
@@ -238,6 +238,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_DescriptionLabel">描述:</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_AutomationService">自动化服务</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_RulesHeader">规则</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesHeader">已保存的进程规则</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulesDescription">在“进程”选项卡中保存的规则。只要自动化监控处于开启状态，ThreadPilot 会在该进程每次启动时重新应用它们。它们与上方的电源计划规则不同，后者切换的是 Windows 全局电源计划。</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleProcess">进程</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplies">应用</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMode">模式</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">更新时间</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">删除</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">尚无已保存的进程规则。在“进程”选项卡中右键点击某个进程并选择“规则”即可保存。</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">可执行文件</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_PowerPlan">电源计划</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_CpuMask">CPU 掩码</sys:String>

--- a/MainWindow.Behaviors.partial.cs
+++ b/MainWindow.Behaviors.partial.cs
@@ -1604,6 +1604,11 @@ namespace ThreadPilot
             this.SelectMainTab("Rules");
         }
 
+        private void OnOpenMasksRequested(object? sender, EventArgs e)
+        {
+            this.SelectMainTab("Masks");
+        }
+
         private void ShowWindowFromTray(string? tabTag = null)
         {
             this.ShowInTaskbar = true;
@@ -2030,6 +2035,18 @@ namespace ThreadPilot
             this.SystemTweaksView.Visibility = tag == "Tweaks" ? Visibility.Visible : Visibility.Collapsed;
             this.SettingsView.Visibility = tag == "Settings" ? Visibility.Visible : Visibility.Collapsed;
 
+            if (string.Equals(tag, "Rules", StringComparison.Ordinal))
+            {
+                // Re-read on every visit: a rule saved from the Process tab a moment ago has to be
+                // there when the user comes to look for it.
+                // ponytail: refresh on show, not a store change event - the two views are never
+                // visible at the same time. Revisit if a rule can ever be written while this is up.
+                TaskSafety.FireAndForget(this.associationViewModel.RefreshSavedProcessRulesAsync(), ex =>
+                {
+                    this.LogDebug($"Refreshing saved process rules failed: {ex.Message}");
+                });
+            }
+
             this.NavProcess.IsActive = tag == "Process";
             this.NavMasks.IsActive = tag == "Masks";
             this.NavPower.IsActive = tag == "Power";
@@ -2201,6 +2218,7 @@ namespace ThreadPilot
             {
                 this.Loaded -= this.OnWindowLoaded;
                 this.processViewModel.OpenRulesRequested -= this.OnOpenRulesRequested;
+                this.processViewModel.OpenMasksRequested -= this.OnOpenMasksRequested;
 
                 this.settingsService.SettingsChanged -= this.OnSettingsChanged;
                 this.processMonitorService.MonitoringStatusChanged -= this.OnMonitoringStatusChanged;

--- a/MainWindow.Behaviors.partial.cs
+++ b/MainWindow.Behaviors.partial.cs
@@ -1400,8 +1400,13 @@ namespace ThreadPilot
             }
         }
 
+        private WindowState lastObservedWindowState = WindowState.Normal;
+
         protected override void OnStateChanged(EventArgs e)
         {
+            var previousWindowState = this.lastObservedWindowState;
+            this.lastObservedWindowState = this.WindowState;
+
             try
             {
                 if (this.WindowState == WindowState.Minimized)
@@ -1420,7 +1425,15 @@ namespace ThreadPilot
                 else if (this.WindowState == WindowState.Normal || this.WindowState == WindowState.Maximized)
                 {
                     this.ShowInTaskbar = true;
-                    this.EnsureDashboardVisibleOnScreen();
+
+                    // While StateChanged runs, ActualWidth/ActualHeight/Left/Top still describe the
+                    // pre-transition window, so correcting placement here would write the maximised
+                    // size back into Width/Height and destroy the restore bounds. Let it settle first.
+                    var restoredFromMaximized = this.WindowState == WindowState.Normal
+                        && previousWindowState == WindowState.Maximized;
+                    _ = this.Dispatcher.BeginInvoke(
+                        new Action(() => this.EnsureDashboardVisibleOnScreen(restoredFromMaximized)),
+                        System.Windows.Threading.DispatcherPriority.Background);
 
                     this.ApplyAppRefreshPolicy(this.GetForegroundActivityState());
                 }
@@ -1625,10 +1638,11 @@ namespace ThreadPilot
 
             if (this.WindowState == WindowState.Minimized)
             {
+                // OnStateChanged schedules the placement correction once the restore has settled;
+                // doing it here would read the pre-restore metrics.
                 this.WindowState = WindowState.Normal;
             }
 
-            this.EnsureDashboardVisibleOnScreen();
             this.ShowInTaskbar = true;
 
             if (tabTag != null)
@@ -1653,9 +1667,9 @@ namespace ThreadPilot
                 : AppActivityState.ForegroundOtherTab);
         }
 
-        internal bool EnsureDashboardVisibleOnScreen()
+        internal bool EnsureDashboardVisibleOnScreen(bool shrinkWhenFillingWorkingArea = false)
         {
-            return WindowPlacementHelper.TryCorrectWindowPlacement(this);
+            return WindowPlacementHelper.TryCorrectWindowPlacement(this, shrinkWhenFillingWorkingArea);
         }
 
         private void SelectMainTab(string tag)

--- a/MainWindow.Behaviors.partial.cs
+++ b/MainWindow.Behaviors.partial.cs
@@ -578,6 +578,50 @@ namespace ThreadPilot
             {
                 System.Diagnostics.Debug.WriteLine($"Failed to load settings: {ex.Message}");
             }
+
+            await this.MigratePersistentRuleCpuAssignmentModesAsync();
+        }
+
+        // A rule stores the CPU assignment mode it was saved with, so the 1.7.2 profile migration
+        // leaves rules captured before 1.7.1 on Automatic: they keep applying CPU Sets on every
+        // process start, which changes nothing the user can see. Move them once, here rather than
+        // in the settings service, which has no business knowing about the rule store.
+        private async Task MigratePersistentRuleCpuAssignmentModesAsync()
+        {
+            var settings = this.settingsService.Settings;
+            if (settings.HasMigratedPersistentRuleCpuAssignmentModes)
+            {
+                return;
+            }
+
+            try
+            {
+                var ruleStore = this.serviceProvider.GetService<IPersistentProcessRuleStore>();
+                if (ruleStore == null)
+                {
+                    return;
+                }
+
+                var rules = await ruleStore.LoadAsync();
+                var migrated = CpuAssignmentModeMigrationPolicy.ApplyToRules(rules);
+                if (migrated != null)
+                {
+                    await ruleStore.SaveAsync(migrated);
+                    var movedCount = rules
+                        .Zip(migrated, (before, after) => before.CpuAssignmentMode != after.CpuAssignmentMode)
+                        .Count(moved => moved);
+                    this.LogDebug($"Migrated {movedCount} saved rule(s) from Automatic to Affinity Mask");
+                }
+
+                // Only after the rules have reached disk: a failed write has to be retried on the
+                // next launch, not recorded as done.
+                settings.HasMigratedPersistentRuleCpuAssignmentModes = true;
+                await this.settingsService.UpdateSettingsAsync(settings);
+            }
+            catch (Exception ex)
+            {
+                this.LogDebug($"Could not migrate saved rule CPU assignment modes: {ex.Message}");
+            }
         }
 
         private async Task InitializeSystemTrayAsync()

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -131,6 +131,7 @@ namespace ThreadPilot
                 this.securityService = securityService;
 
                 this.processViewModel.OpenRulesRequested += this.OnOpenRulesRequested;
+                this.processViewModel.OpenMasksRequested += this.OnOpenMasksRequested;
 
                 System.Diagnostics.Debug.WriteLine("Dependencies assigned");
 

--- a/Models/ApplicationSettingsModel.cs
+++ b/Models/ApplicationSettingsModel.cs
@@ -170,6 +170,11 @@ namespace ThreadPilot.Models
         [ObservableProperty]
         private bool hasSeenCpuAssignmentModeChangeNotice;
 
+        // Separate from the profile flag above: profiles were migrated in 1.7.2, saved rules
+        // were not, so a shared flag would skip the rules of everyone already on 1.7.2.
+        [ObservableProperty]
+        private bool hasMigratedPersistentRuleCpuAssignmentModes;
+
         // Advanced Settings
         [ObservableProperty]
         private bool enableDebugLogging = false;
@@ -272,6 +277,7 @@ namespace ThreadPilot.Models
             this.HasSeenStartupMinimizedSuggestion = other.HasSeenStartupMinimizedSuggestion;
             this.HasMigratedCpuAssignmentModeDefault = other.HasMigratedCpuAssignmentModeDefault;
             this.HasSeenCpuAssignmentModeChangeNotice = other.HasSeenCpuAssignmentModeChangeNotice;
+            this.HasMigratedPersistentRuleCpuAssignmentModes = other.HasMigratedPersistentRuleCpuAssignmentModes;
             this.EnableSelfLowImpactMode = other.EnableSelfLowImpactMode;
             this.EnableSelfAffinityLimit = other.EnableSelfAffinityLimit;
             this.MaxLogFileSizeMb = other.MaxLogFileSizeMb;

--- a/Platforms/Windows/IProcessCpuSetHandler.cs
+++ b/Platforms/Windows/IProcessCpuSetHandler.cs
@@ -17,6 +17,8 @@ namespace ThreadPilot.Platforms.Windows
 
         CpuSetApplyResult ApplyCpuSelectionDetailed(CpuSelection? selection, bool clearSelection = false);
 
+        IReadOnlyList<int>? GetDefaultCpuSetLogicalProcessorIndexes() => null;
+
         double GetAverageCpuUsage();
 
         bool IsValid { get; }

--- a/Platforms/Windows/ProcessCpuSetHandler.cs
+++ b/Platforms/Windows/ProcessCpuSetHandler.cs
@@ -66,6 +66,28 @@ namespace ThreadPilot.Platforms.Windows
 
         public bool IsValid => this.queryLimitedInfoHandle != null && !this.queryLimitedInfoHandle.IsInvalid;
 
+        public IReadOnlyList<int>? GetDefaultCpuSetLogicalProcessorIndexes()
+        {
+            var cpuSetIds = this.TryGetDefaultCpuSetIds();
+            if (cpuSetIds == null)
+            {
+                return null;
+            }
+
+            var indexes = new List<int>(cpuSetIds.Count);
+            foreach (var cpuSetId in cpuSetIds)
+            {
+                if (!this.cpuSetMapping.TryGetProcessorRef(cpuSetId, out var processor))
+                {
+                    return null;
+                }
+
+                indexes.Add(processor.GlobalIndex);
+            }
+
+            return indexes.Distinct().OrderBy(index => index).ToList();
+        }
+
         private static CpuSetMapping EnsureStaticInitialization(IProcessCpuSetNativeApi nativeApi)
         {
             if (staticInitialized)
@@ -360,19 +382,30 @@ namespace ThreadPilot.Platforms.Windows
 
         private bool VerifyCpuSetIds(uint[] expected, uint expectedCount)
         {
-            if (!this.nativeApi.GetProcessDefaultCpuSets(this.queryLimitedInfoHandle!, null, 0, out var requiredCount) && requiredCount == 0)
+            var observed = this.TryGetDefaultCpuSetIds();
+            return observed != null &&
+                observed.OrderBy(id => id).SequenceEqual(expected.Take((int)expectedCount).OrderBy(id => id));
+        }
+
+        private List<uint>? TryGetDefaultCpuSetIds()
+        {
+            if (!this.IsValid)
             {
-                return false;
+                return null;
             }
 
+            var firstCallSucceeded = this.nativeApi.GetProcessDefaultCpuSets(
+                this.queryLimitedInfoHandle!, null, 0, out var requiredCount);
             if (requiredCount == 0)
             {
-                return expectedCount == 0;
+                return firstCallSucceeded ? [] : null;
             }
 
             var observed = new uint[requiredCount];
-            return this.nativeApi.GetProcessDefaultCpuSets(this.queryLimitedInfoHandle!, observed, requiredCount, out requiredCount) &&
-                observed.Take((int)requiredCount).OrderBy(id => id).SequenceEqual(expected.Take((int)expectedCount).OrderBy(id => id));
+            return this.nativeApi.GetProcessDefaultCpuSets(
+                this.queryLimitedInfoHandle!, observed, requiredCount, out var observedCount)
+                ? observed.Take((int)observedCount).ToList()
+                : null;
         }
 
         private List<uint> GetUnavailableAllocatedCpuSetIds(IReadOnlyList<uint> selectedIds)

--- a/Platforms/Windows/ProcessThreadCpuAssignmentHandler.cs
+++ b/Platforms/Windows/ProcessThreadCpuAssignmentHandler.cs
@@ -68,6 +68,46 @@ namespace ThreadPilot.Platforms.Windows
             });
         }
 
+        public IReadOnlyList<int>? GetIdealProcessorIndexes()
+        {
+            try
+            {
+                using var process = Process.GetProcessById(this.processId);
+                var indexes = new HashSet<int>();
+                foreach (var threadId in process.Threads.Cast<ProcessThread>().Select(thread => thread.Id))
+                {
+                    using var handle = NativeMethods.OpenThread(ThreadQueryLimitedInformation, false, (uint)threadId);
+                    if (handle.IsInvalid)
+                    {
+                        if (Marshal.GetLastWin32Error() == ErrorInvalidParameter)
+                        {
+                            continue;
+                        }
+
+                        return null;
+                    }
+
+                    if (!NativeMethods.GetThreadIdealProcessorEx(handle, out var processor))
+                    {
+                        if (Marshal.GetLastWin32Error() == ErrorInvalidParameter)
+                        {
+                            continue;
+                        }
+
+                        return null;
+                    }
+
+                    indexes.Add((processor.Group * 64) + processor.Number);
+                }
+
+                return indexes.Count == 0 ? null : indexes.OrderBy(index => index).ToList();
+            }
+            catch (Exception ex) when (ex is ArgumentException or InvalidOperationException or Win32Exception)
+            {
+                return null;
+            }
+        }
+
         internal static IReadOnlyList<GroupAffinity> BuildGroupAffinities(IEnumerable<ProcessorRef> processors) =>
             processors
                 .Distinct()

--- a/Services/CoreMaskService.cs
+++ b/Services/CoreMaskService.cs
@@ -541,6 +541,12 @@ namespace ThreadPilot.Services
             bool canCreateNoSmtVariants = topologyConfident && hasHyperThreading;
             bool changed = false;
 
+            // Only rewrite already-stored masks when the core count came from a successful
+            // topology detection. Environment.ProcessorCount (the ResolveLogicalCoreCount
+            // fallback) can under-report under affinity/job-object limits, and resizing masks
+            // to a wrong length would silently redefine them.
+            bool canReconcileLengths = topologyConfident && coreCount > 0;
+
             // Collect all default masks with their "no SMT" variants
             var defaultMasks = new List<(string name, List<bool> boolMask, string description)>();
 
@@ -562,7 +568,7 @@ namespace ThreadPilot.Services
                 allCoresMask.BoolMask.Add(true);
             }
 
-            changed |= this.AddBuiltInMaskIfMissing(allCoresMask);
+            changed |= this.AddOrReconcileBuiltInMask(allCoresMask, canReconcileLengths);
 
             if (coreCount > 1)
             {
@@ -579,7 +585,7 @@ namespace ThreadPilot.Services
                     noCoreZeroMask.BoolMask.Add(i != 0);
                 }
 
-                changed |= this.AddBuiltInMaskIfMissing(noCoreZeroMask);
+                changed |= this.AddOrReconcileBuiltInMask(noCoreZeroMask, canReconcileLengths);
             }
 
             // 2. Intel Hybrid Architecture: P-Cores, E-Cores, LPE-Cores (Arrow Lake+)
@@ -690,7 +696,7 @@ namespace ThreadPilot.Services
             // Add all generated masks to AvailableMasks
             foreach (var mask in resultMasks)
             {
-                changed |= this.AddBuiltInMaskIfMissing(mask);
+                changed |= this.AddOrReconcileBuiltInMask(mask, canReconcileLengths);
             }
 
             await Task.CompletedTask;
@@ -707,17 +713,45 @@ namespace ThreadPilot.Services
             return Environment.ProcessorCount;
         }
 
-        private bool AddBuiltInMaskIfMissing(CoreMask mask)
+        private bool AddOrReconcileBuiltInMask(CoreMask mask, bool reconcileLength)
         {
-            if (this.AvailableMasks.Any(existing =>
-                existing.Name.Equals(mask.Name, StringComparison.OrdinalIgnoreCase)))
+            var existing = this.AvailableMasks.FirstOrDefault(m =>
+                m.Name.Equals(mask.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (existing == null)
+            {
+                this.AvailableMasks.Add(mask);
+                this.logger.LogInformation("Backfilled built-in core mask '{Name}'", mask.Name);
+                return true;
+            }
+
+            if (!reconcileLength || existing.BoolMask.Count == mask.BoolMask.Count)
             {
                 return false;
             }
 
-            this.AvailableMasks.Add(mask);
-            this.logger.LogInformation("Backfilled built-in core mask '{Name}'", mask.Name);
+            this.logger.LogInformation(
+                "Re-derived built-in core mask '{Name}' ({Id}) from the current topology: stored {OldCount} logical CPUs, machine has {NewCount}",
+                existing.Name, existing.Id, existing.BoolMask.Count, mask.BoolMask.Count);
+
+            ReplaceBoolMask(existing, mask.BoolMask);
             return true;
+        }
+
+        private static void ReplaceBoolMask(CoreMask mask, IEnumerable<bool> bits)
+        {
+            mask.BoolMask.Clear();
+            foreach (var bit in bits)
+            {
+                mask.BoolMask.Add(bit);
+            }
+
+            // Drop the stale CpuSelection so it is re-derived from the new BoolMask by
+            // ApplyCpuSelectionMigrationAsync (which skips masks that already have one).
+            mask.CpuSelection = null;
+            mask.CpuSelectionMigration = null;
+            mask.ProfileSchemaVersion = CpuAffinityProfileSchemaVersions.Legacy;
+            mask.UpdatedAt = DateTime.UtcNow;
         }
 
         private async Task CreateAmdCcdMasksAsync(

--- a/Services/CoreMaskService.cs
+++ b/Services/CoreMaskService.cs
@@ -38,6 +38,8 @@ namespace ThreadPilot.Services
 
         public ObservableCollection<CoreMask> AvailableMasks { get; private set; } = new();
 
+        public IReadOnlyList<string> MasksNeedingTopologyReview { get; private set; } = [];
+
         public CoreMask? DefaultMask => this.AvailableMasks.FirstOrDefault(m => m.IsDefault);
 
         private const string ALLCORESMASKNAME = "All Cores";
@@ -699,6 +701,8 @@ namespace ThreadPilot.Services
                 changed |= this.AddOrReconcileBuiltInMask(mask, canReconcileLengths);
             }
 
+            this.CollectMasksNeedingTopologyReview(coreCount, canReconcileLengths);
+
             await Task.CompletedTask;
             return changed;
         }
@@ -711,6 +715,34 @@ namespace ThreadPilot.Services
             }
 
             return Environment.ProcessorCount;
+        }
+
+        // A built-in mask can be re-derived, because ThreadPilot knows what it is supposed to mean.
+        // A mask the user drew cannot: only they know whether the CPUs that appeared should be part
+        // of it. So flag those and let the Masks tab ask, rather than resize them behind their back
+        // or leave them quietly selecting the wrong cores.
+        private void CollectMasksNeedingTopologyReview(int coreCount, bool topologyIsTrustworthy)
+        {
+            if (!topologyIsTrustworthy)
+            {
+                return;
+            }
+
+            var stale = this.AvailableMasks
+                .Where(mask => !mask.IsDefault && mask.BoolMask.Count > 0 && mask.BoolMask.Count != coreCount)
+                .Select(mask => mask.Name)
+                .ToList();
+
+            this.MasksNeedingTopologyReview = stale;
+
+            if (stale.Count > 0)
+            {
+                this.logger.LogInformation(
+                    "{Count} custom core mask(s) were built for a different CPU ({Names}): stored bit count does not match the {CoreCount} logical CPUs on this machine",
+                    stale.Count,
+                    string.Join(", ", stale),
+                    coreCount);
+            }
         }
 
         private bool AddOrReconcileBuiltInMask(CoreMask mask, bool reconcileLength)

--- a/Services/ICoreMaskService.cs
+++ b/Services/ICoreMaskService.cs
@@ -11,6 +11,9 @@ namespace ThreadPilot.Services
 
         CoreMask? DefaultMask { get; }
 
+        // Custom masks whose stored bit count no longer matches this machine's logical CPU count.
+        IReadOnlyList<string> MasksNeedingTopologyReview => [];
+
         Task InitializeAsync();
 
         Task<CoreMask> CreateMaskAsync(string name, string description, IEnumerable<bool> boolMask);

--- a/Services/IProcessService.cs
+++ b/Services/IProcessService.cs
@@ -24,6 +24,10 @@ namespace ThreadPilot.Services
 
         Task RefreshProcessInfo(ProcessModel process);
 
+        Task<IReadOnlyList<int>?> GetCpuAssignmentLogicalProcessorIndexesAsync(
+            ProcessModel process,
+            CpuAssignmentMode mode);
+
         Task<ProcessModel?> GetProcessByIdAsync(int processId);
 
         Task<IEnumerable<ProcessModel>> GetProcessesByNameAsync(string executableName);

--- a/Services/ProcessRuleCreationService.cs
+++ b/Services/ProcessRuleCreationService.cs
@@ -26,6 +26,10 @@ namespace ThreadPilot.Services
         Task<ProcessRuleCreationResult> DeleteRuleAsync(
             ProcessModel process,
             CancellationToken cancellationToken = default);
+
+        Task<ProcessRuleCreationResult> DeleteRuleByIdAsync(
+            string ruleId,
+            CancellationToken cancellationToken = default);
     }
 
     public sealed record ProcessRuleCreationPayload
@@ -164,15 +168,44 @@ namespace ThreadPilot.Services
                 return ProcessRuleCreationResult.Failed("NoSavedRuleToDelete", NoSavedRuleMessage);
             }
 
-            var removed = rules[existingIndex];
-            rules.RemoveAt(existingIndex);
+            return await this.RemoveAtAsync(rules, existingIndex, cancellationToken).ConfigureAwait(false);
+        }
+
+        // The saved-rules list in the Rules tab holds rules, not processes: it can address a rule
+        // whose process is not running, which is exactly when a stale rule needs removing.
+        public async Task<ProcessRuleCreationResult> DeleteRuleByIdAsync(
+            string ruleId,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(ruleId))
+            {
+                return ProcessRuleCreationResult.Failed("NoSavedRuleToDelete", NoSavedRuleMessage);
+            }
+
+            var rules = (await this.ruleStore.LoadAsync().ConfigureAwait(false)).ToList();
+            var existingIndex = rules.FindIndex(rule => string.Equals(rule.Id, ruleId, StringComparison.Ordinal));
+            if (existingIndex < 0)
+            {
+                return ProcessRuleCreationResult.Failed("NoSavedRuleToDelete", NoSavedRuleMessage);
+            }
+
+            return await this.RemoveAtAsync(rules, existingIndex, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<ProcessRuleCreationResult> RemoveAtAsync(
+            List<PersistentProcessRule> rules,
+            int index,
+            CancellationToken cancellationToken)
+        {
+            var removed = rules[index];
+            rules.RemoveAt(index);
 
             cancellationToken.ThrowIfCancellationRequested();
             await this.ruleStore.SaveAsync(rules).ConfigureAwait(false);
 
-            var processName = string.IsNullOrWhiteSpace(process.Name)
+            var processName = string.IsNullOrWhiteSpace(removed.ProcessName)
                 ? "process"
-                : process.Name.Trim();
+                : removed.ProcessName.Trim();
             this.logger.LogInformation(
                 "Deleted saved rule {RuleId} for process {ProcessName}",
                 removed.Id,

--- a/Services/ProcessRuleCreationService.cs
+++ b/Services/ProcessRuleCreationService.cs
@@ -30,6 +30,10 @@ namespace ThreadPilot.Services
         Task<ProcessRuleCreationResult> DeleteRuleByIdAsync(
             string ruleId,
             CancellationToken cancellationToken = default);
+
+        Task<ProcessRuleCreationResult> UpdateRuleAsync(
+            PersistentProcessRule rule,
+            CancellationToken cancellationToken = default);
     }
 
     public sealed record ProcessRuleCreationPayload
@@ -190,6 +194,63 @@ namespace ThreadPilot.Services
             }
 
             return await this.RemoveAtAsync(rules, existingIndex, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Editing a rule in place, from the saved-rules list. The affinity payload is not editable
+        // there - that needs the core picker in the Process tab - so it is carried over untouched
+        // rather than rebuilt, and only the fields the editor owns are replaced.
+        public async Task<ProcessRuleCreationResult> UpdateRuleAsync(
+            PersistentProcessRule rule,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(rule);
+
+            if (rule.Priority.HasValue && ProcessPriorityGuardrails.IsBlocked(rule.Priority.Value))
+            {
+                return ProcessRuleCreationResult.Failed(
+                    "RealtimePriorityBlocked",
+                    ProcessOperationUserMessages.RealtimePriorityBlocked);
+            }
+
+            var rules = (await this.ruleStore.LoadAsync().ConfigureAwait(false)).ToList();
+            var existingIndex = rules.FindIndex(candidate => string.Equals(candidate.Id, rule.Id, StringComparison.Ordinal));
+            if (existingIndex < 0)
+            {
+                return ProcessRuleCreationResult.Failed("NoSavedRuleToUpdate", NoSavedRuleMessage);
+            }
+
+            var existing = rules[existingIndex];
+            var updated = existing with
+            {
+                IsEnabled = rule.IsEnabled,
+                Priority = rule.Priority,
+                MemoryPriority = rule.MemoryPriority,
+                IoPriority = rule.IoPriority,
+                CpuAssignmentMode = rule.CpuAssignmentMode,
+                PreventSystemSleepWhileRunning = rule.PreventSystemSleepWhileRunning,
+                ApplyPriorityOnStart = rule.Priority.HasValue,
+                ApplyMemoryPriorityOnStart = rule.MemoryPriority.HasValue,
+                ApplyIoPriorityOnStart = rule.IoPriority.HasValue,
+                UpdatedAt = DateTime.UtcNow,
+            };
+
+            rules[existingIndex] = updated;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await this.ruleStore.SaveAsync(rules).ConfigureAwait(false);
+
+            var processName = string.IsNullOrWhiteSpace(updated.ProcessName)
+                ? "process"
+                : updated.ProcessName.Trim();
+            this.logger.LogInformation("Updated saved rule {RuleId} for process {ProcessName}", updated.Id, processName);
+
+            return new ProcessRuleCreationResult
+            {
+                Success = true,
+                Updated = true,
+                Rule = updated,
+                UserMessage = $"Updated saved rule for {processName}.",
+            };
         }
 
         private async Task<ProcessRuleCreationResult> RemoveAtAsync(

--- a/Services/ProcessRuleCreationService.cs
+++ b/Services/ProcessRuleCreationService.cs
@@ -22,6 +22,10 @@ namespace ThreadPilot.Services
             ProcessIoPriority? currentIoPriority = null,
             bool preventSystemSleepWhileRunning = false,
             CancellationToken cancellationToken = default);
+
+        Task<ProcessRuleCreationResult> DeleteRuleAsync(
+            ProcessModel process,
+            CancellationToken cancellationToken = default);
     }
 
     public sealed record ProcessRuleCreationPayload
@@ -68,6 +72,9 @@ namespace ThreadPilot.Services
     {
         public const string NoCurrentSettingsMessage =
             "There are no current settings to save as a rule.";
+
+        public const string NoSavedRuleMessage =
+            "There is no saved rule for this process.";
 
         public const string UnsafeAffinityMessage =
             "The current affinity selection cannot be saved safely on this CPU topology.";
@@ -141,6 +148,44 @@ namespace ThreadPilot.Services
             return await this.SaveRuleAsync(process, payload, cancellationToken).ConfigureAwait(false);
         }
 
+        // Deliberately matched with the same FindExistingRuleIndex that saving uses: if delete and
+        // save disagreed on which rule belongs to a process, a rule could become impossible to
+        // remove from the UI that created it.
+        public async Task<ProcessRuleCreationResult> DeleteRuleAsync(
+            ProcessModel process,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(process);
+
+            var rules = (await this.ruleStore.LoadAsync().ConfigureAwait(false)).ToList();
+            var existingIndex = FindExistingRuleIndex(rules, process);
+            if (existingIndex < 0)
+            {
+                return ProcessRuleCreationResult.Failed("NoSavedRuleToDelete", NoSavedRuleMessage);
+            }
+
+            var removed = rules[existingIndex];
+            rules.RemoveAt(existingIndex);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await this.ruleStore.SaveAsync(rules).ConfigureAwait(false);
+
+            var processName = string.IsNullOrWhiteSpace(process.Name)
+                ? "process"
+                : process.Name.Trim();
+            this.logger.LogInformation(
+                "Deleted saved rule {RuleId} for process {ProcessName}",
+                removed.Id,
+                processName);
+
+            return new ProcessRuleCreationResult
+            {
+                Success = true,
+                Rule = removed,
+                UserMessage = $"Deleted saved rule for {processName}.",
+            };
+        }
+
         public async Task<ProcessRuleCreationResult> SaveRuleAsync(
             ProcessModel process,
             ProcessRuleCreationPayload payload,
@@ -172,6 +217,24 @@ namespace ThreadPilot.Services
                 ? null
                 : process.ExecutablePath.Trim();
             var existing = created ? null : rules[existingIndex];
+
+            // Saving is a merge, not a replacement. A caller that does not carry a field - or a
+            // field that could not be read from the process this time - must not silently erase
+            // what the rule already had: that turned "Apply CPU assignment and save as rule" into
+            // a quiet way to lose the memory and I/O priority saved a moment earlier. Removing a
+            // field is done by deleting the rule, which is an explicit action.
+            var hasAffinityPayload = HasSelectionPayload(payload.CpuSelection) || payload.LegacyAffinityMask.HasValue;
+            var cpuSelection = hasAffinityPayload ? payload.CpuSelection : existing?.CpuSelection;
+            var legacyAffinityMask = hasAffinityPayload
+                ? (HasSelectionPayload(payload.CpuSelection) ? null : payload.LegacyAffinityMask)
+                : existing?.LegacyAffinityMask;
+            var cpuAssignmentMode = hasAffinityPayload
+                ? payload.CpuAssignmentMode
+                : existing?.CpuAssignmentMode ?? payload.CpuAssignmentMode;
+            var priority = payload.Priority ?? existing?.Priority;
+            var memoryPriority = payload.MemoryPriority ?? existing?.MemoryPriority;
+            var ioPriority = payload.IoPriority ?? existing?.IoPriority;
+
             var rule = new PersistentProcessRule
             {
                 Id = existing?.Id ?? Guid.NewGuid().ToString("N"),
@@ -179,16 +242,16 @@ namespace ThreadPilot.Services
                 IsEnabled = true,
                 ProcessName = processName,
                 ExecutablePath = executablePath,
-                CpuSelection = payload.CpuSelection,
-                LegacyAffinityMask = HasSelectionPayload(payload.CpuSelection) ? null : payload.LegacyAffinityMask,
-                CpuAssignmentMode = payload.CpuAssignmentMode,
-                Priority = payload.Priority,
-                MemoryPriority = payload.MemoryPriority,
-                IoPriority = payload.IoPriority,
-                ApplyAffinityOnStart = HasSelectionPayload(payload.CpuSelection) || payload.LegacyAffinityMask.HasValue,
-                ApplyPriorityOnStart = payload.Priority.HasValue,
-                ApplyMemoryPriorityOnStart = payload.MemoryPriority.HasValue,
-                ApplyIoPriorityOnStart = payload.IoPriority.HasValue,
+                CpuSelection = cpuSelection,
+                LegacyAffinityMask = HasSelectionPayload(cpuSelection) ? null : legacyAffinityMask,
+                CpuAssignmentMode = cpuAssignmentMode,
+                Priority = priority,
+                MemoryPriority = memoryPriority,
+                IoPriority = ioPriority,
+                ApplyAffinityOnStart = HasSelectionPayload(cpuSelection) || legacyAffinityMask.HasValue,
+                ApplyPriorityOnStart = priority.HasValue,
+                ApplyMemoryPriorityOnStart = memoryPriority.HasValue,
+                ApplyIoPriorityOnStart = ioPriority.HasValue,
                 PreventSystemSleepWhileRunning = payload.PreventSystemSleepWhileRunning,
                 CreatedAt = existing?.CreatedAt ?? now,
                 UpdatedAt = now,

--- a/Services/ProcessService.cs
+++ b/Services/ProcessService.cs
@@ -514,6 +514,22 @@ namespace ThreadPilot.Services
                 return new ProcessCpuSetHandler((uint)pid, process.Name, this.logger);
             });
 
+        public Task<IReadOnlyList<int>?> GetCpuAssignmentLogicalProcessorIndexesAsync(
+            ProcessModel process,
+            CpuAssignmentMode mode)
+        {
+            ArgumentNullException.ThrowIfNull(process);
+
+            return Task.Run<IReadOnlyList<int>?>(() => mode switch
+            {
+                CpuAssignmentMode.CpuSets => this.GetOrCreateCpuSetHandler(process)
+                    .GetDefaultCpuSetLogicalProcessorIndexes(),
+                CpuAssignmentMode.IdealProcessor => new ProcessThreadCpuAssignmentHandler(process.ProcessId)
+                    .GetIdealProcessorIndexes(),
+                _ => null,
+            });
+        }
+
         private async Task<long> ApplyLegacyProcessorAffinityDirectAsync(ProcessModel process, long affinityMask)
         {
             return await Task.Run(() =>

--- a/Services/SystemTweaksService.cs
+++ b/Services/SystemTweaksService.cs
@@ -9,6 +9,7 @@ namespace ThreadPilot.Services
     using System.Linq;
     using System.Management;
     using System.Runtime.InteropServices;
+    using System.Security;
     using System.ServiceProcess;
     using System.Text.Json;
     using System.Text.RegularExpressions;
@@ -224,20 +225,32 @@ namespace ThreadPilot.Services
 
         public Task<TweakStatus> GetMemoryIntegrityStatusAsync()
         {
+            // CI\State is only populated on some builds. DeviceGuard\Scenarios is where the
+            // running HVCI state actually lives on current Windows, so read that first and keep
+            // CI\State as the fallback - checking only the latter reported "not exposed" on
+            // machines where Memory Integrity is plainly on.
+            var value =
+                ReadRegistryIntValueOrNull(@"SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity", "Enabled")
+                ?? ReadRegistryIntValueOrNull(@"SYSTEM\CurrentControlSet\Control\CI\State", "HVCIEnabled");
+
+            return Task.FromResult(new TweakStatus
+            {
+                IsEnabled = value == 1,
+                IsAvailable = value.HasValue,
+                ErrorMessage = value.HasValue ? null : "Memory Integrity state is not exposed by Windows.",
+            });
+        }
+
+        private static int? ReadRegistryIntValueOrNull(string path, string valueName)
+        {
             try
             {
-                using var key = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\CI\State");
-                var value = key == null ? null : ReadRegistryIntValue(key, "HVCIEnabled");
-                return Task.FromResult(new TweakStatus
-                {
-                    IsEnabled = value == 1,
-                    IsAvailable = value.HasValue,
-                    ErrorMessage = value.HasValue ? null : "Memory Integrity state is not exposed by Windows.",
-                });
+                using var key = Registry.LocalMachine.OpenSubKey(path);
+                return key == null ? null : ReadRegistryIntValue(key, valueName);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is SecurityException or UnauthorizedAccessException or IOException)
             {
-                return Task.FromResult(new TweakStatus { IsAvailable = false, ErrorMessage = ex.Message });
+                return null;
             }
         }
 
@@ -657,15 +670,42 @@ namespace ThreadPilot.Services
         private static List<RegistryTarget> FindEthernetTargets(IEnumerable<string> valueNames)
         {
             var targets = new List<RegistryTarget>();
-            using var adapters = Registry.LocalMachine.OpenSubKey(NetworkAdapterClassPath);
-            if (adapters == null)
+            var names = valueNames.ToList();
+
+            try
+            {
+                using var adapters = Registry.LocalMachine.OpenSubKey(NetworkAdapterClassPath);
+                if (adapters == null)
+                {
+                    return targets;
+                }
+
+                foreach (var subKeyName in adapters.GetSubKeyNames())
+                {
+                    // One adapter subkey the current user cannot read - VPN and vendor virtual
+                    // adapters ship with tighter ACLs - used to throw out of the whole scan, so the
+                    // tweak reported itself unavailable with a raw framework message even though
+                    // every real Ethernet adapter on the machine was readable. Skip that key only.
+                    CollectEthernetTargetsFromAdapter(targets, subKeyName, names);
+                }
+            }
+            catch (Exception ex) when (ex is SecurityException or UnauthorizedAccessException or IOException)
             {
                 return targets;
             }
 
-            foreach (var subKeyName in adapters.GetSubKeyNames())
+            return targets;
+        }
+
+        private static void CollectEthernetTargetsFromAdapter(
+            ICollection<RegistryTarget> targets,
+            string subKeyName,
+            IReadOnlyCollection<string> valueNames)
+        {
+            var path = $@"{NetworkAdapterClassPath}\{subKeyName}";
+
+            try
             {
-                var path = $@"{NetworkAdapterClassPath}\{subKeyName}";
                 using var adapter = Registry.LocalMachine.OpenSubKey(path);
                 var characteristics = adapter == null ? null : ReadRegistryIntValue(adapter, "Characteristics");
                 if (adapter == null ||
@@ -673,7 +713,7 @@ namespace ThreadPilot.Services
                     !characteristics.HasValue ||
                     (characteristics.Value & 0x4) == 0)
                 {
-                    continue;
+                    return;
                 }
 
                 foreach (var valueName in valueNames)
@@ -681,8 +721,9 @@ namespace ThreadPilot.Services
                     AddRegistryTarget(targets, adapter, path, valueName);
                 }
             }
-
-            return targets;
+            catch (Exception ex) when (ex is SecurityException or UnauthorizedAccessException or IOException)
+            {
+            }
         }
 
         private static List<RegistryTarget> FindGpuMsiTargets()

--- a/Tests/ThreadPilot.Core.Tests/BaseViewModelStatusTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/BaseViewModelStatusTests.cs
@@ -17,6 +17,32 @@ namespace ThreadPilot.Core.Tests
             Assert.False(viewModel.IsBusy);
         }
 
+        [Fact]
+        public void ClearStatus_KeepsACompletionMessage()
+        {
+            // The regression this covers: an apply succeeded, set its status, and the operation's
+            // own finally wiped it before the user could read it - while failures stayed up.
+            var viewModel = new TestViewModel();
+
+            viewModel.SetCompletion("CPU assignment applied successfully to cs2 using AffinityMask.");
+            viewModel.Clear();
+
+            Assert.Equal("CPU assignment applied successfully to cs2 using AffinityMask.", viewModel.StatusMessage);
+            Assert.False(viewModel.IsBusy);
+        }
+
+        [Fact]
+        public void ClearStatus_StillClearsAProgressMessage()
+        {
+            var viewModel = new TestViewModel();
+
+            viewModel.SetProgress("Setting affinity for cs2...");
+            viewModel.Clear();
+
+            Assert.Equal(string.Empty, viewModel.StatusMessage);
+            Assert.False(viewModel.IsBusy);
+        }
+
         private sealed class TestViewModel : BaseViewModel
         {
             public TestViewModel()
@@ -25,6 +51,10 @@ namespace ThreadPilot.Core.Tests
             }
 
             public void SetCritical(string message) => this.SetCriticalStatus(message);
+
+            public void SetCompletion(string message) => this.SetStatus(message, false);
+
+            public void SetProgress(string message) => this.SetStatus(message);
 
             public void Clear() => this.ClearStatus();
         }

--- a/Tests/ThreadPilot.Core.Tests/CoreMaskServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/CoreMaskServiceTests.cs
@@ -94,6 +94,26 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
+        public async Task InitializeAsync_AfterCpuChange_RebuildsBuiltInsButPreservesUserMask()
+        {
+            var masksFilePath = CreateTempMasksPath();
+            await WriteMasksAsync(
+                masksFilePath,
+                CreateStoredMask("all-cores", "All Cores", [true, true, true, true], isDefault: true),
+                CreateStoredMask("custom-mask", "My Game Mask", [true, false, true, false]));
+            var service = CreateService(CreateTopology(logicalCoreCount: 8), masksFilePath);
+
+            await service.InitializeAsync();
+
+            var allCores = Assert.Single(service.AvailableMasks, mask => mask.Name == "All Cores");
+            Assert.Equal("all-cores", allCores.Id);
+            Assert.Equal(8, allCores.BoolMask.Count);
+            Assert.All(allCores.BoolMask, Assert.True);
+            var customMask = Assert.Single(service.AvailableMasks, mask => mask.Id == "custom-mask");
+            Assert.Equal(new[] { true, false, true, false }, customMask.BoolMask);
+        }
+
+        [Fact]
         public async Task TopologyDetected_AfterInitialLoad_BackfillsSmtDefaults()
         {
             var masksFilePath = CreateTempMasksPath();

--- a/Tests/ThreadPilot.Core.Tests/CpuAssignmentModeMigrationPolicyTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/CpuAssignmentModeMigrationPolicyTests.cs
@@ -1,5 +1,6 @@
 namespace ThreadPilot.Core.Tests
 {
+    using System.Linq;
     using ThreadPilot.Helpers;
     using ThreadPilot.Models;
 
@@ -103,6 +104,7 @@ namespace ThreadPilot.Core.Tests
             {
                 HasMigratedCpuAssignmentModeDefault = true,
                 HasSeenCpuAssignmentModeChangeNotice = true,
+                HasMigratedPersistentRuleCpuAssignmentModes = true,
             };
             var target = new ApplicationSettingsModel();
 
@@ -110,6 +112,86 @@ namespace ThreadPilot.Core.Tests
 
             Assert.True(target.HasMigratedCpuAssignmentModeDefault);
             Assert.True(target.HasSeenCpuAssignmentModeChangeNotice);
+            Assert.True(target.HasMigratedPersistentRuleCpuAssignmentModes);
         }
+
+        [Fact]
+        public void ApplyToRules_MovesASavedRuleWithACpuSelectionOffAutomatic()
+        {
+            // A rule saved before 1.7.1 keeps applying CPU Sets on every process start: nothing the
+            // user can see changes, so the rule is indistinguishable from one that never runs.
+            var rules = new[] { RuleWithSelection(CpuAssignmentMode.Automatic) };
+
+            var migrated = CpuAssignmentModeMigrationPolicy.ApplyToRules(rules);
+
+            Assert.NotNull(migrated);
+            Assert.Equal(CpuAssignmentMode.AffinityMask, migrated!.Single().CpuAssignmentMode);
+            Assert.Equal(rules[0].Id, migrated.Single().Id);
+            Assert.Equal(rules[0].CpuSelection, migrated.Single().CpuSelection);
+        }
+
+        [Fact]
+        public void ApplyToRules_IsIdempotent()
+        {
+            var rules = new[] { RuleWithSelection(CpuAssignmentMode.Automatic) };
+
+            var migrated = CpuAssignmentModeMigrationPolicy.ApplyToRules(rules);
+
+            Assert.Null(CpuAssignmentModeMigrationPolicy.ApplyToRules(migrated!));
+        }
+
+        [Theory]
+        [InlineData(CpuAssignmentMode.AffinityMask)]
+        [InlineData(CpuAssignmentMode.IdealProcessor)]
+        [InlineData(CpuAssignmentMode.CpuSets)]
+        public void ApplyToRules_LeavesADeliberateModeAlone(CpuAssignmentMode mode)
+        {
+            var rules = new[] { RuleWithSelection(mode) };
+
+            Assert.Null(CpuAssignmentModeMigrationPolicy.ApplyToRules(rules));
+        }
+
+        [Fact]
+        public void ApplyToRules_LeavesALegacyMaskRuleAlone()
+        {
+            // Automatic with a legacy mask already applies a real affinity, so there is nothing to
+            // repair - and rewriting it would change a working rule for no reason.
+            var rules = new[]
+            {
+                new PersistentProcessRule
+                {
+                    ProcessName = "cs2",
+                    IsEnabled = true,
+                    LegacyAffinityMask = 0b1111,
+                    ApplyAffinityOnStart = true,
+                    CpuAssignmentMode = CpuAssignmentMode.Automatic,
+                },
+            };
+
+            Assert.Null(CpuAssignmentModeMigrationPolicy.ApplyToRules(rules));
+        }
+
+        [Fact]
+        public void ApplyToRules_LeavesARuleThatDoesNotApplyAffinityAlone()
+        {
+            var rules = new[] { RuleWithSelection(CpuAssignmentMode.Automatic) with { ApplyAffinityOnStart = false } };
+
+            Assert.Null(CpuAssignmentModeMigrationPolicy.ApplyToRules(rules));
+        }
+
+        private static PersistentProcessRule RuleWithSelection(CpuAssignmentMode mode) =>
+            new()
+            {
+                ProcessName = "cs2",
+                IsEnabled = true,
+                ApplyAffinityOnStart = true,
+                CpuAssignmentMode = mode,
+                CpuSelection = new CpuSelection
+                {
+                    CpuSetIds = { 256u },
+                    LogicalProcessors = { new ProcessorRef(0, 0, 0) },
+                    GlobalLogicalProcessorIndexes = { 0 },
+                },
+            };
     }
 }

--- a/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
@@ -4,8 +4,8 @@ namespace ThreadPilot.Core.Tests
 
     public sealed partial class PackagingMetadataTests
     {
-        private const string ReleaseVersion = "1.7.2";
-        private const string ReleaseAssemblyVersion = "1.7.2.0";
+        private const string ReleaseVersion = "1.7.3";
+        private const string ReleaseAssemblyVersion = "1.7.3.0";
 
         [Fact]
         public void InnoInstallers_UseStableDisplayNameAndSeparateVersionMetadata()
@@ -120,7 +120,7 @@ namespace ThreadPilot.Core.Tests
             throw new InvalidOperationException("Repository root could not be located.");
         }
 
-        [GeneratedRegex("#define MyAppVersion \"1\\.7\\.2\"", RegexOptions.CultureInvariant)]
+        [GeneratedRegex("#define MyAppVersion \"1\\.7\\.3\"", RegexOptions.CultureInvariant)]
         private static partial Regex MyAppVersionRegex();
     }
 }

--- a/Tests/ThreadPilot.Core.Tests/ProcessCpuSetHandlerTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessCpuSetHandlerTests.cs
@@ -344,6 +344,24 @@ namespace ThreadPilot.Core.Tests
             Assert.Equal(AffinityApplyErrorCodes.NativeApplyFailed, result.ErrorCode);
         }
 
+        [Fact]
+        public void ProcessCpuSetHandler_ReadsCurrentSelectionAsLogicalProcessorIndexes()
+        {
+            var first = new ProcessorRef(0, 0, 0);
+            var third = new ProcessorRef(0, 2, 2);
+            var mapping = CpuSetMapping.Create(new Dictionary<ProcessorRef, uint>
+            {
+                [first] = 100,
+                [third] = 300,
+            });
+            var nativeApi = new FakeProcessCpuSetNativeApi { VerifiedCpuSetIds = [300, 100] };
+            using var handler = CreateHandler(nativeApi, mapping);
+
+            var indexes = handler.GetDefaultCpuSetLogicalProcessorIndexes();
+
+            Assert.Equal(new[] { 0, 2 }, indexes);
+        }
+
         private static ProcessCpuSetHandler CreateHandler(
             FakeProcessCpuSetNativeApi nativeApi,
             CpuSetMapping mapping)

--- a/Tests/ThreadPilot.Core.Tests/ProcessPowerPlanAssociationViewModelTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessPowerPlanAssociationViewModelTests.cs
@@ -2,6 +2,7 @@ namespace ThreadPilot.Core.Tests
 {
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
+    using ThreadPilot.Models;
     using ThreadPilot.Services;
     using ThreadPilot.ViewModels;
 
@@ -30,6 +31,85 @@ namespace ThreadPilot.Core.Tests
             powerPlans.Verify(service => service.GetPowerPlansAsync(), Times.Never);
             processes.Verify(service => service.GetProcessesAsync(), Times.Never);
             masks.Verify(service => service.InitializeAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task RefreshSavedProcessRulesAsync_ListsWhatEachRuleActuallyApplies()
+        {
+            var store = new FakeRuleStore(
+            [
+                new PersistentProcessRule
+                {
+                    Id = "rule-1",
+                    ProcessName = "cs2",
+                    IsEnabled = true,
+                    ApplyAffinityOnStart = true,
+                    CpuAssignmentMode = CpuAssignmentMode.AffinityMask,
+                    ApplyMemoryPriorityOnStart = true,
+                    MemoryPriority = ProcessMemoryPriority.Low,
+                },
+            ]);
+            var viewModel = CreateViewModel(store, new Mock<IProcessRuleCreationService>().Object);
+
+            await viewModel.RefreshSavedProcessRulesAsync();
+
+            var row = Assert.Single(viewModel.SavedProcessRules);
+            Assert.Equal("cs2", row.ProcessName);
+            Assert.Contains("CPU assignment", row.Applies);
+            Assert.Contains("memory Low", row.Applies);
+            Assert.Equal("AffinityMask", row.Mode);
+            Assert.True(viewModel.HasSavedProcessRules);
+        }
+
+        [Fact]
+        public async Task DeleteSavedProcessRuleCommand_RemovesTheRuleAndReloadsTheList()
+        {
+            var store = new FakeRuleStore(
+            [
+                new PersistentProcessRule { Id = "rule-1", ProcessName = "cs2", IsEnabled = true },
+            ]);
+            var ruleService = new Mock<IProcessRuleCreationService>();
+            ruleService
+                .Setup(service => service.DeleteRuleByIdAsync("rule-1", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    store.Rules = [];
+                    return new ProcessRuleCreationResult { Success = true, UserMessage = "Deleted saved rule for cs2." };
+                });
+            var viewModel = CreateViewModel(store, ruleService.Object);
+            await viewModel.RefreshSavedProcessRulesAsync();
+
+            await viewModel.DeleteSavedProcessRuleCommand.ExecuteAsync(viewModel.SavedProcessRules[0]);
+
+            ruleService.Verify(service => service.DeleteRuleByIdAsync("rule-1", It.IsAny<CancellationToken>()), Times.Once);
+            Assert.Empty(viewModel.SavedProcessRules);
+            Assert.False(viewModel.HasSavedProcessRules);
+        }
+
+        private static ProcessPowerPlanAssociationViewModel CreateViewModel(
+            IPersistentProcessRuleStore store,
+            IProcessRuleCreationService ruleService) =>
+            new(
+                NullLogger<ProcessPowerPlanAssociationViewModel>.Instance,
+                new Mock<IProcessPowerPlanAssociationService>(MockBehavior.Loose).Object,
+                new Mock<IPowerPlanService>(MockBehavior.Loose).Object,
+                new Mock<IProcessService>(MockBehavior.Loose).Object,
+                new Mock<IProcessMonitorManagerService>(MockBehavior.Loose).Object,
+                new Mock<ICoreMaskService>(MockBehavior.Loose).Object,
+                persistentRuleStore: store,
+                ruleCreationService: ruleService);
+
+        private sealed class FakeRuleStore(IReadOnlyList<PersistentProcessRule> rules) : IPersistentProcessRuleStore
+        {
+            public IReadOnlyList<PersistentProcessRule> Rules { get; set; } = rules;
+
+            public Task<IReadOnlyList<PersistentProcessRule>> LoadAsync() => Task.FromResult(this.Rules);
+
+            public Task SaveAsync(IReadOnlyList<PersistentProcessRule> rules)
+            {
+                this.Rules = rules;
+                return Task.CompletedTask;
+            }
         }
     }
 }

--- a/Tests/ThreadPilot.Core.Tests/ProcessRuleCreationServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessRuleCreationServiceTests.cs
@@ -426,6 +426,136 @@ namespace ThreadPilot.Core.Tests
                 GlobalLogicalProcessorIndexes = [0],
             };
 
+        [Fact]
+        public async Task SaveRuleAsync_KeepsFieldsTheCallerDidNotCarry()
+        {
+            // The regression this covers: "Apply CPU assignment and save as rule" sent no memory or
+            // I/O priority, and the rewrite dropped both from a rule that already had them.
+            var existing = new PersistentProcessRule
+            {
+                Id = "existing-rule",
+                ProcessName = "Game.exe",
+                ExecutablePath = @"C:\Games\Game.exe",
+                IsEnabled = true,
+                MemoryPriority = ProcessMemoryPriority.Low,
+                IoPriority = ProcessIoPriority.Low,
+                Priority = ProcessPriorityClass.High,
+                ApplyMemoryPriorityOnStart = true,
+                ApplyIoPriorityOnStart = true,
+                ApplyPriorityOnStart = true,
+            };
+            var store = new CapturingRuleStore([existing]);
+            var service = CreateService(store);
+
+            var result = await service.SaveRuleAsync(
+                CreateProcess(path: @"C:\Games\Game.exe"),
+                new ProcessRuleCreationPayload { CpuSelection = CreateCpuSelection() });
+
+            Assert.True(result.Success);
+            var rule = Assert.Single(store.SavedRules);
+            Assert.Equal(ProcessMemoryPriority.Low, rule.MemoryPriority);
+            Assert.Equal(ProcessIoPriority.Low, rule.IoPriority);
+            Assert.Equal(ProcessPriorityClass.High, rule.Priority);
+            Assert.True(rule.ApplyMemoryPriorityOnStart);
+            Assert.True(rule.ApplyIoPriorityOnStart);
+            Assert.True(rule.ApplyPriorityOnStart);
+            Assert.True(rule.ApplyAffinityOnStart);
+        }
+
+        [Fact]
+        public async Task SaveRuleAsync_KeepsTheExistingAffinityWhenOnlyPrioritiesAreSaved()
+        {
+            var selection = CreateCpuSelection();
+            var existing = new PersistentProcessRule
+            {
+                Id = "existing-rule",
+                ProcessName = "Game.exe",
+                ExecutablePath = @"C:\Games\Game.exe",
+                IsEnabled = true,
+                CpuSelection = selection,
+                CpuAssignmentMode = CpuAssignmentMode.CpuSets,
+                ApplyAffinityOnStart = true,
+            };
+            var store = new CapturingRuleStore([existing]);
+            var service = CreateService(store);
+
+            await service.SaveRuleAsync(
+                CreateProcess(path: @"C:\Games\Game.exe"),
+                new ProcessRuleCreationPayload { Priority = ProcessPriorityClass.High });
+
+            var rule = Assert.Single(store.SavedRules);
+            Assert.Same(selection, rule.CpuSelection);
+            Assert.Equal(CpuAssignmentMode.CpuSets, rule.CpuAssignmentMode);
+            Assert.True(rule.ApplyAffinityOnStart);
+        }
+
+        [Fact]
+        public async Task SaveRuleAsync_StillReplacesAFieldTheCallerDoesCarry()
+        {
+            var existing = new PersistentProcessRule
+            {
+                Id = "existing-rule",
+                ProcessName = "Game.exe",
+                ExecutablePath = @"C:\Games\Game.exe",
+                IsEnabled = true,
+                MemoryPriority = ProcessMemoryPriority.Low,
+                ApplyMemoryPriorityOnStart = true,
+            };
+            var store = new CapturingRuleStore([existing]);
+            var service = CreateService(store);
+
+            await service.SaveRuleAsync(
+                CreateProcess(path: @"C:\Games\Game.exe"),
+                new ProcessRuleCreationPayload { MemoryPriority = ProcessMemoryPriority.BelowNormal });
+
+            var rule = Assert.Single(store.SavedRules);
+            Assert.Equal(ProcessMemoryPriority.BelowNormal, rule.MemoryPriority);
+        }
+
+        [Fact]
+        public async Task DeleteRuleAsync_RemovesTheRuleMatchingTheProcess()
+        {
+            var target = new PersistentProcessRule
+            {
+                Id = "target-rule",
+                ProcessName = "Game.exe",
+                ExecutablePath = @"C:\Games\Game.exe",
+                IsEnabled = true,
+                Priority = ProcessPriorityClass.High,
+                ApplyPriorityOnStart = true,
+            };
+            var other = new PersistentProcessRule
+            {
+                Id = "other-rule",
+                ProcessName = "Other.exe",
+                ExecutablePath = @"C:\Games\Other.exe",
+                IsEnabled = true,
+            };
+            var store = new CapturingRuleStore([target, other]);
+            var service = CreateService(store);
+
+            var result = await service.DeleteRuleAsync(CreateProcess(path: @"C:\Games\Game.exe"));
+
+            Assert.True(result.Success);
+            Assert.Equal("Deleted saved rule for Game.exe.", result.UserMessage);
+            var remaining = Assert.Single(store.SavedRules);
+            Assert.Equal("other-rule", remaining.Id);
+        }
+
+        [Fact]
+        public async Task DeleteRuleAsync_ReportsAControlledFailureWhenNoRuleMatches()
+        {
+            var store = new CapturingRuleStore([]);
+            var service = CreateService(store);
+
+            var result = await service.DeleteRuleAsync(CreateProcess());
+
+            Assert.False(result.Success);
+            Assert.Equal("NoSavedRuleToDelete", result.ErrorCode);
+            Assert.Equal(ProcessRuleCreationService.NoSavedRuleMessage, result.UserMessage);
+            Assert.Empty(store.SavedRules);
+        }
+
         private static ProcessModel CreateProcess(
             string name = "Game.exe",
             string path = @"C:\Games\Game.exe",

--- a/Tests/ThreadPilot.Core.Tests/ProcessRuleCreationServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessRuleCreationServiceTests.cs
@@ -556,6 +556,94 @@ namespace ThreadPilot.Core.Tests
             Assert.Empty(store.SavedRules);
         }
 
+        [Fact]
+        public async Task UpdateRuleAsync_ChangesTheEditableFieldsAndKeepsTheAffinity()
+        {
+            var selection = CreateCpuSelection();
+            var existing = new PersistentProcessRule
+            {
+                Id = "rule-1",
+                ProcessName = "cs2",
+                IsEnabled = true,
+                CpuSelection = selection,
+                ApplyAffinityOnStart = true,
+                CpuAssignmentMode = CpuAssignmentMode.AffinityMask,
+            };
+            var store = new CapturingRuleStore([existing]);
+            var service = CreateService(store);
+
+            var result = await service.UpdateRuleAsync(existing with
+            {
+                IsEnabled = false,
+                MemoryPriority = ProcessMemoryPriority.Low,
+                Priority = ProcessPriorityClass.High,
+            });
+
+            Assert.True(result.Success);
+            var rule = Assert.Single(store.SavedRules);
+            Assert.False(rule.IsEnabled);
+            Assert.Equal(ProcessMemoryPriority.Low, rule.MemoryPriority);
+            Assert.True(rule.ApplyMemoryPriorityOnStart);
+            Assert.Equal(ProcessPriorityClass.High, rule.Priority);
+            Assert.True(rule.ApplyPriorityOnStart);
+            Assert.Same(selection, rule.CpuSelection);
+            Assert.True(rule.ApplyAffinityOnStart);
+        }
+
+        [Fact]
+        public async Task UpdateRuleAsync_ClearsAFieldTheEditorSetBackToNone()
+        {
+            var existing = new PersistentProcessRule
+            {
+                Id = "rule-1",
+                ProcessName = "cs2",
+                IsEnabled = true,
+                MemoryPriority = ProcessMemoryPriority.Low,
+                ApplyMemoryPriorityOnStart = true,
+            };
+            var store = new CapturingRuleStore([existing]);
+            var service = CreateService(store);
+
+            await service.UpdateRuleAsync(existing with { MemoryPriority = null });
+
+            var rule = Assert.Single(store.SavedRules);
+            Assert.Null(rule.MemoryPriority);
+            Assert.False(rule.ApplyMemoryPriorityOnStart);
+        }
+
+        [Fact]
+        public async Task UpdateRuleAsync_RefusesRealtimeAndLeavesTheRuleAlone()
+        {
+            var existing = new PersistentProcessRule
+            {
+                Id = "rule-1",
+                ProcessName = "cs2",
+                IsEnabled = true,
+                Priority = ProcessPriorityClass.High,
+                ApplyPriorityOnStart = true,
+            };
+            var store = new CapturingRuleStore([existing]);
+            var service = CreateService(store);
+
+            var result = await service.UpdateRuleAsync(existing with { Priority = ProcessPriorityClass.RealTime });
+
+            Assert.False(result.Success);
+            Assert.Equal("RealtimePriorityBlocked", result.ErrorCode);
+            Assert.Empty(store.SavedRules);
+        }
+
+        [Fact]
+        public async Task UpdateRuleAsync_ReportsAControlledFailureForAnUnknownRule()
+        {
+            var store = new CapturingRuleStore([]);
+            var service = CreateService(store);
+
+            var result = await service.UpdateRuleAsync(new PersistentProcessRule { Id = "missing", ProcessName = "cs2" });
+
+            Assert.False(result.Success);
+            Assert.Equal("NoSavedRuleToUpdate", result.ErrorCode);
+        }
+
         private static ProcessModel CreateProcess(
             string name = "Game.exe",
             string path = @"C:\Games\Game.exe",

--- a/Tests/ThreadPilot.Core.Tests/ProcessViewModelAffinityTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessViewModelAffinityTests.cs
@@ -84,13 +84,78 @@ namespace ThreadPilot.Core.Tests
             Assert.Same(topologyProvider.Object, provider);
         }
 
+        [Fact]
+        public void PollingInterval_InitializesAndUpdatesFromSettings()
+        {
+            var processService = new Mock<IProcessService>(MockBehavior.Loose);
+            var gameModeService = new Mock<IGameModeService>(MockBehavior.Loose);
+            var initial = new ApplicationSettingsModel { PollingIntervalMs = 2345 };
+            var settingsService = new Mock<IApplicationSettingsService>(MockBehavior.Loose);
+            settingsService.SetupGet(service => service.Settings).Returns(initial);
+            using var viewModel = CreateViewModel(
+                processService.Object,
+                gameModeService.Object,
+                cpuTopologyProvider: null,
+                settingsService: settingsService.Object);
+            var timer = (System.Timers.Timer)typeof(ProcessViewModel)
+                .GetField("refreshTimer", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(viewModel)!;
+
+            Assert.Equal(2345, timer.Interval);
+
+            var updated = (ApplicationSettingsModel)initial.Clone();
+            updated.PollingIntervalMs = 6789;
+            settingsService.Raise(
+                service => service.SettingsChanged += null,
+                new ApplicationSettingsChangedEventArgs(initial, updated, [nameof(ApplicationSettingsModel.PollingIntervalMs)]));
+
+            Assert.Equal(6789, timer.Interval);
+        }
+
+        [Fact]
+        public void SelectingProcessInCpuSetsMode_SynchronizesCheckboxesFromWindowsCpuSets()
+        {
+            var processService = new Mock<IProcessService>(MockBehavior.Loose);
+            processService.Setup(service => service.IsProcessStillRunning(It.IsAny<ProcessModel>())).ReturnsAsync(true);
+            processService.Setup(service => service.RefreshProcessInfo(It.IsAny<ProcessModel>())).Returns(Task.CompletedTask);
+            processService
+                .Setup(service => service.GetCpuAssignmentLogicalProcessorIndexesAsync(
+                    It.IsAny<ProcessModel>(), CpuAssignmentMode.CpuSets))
+                .ReturnsAsync([0]);
+            var gameModeService = new Mock<IGameModeService>(MockBehavior.Loose);
+            var settings = new ApplicationSettingsModel { DefaultCpuAssignmentMode = CpuAssignmentMode.AffinityMask };
+            var settingsService = new Mock<IApplicationSettingsService>(MockBehavior.Loose);
+            settingsService.SetupGet(service => service.Settings).Returns(settings);
+            using var viewModel = CreateViewModel(
+                processService.Object,
+                gameModeService.Object,
+                cpuTopologyProvider: null,
+                settingsService: settingsService.Object);
+            viewModel.CpuTopology = CreateTwoCoreTopology();
+            viewModel.CpuCores = new System.Collections.ObjectModel.ObservableCollection<CpuCoreModel>(
+                viewModel.CpuTopology.LogicalCores);
+
+            viewModel.SelectedProcess = new ProcessModel
+            {
+                ProcessId = 1234,
+                Name = "Game",
+                ProcessorAffinity = 3,
+            };
+
+            Assert.True(SpinWait.SpinUntil(
+                () => viewModel.CpuCores[0].IsSelected && !viewModel.CpuCores[1].IsSelected,
+                TimeSpan.FromSeconds(2)));
+            Assert.Equal("Current CPU Sets: CPU 0", viewModel.CurrentAffinityText);
+        }
+
         private static ProcessViewModel CreateViewModel(IProcessService processService, IGameModeService gameModeService)
             => CreateViewModel(processService, gameModeService, cpuTopologyProvider: null);
 
         private static ProcessViewModel CreateViewModel(
             IProcessService processService,
             IGameModeService gameModeService,
-            ICpuTopologyProvider? cpuTopologyProvider)
+            ICpuTopologyProvider? cpuTopologyProvider,
+            IApplicationSettingsService? settingsService = null)
         {
             var virtualizedProcessService = new Mock<IVirtualizedProcessService>(MockBehavior.Loose);
             virtualizedProcessService.SetupProperty(
@@ -116,7 +181,8 @@ namespace ThreadPilot.Core.Tests
                 coreMaskService.Object,
                 associationService.Object,
                 gameModeService,
-                cpuTopologyProvider: cpuTopologyProvider);
+                cpuTopologyProvider: cpuTopologyProvider,
+                settingsService: settingsService);
         }
 
         private static CpuTopologyModel CreateTwoCoreTopology()

--- a/Tests/ThreadPilot.Core.Tests/ProcessViewModelContextMenuTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessViewModelContextMenuTests.cs
@@ -77,6 +77,7 @@ namespace ThreadPilot.Core.Tests
                     It.Is<string>(context => context.Contains("Process: Game.exe") && context.Contains("PID: 100"))),
                 Times.Once);
             Assert.Same(rowProcess, viewModel.SelectedProcess);
+            Assert.Equal("CPU assignment applied successfully to Game.exe using AffinityMask.", viewModel.StatusMessage);
             var entry = Assert.Single(await audit.GetEntriesAsync());
             Assert.Equal("Affinity", entry.Category);
             Assert.Equal(ActivityAuditSeverity.Success, entry.Severity);

--- a/Tests/ThreadPilot.Core.Tests/SettingsViewModelThemeTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/SettingsViewModelThemeTests.cs
@@ -153,6 +153,21 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
+        public async Task SaveSettingsCommand_WhenStartMinimizedIsDisabled_UpdatesEnabledAutostart()
+        {
+            var harness = new Harness(initialStartMinimized: true);
+            harness.Autostart
+                .Setup(service => service.UpdateAutostartAsync(false))
+                .ReturnsAsync(true);
+            var viewModel = harness.CreateViewModel();
+            viewModel.Settings.StartMinimized = false;
+
+            await ((IAsyncRelayCommand)viewModel.SaveSettingsCommand).ExecuteAsync(null);
+
+            harness.Autostart.Verify(service => service.UpdateAutostartAsync(false), Times.Once);
+        }
+
+        [Fact]
         public async Task SaveSettingsCommand_MergesPendingEditWithExternalUpdate()
         {
             var harness = new Harness();
@@ -215,6 +230,24 @@ namespace ThreadPilot.Core.Tests
             Assert.Contains("TextWrapping=\"Wrap\"", serialized, StringComparison.Ordinal);
             Assert.Contains("IsChecked=\"{Binding Settings.ApplyPersistentRulesOnProcessStart}\"", serialized, StringComparison.Ordinal);
             Assert.Contains("Text=\"{DynamicResource SettingsView_ApplyOnStartDescription}\"", serialized, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SettingsView_ExposesResetProcessChangesOnExitToggle()
+        {
+            var settingsViewPath = Path.Combine(
+                AppContext.BaseDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "Views",
+                "SettingsView.xaml");
+            var serialized = File.ReadAllText(settingsViewPath);
+
+            Assert.Contains("IsChecked=\"{Binding Settings.ClearMasksOnClose}\"", serialized, StringComparison.Ordinal);
+            Assert.Contains("SettingsView_ResetProcessChangesOnExitDescription", serialized, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -310,12 +343,13 @@ namespace ThreadPilot.Core.Tests
 
             public ApplicationSettingsModel PersistedSettings => this.settings;
 
-            public Harness(bool initialDarkTheme = false)
+            public Harness(bool initialDarkTheme = false, bool initialStartMinimized = false)
             {
                 this.settings = new ApplicationSettingsModel
                 {
                     UseDarkTheme = initialDarkTheme,
                     HasUserThemePreference = initialDarkTheme,
+                    StartMinimized = initialStartMinimized,
                 };
                 this.SettingsService.SetupGet(service => service.Settings).Returns(this.settings);
                 this.Autostart

--- a/Tests/ThreadPilot.Core.Tests/WindowPlacementHelperTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/WindowPlacementHelperTests.cs
@@ -64,6 +64,85 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
+        public void CorrectWindowBounds_WhenFillingWorkingAreaAndShrinkRequested_CentersDefaultSizeOnSameMonitor()
+        {
+            var monitors = new[]
+            {
+                new MonitorWorkingArea(0, 0, 1920, 1040, true),
+                new MonitorWorkingArea(1920, 0, 2560, 1400, false),
+            };
+
+            // Restored from maximised on the secondary monitor with no smaller windowed size to return to.
+            var result = WindowPlacementHelper.CorrectWindowBounds(
+                new WindowBounds(1920, 0, 2560, 1400),
+                monitors,
+                shrinkWhenFillingWorkingArea: true);
+
+            Assert.True(result.WasCorrected);
+            Assert.Equal(1280, result.Bounds.Width);
+            Assert.Equal(864, result.Bounds.Height);
+            Assert.Equal(1920 + ((2560 - 1280) / 2), result.Bounds.Left);
+            Assert.Equal((1400 - 864) / 2, result.Bounds.Top);
+        }
+
+        [Fact]
+        public void CorrectWindowBounds_WhenFillingSmallWorkingAreaAndShrinkRequested_StaysClearlySmallerThanWorkingArea()
+        {
+            var monitors = new[]
+            {
+                new MonitorWorkingArea(0, 0, 1366, 728, true),
+            };
+
+            var result = WindowPlacementHelper.CorrectWindowBounds(
+                new WindowBounds(0, 0, 1366, 728),
+                monitors,
+                shrinkWhenFillingWorkingArea: true);
+
+            Assert.True(result.WasCorrected);
+            Assert.True(result.Bounds.Width < 1366);
+            Assert.True(result.Bounds.Height < 728);
+            Assert.Equal(1229, result.Bounds.Width);
+            Assert.Equal(655, result.Bounds.Height);
+        }
+
+        [Fact]
+        public void CorrectWindowBounds_WhenFillingWorkingAreaAndShrinkNotRequested_KeepsSize()
+        {
+            var monitors = new[]
+            {
+                new MonitorWorkingArea(0, 0, 1920, 1040, true),
+            };
+
+            var result = WindowPlacementHelper.CorrectWindowBounds(
+                new WindowBounds(0, 0, 1920, 1040),
+                monitors);
+
+            Assert.False(result.WasCorrected);
+            Assert.Equal(1920, result.Bounds.Width);
+            Assert.Equal(1040, result.Bounds.Height);
+        }
+
+        [Fact]
+        public void CorrectWindowBounds_WhenSmallerThanWorkingAreaAndShrinkRequested_KeepsWindowedBounds()
+        {
+            var monitors = new[]
+            {
+                new MonitorWorkingArea(0, 0, 1920, 1040, true),
+            };
+
+            var result = WindowPlacementHelper.CorrectWindowBounds(
+                new WindowBounds(300, 200, 1100, 700),
+                monitors,
+                shrinkWhenFillingWorkingArea: true);
+
+            Assert.False(result.WasCorrected);
+            Assert.Equal(300, result.Bounds.Left);
+            Assert.Equal(200, result.Bounds.Top);
+            Assert.Equal(1100, result.Bounds.Width);
+            Assert.Equal(700, result.Bounds.Height);
+        }
+
+        [Fact]
         public void CorrectWindowBounds_WhenAlreadyVisibleOnSecondaryMonitor_DoesNotMoveWindow()
         {
             var monitors = new[]

--- a/ThreadPilot.csproj
+++ b/ThreadPilot.csproj
@@ -16,10 +16,10 @@
     <TrimMode>link</TrimMode>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1998;CS0067;CS0414;WFAC010;IL3000;MVVMTK0034</NoWarn>
-    <Version>1.7.2</Version>
-    <AssemblyVersion>1.7.2.0</AssemblyVersion>
-    <FileVersion>1.7.2.0</FileVersion>
-    <InformationalVersion>1.7.2</InformationalVersion>
+    <Version>1.7.3</Version>
+    <AssemblyVersion>1.7.3.0</AssemblyVersion>
+    <FileVersion>1.7.3.0</FileVersion>
+    <InformationalVersion>1.7.3</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ViewModels/BaseViewModel.cs
+++ b/ViewModels/BaseViewModel.cs
@@ -77,6 +77,15 @@ namespace ThreadPilot.ViewModels
                 return;
             }
 
+            // A completion message is not busy state: SetStatus(..., isBusyState: false) already
+            // gave it a fade lifetime of its own. Blanking it here is what made every successful
+            // apply vanish instantly, while failures - which take the preserved path above - stayed
+            // on screen. Clearing belongs to progress messages only.
+            if (!this.IsBusy && !string.IsNullOrEmpty(this.StatusMessage))
+            {
+                return;
+            }
+
             this.CancelStatusLifetime();
             this.StatusMessage = string.Empty;
             this.StatusOpacity = 1.0;

--- a/ViewModels/MasksViewModel.cs
+++ b/ViewModels/MasksViewModel.cs
@@ -78,6 +78,9 @@ namespace ThreadPilot.ViewModels
             _ = this.InitializeAsync();
         }
 
+        [ObservableProperty]
+        private string topologyReviewMessage = string.Empty;
+
         private async Task InitializeAsync()
         {
             try
@@ -89,6 +92,14 @@ namespace ThreadPilot.ViewModels
 
                 // Select the default mask
                 this.SelectedCoreMask = this.coreMaskService.DefaultMask;
+
+                // A CPU change leaves custom masks describing a machine that no longer exists.
+                // ThreadPilot will not redraw them for the user, so it has to say so where they
+                // would go to fix them.
+                var needingReview = this.coreMaskService.MasksNeedingTopologyReview;
+                this.TopologyReviewMessage = needingReview.Count == 0
+                    ? string.Empty
+                    : $"These custom masks were built for a different CPU and no longer cover every logical processor on this machine: {string.Join(", ", needingReview)}. Open each one, check the cores, and save it again.";
 
                 this.logger.LogInformation("MasksViewModel initialized with {Count} masks", this.CoreMasks.Count);
             }

--- a/ViewModels/ProcessPowerPlanAssociationViewModel.cs
+++ b/ViewModels/ProcessPowerPlanAssociationViewModel.cs
@@ -1,6 +1,7 @@
 namespace ThreadPilot.ViewModels
 {
     using System;
+    using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.IO;
     using System.Linq;
@@ -21,6 +22,8 @@ namespace ThreadPilot.ViewModels
         private readonly IProcessService processService;
         private readonly IProcessMonitorManagerService monitorManagerService;
         private readonly ICoreMaskService coreMaskService;
+        private readonly IPersistentProcessRuleStore? persistentRuleStore;
+        private readonly IProcessRuleCreationService? ruleCreationService;
         private bool isInitialized;
         private readonly ILocalizationService? localizationService;
 
@@ -110,7 +113,9 @@ namespace ThreadPilot.ViewModels
             IProcessMonitorManagerService monitorManagerService,
             ICoreMaskService coreMaskService,
             IEnhancedLoggingService? enhancedLoggingService = null,
-            ILocalizationService? localizationService = null)
+            ILocalizationService? localizationService = null,
+            IPersistentProcessRuleStore? persistentRuleStore = null,
+            IProcessRuleCreationService? ruleCreationService = null)
             : base(logger, enhancedLoggingService)
         {
             this.associationService = associationService ?? throw new ArgumentNullException(nameof(associationService));
@@ -119,11 +124,105 @@ namespace ThreadPilot.ViewModels
             this.monitorManagerService = monitorManagerService ?? throw new ArgumentNullException(nameof(monitorManagerService));
             this.coreMaskService = coreMaskService ?? throw new ArgumentNullException(nameof(coreMaskService));
             this.localizationService = localizationService;
+            this.persistentRuleStore = persistentRuleStore;
+            this.ruleCreationService = ruleCreationService;
 
             // Subscribe to events
             this.associationService.ConfigurationChanged += this.OnConfigurationChanged;
             this.monitorManagerService.ServiceStatusChanged += this.OnServiceStatusChanged;
             this.monitorManagerService.ProcessPowerPlanChanged += this.OnProcessPowerPlanChanged;
+        }
+
+        // The per-process rules saved from the Process tab context menu. They are a different thing
+        // from the associations above - those switch the global power plan, these re-apply a
+        // process's own settings - and until they were listed here there was no way to see, or
+        // remove, a rule you had saved.
+        public ObservableCollection<SavedProcessRule> SavedProcessRules { get; } = new();
+
+        [ObservableProperty]
+        private bool hasSavedProcessRules;
+
+        public async Task RefreshSavedProcessRulesAsync()
+        {
+            if (this.persistentRuleStore == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var rules = await this.persistentRuleStore.LoadAsync().ConfigureAwait(true);
+                this.SavedProcessRules.Clear();
+                foreach (var rule in rules.OrderBy(rule => rule.ProcessName, StringComparer.OrdinalIgnoreCase))
+                {
+                    this.SavedProcessRules.Add(SavedProcessRule.From(rule));
+                }
+
+                this.HasSavedProcessRules = this.SavedProcessRules.Count > 0;
+            }
+            catch (Exception ex)
+            {
+                this.Logger.LogWarning(ex, "Could not load saved process rules for the Rules tab");
+            }
+        }
+
+        [RelayCommand]
+        private async Task DeleteSavedProcessRuleAsync(SavedProcessRule? rule)
+        {
+            if (rule == null || this.ruleCreationService == null)
+            {
+                return;
+            }
+
+            var result = await this.ruleCreationService.DeleteRuleByIdAsync(rule.Id).ConfigureAwait(true);
+            this.SetStatus(result.UserMessage, false);
+            await this.RefreshSavedProcessRulesAsync().ConfigureAwait(true);
+        }
+
+        public sealed record SavedProcessRule(
+            string Id,
+            string ProcessName,
+            string Applies,
+            string Mode,
+            bool IsEnabled,
+            DateTime UpdatedAt)
+        {
+            public static SavedProcessRule From(PersistentProcessRule rule)
+            {
+                var applies = new List<string>();
+                if (rule.ApplyAffinityOnStart)
+                {
+                    applies.Add("CPU assignment");
+                }
+
+                if (rule.ApplyPriorityOnStart && rule.Priority.HasValue)
+                {
+                    applies.Add($"priority {rule.Priority}");
+                }
+
+                if (rule.ApplyMemoryPriorityOnStart && rule.MemoryPriority.HasValue)
+                {
+                    applies.Add($"memory {rule.MemoryPriority}");
+                }
+
+                if (rule.ApplyIoPriorityOnStart && rule.IoPriority.HasValue)
+                {
+                    applies.Add($"I/O {rule.IoPriority}");
+                }
+
+                if (rule.PreventSystemSleepWhileRunning)
+                {
+                    applies.Add("keeps the system awake");
+                }
+
+                return new SavedProcessRule(
+                    rule.Id,
+                    string.IsNullOrWhiteSpace(rule.ProcessName) ? "(unnamed)" : rule.ProcessName,
+                    applies.Count == 0 ? "nothing" : string.Join(", ", applies),
+                    rule.ApplyAffinityOnStart ? rule.CpuAssignmentMode.ToString() : "-",
+                    rule.IsEnabled,
+                    rule.UpdatedAt.ToLocalTime());
+            }
         }
 
         protected override void OnDispose()
@@ -143,6 +242,7 @@ namespace ThreadPilot.ViewModels
 
             this.isInitialized = true;
             await this.LoadDataAsync();
+            await this.RefreshSavedProcessRulesAsync();
             this.UpdateServiceStatus();
         }
 

--- a/ViewModels/ProcessPowerPlanAssociationViewModel.cs
+++ b/ViewModels/ProcessPowerPlanAssociationViewModel.cs
@@ -179,13 +179,111 @@ namespace ThreadPilot.ViewModels
             await this.RefreshSavedProcessRulesAsync().ConfigureAwait(true);
         }
 
+        // Editing a saved rule in place. Everything except the core selection is editable here;
+        // that one needs the picker in the Process tab, so it is shown but not editable, and
+        // carried through untouched by the update.
+        [ObservableProperty]
+        private SavedProcessRule? selectedSavedProcessRule;
+
+        [ObservableProperty]
+        private bool savedRuleIsEnabled = true;
+
+        [ObservableProperty]
+        private bool savedRulePreventSleep;
+
+        [ObservableProperty]
+        private string savedRulePriority = NoneOption;
+
+        [ObservableProperty]
+        private string savedRuleMemoryPriority = NoneOption;
+
+        [ObservableProperty]
+        private string savedRuleIoPriority = NoneOption;
+
+        [ObservableProperty]
+        private string savedRuleCpuAssignmentMode = nameof(CpuAssignmentMode.AffinityMask);
+
+        public const string NoneOption = "None";
+
+        // Realtime is deliberately absent: the service refuses it, so offering it would only
+        // produce an error the user cannot resolve.
+        public IReadOnlyList<string> SavedRulePriorityOptions { get; } =
+        [
+            NoneOption,
+            nameof(System.Diagnostics.ProcessPriorityClass.Idle),
+            nameof(System.Diagnostics.ProcessPriorityClass.BelowNormal),
+            nameof(System.Diagnostics.ProcessPriorityClass.Normal),
+            nameof(System.Diagnostics.ProcessPriorityClass.AboveNormal),
+            nameof(System.Diagnostics.ProcessPriorityClass.High),
+        ];
+
+        public IReadOnlyList<string> SavedRuleMemoryPriorityOptions { get; } =
+            [NoneOption, .. Enum.GetNames<ProcessMemoryPriority>()];
+
+        public IReadOnlyList<string> SavedRuleIoPriorityOptions { get; } =
+            [NoneOption, .. Enum.GetNames<ProcessIoPriority>()];
+
+        public IReadOnlyList<string> SavedRuleCpuAssignmentModeOptions { get; } =
+            [.. Enum.GetNames<CpuAssignmentMode>()];
+
+        partial void OnSelectedSavedProcessRuleChanged(SavedProcessRule? value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            var rule = value.Source;
+            this.SavedRuleIsEnabled = rule.IsEnabled;
+            this.SavedRulePreventSleep = rule.PreventSystemSleepWhileRunning;
+            this.SavedRulePriority = rule.Priority?.ToString() ?? NoneOption;
+            this.SavedRuleMemoryPriority = rule.MemoryPriority?.ToString() ?? NoneOption;
+            this.SavedRuleIoPriority = rule.IoPriority?.ToString() ?? NoneOption;
+            this.SavedRuleCpuAssignmentMode = rule.CpuAssignmentMode.ToString();
+        }
+
+        [RelayCommand]
+        private async Task SaveSavedProcessRuleAsync()
+        {
+            var selected = this.SelectedSavedProcessRule;
+            if (selected == null || this.ruleCreationService == null)
+            {
+                return;
+            }
+
+            var updated = selected.Source with
+            {
+                IsEnabled = this.SavedRuleIsEnabled,
+                PreventSystemSleepWhileRunning = this.SavedRulePreventSleep,
+                Priority = ParseOption<System.Diagnostics.ProcessPriorityClass>(this.SavedRulePriority),
+                MemoryPriority = ParseOption<ProcessMemoryPriority>(this.SavedRuleMemoryPriority),
+                IoPriority = ParseOption<ProcessIoPriority>(this.SavedRuleIoPriority),
+                CpuAssignmentMode = Enum.TryParse<CpuAssignmentMode>(this.SavedRuleCpuAssignmentMode, out var mode)
+                    ? mode
+                    : selected.Source.CpuAssignmentMode,
+            };
+
+            var result = await this.ruleCreationService.UpdateRuleAsync(updated).ConfigureAwait(true);
+            this.SetStatus(result.UserMessage, false);
+            await this.RefreshSavedProcessRulesAsync().ConfigureAwait(true);
+            this.SelectedSavedProcessRule = this.SavedProcessRules
+                .FirstOrDefault(row => string.Equals(row.Id, selected.Id, StringComparison.Ordinal));
+        }
+
+        private static T? ParseOption<T>(string? option)
+            where T : struct, Enum =>
+            string.IsNullOrWhiteSpace(option) || string.Equals(option, NoneOption, StringComparison.Ordinal)
+                ? null
+                : Enum.TryParse<T>(option, out var parsed) ? parsed : null;
+
         public sealed record SavedProcessRule(
             string Id,
             string ProcessName,
             string Applies,
             string Mode,
             bool IsEnabled,
-            DateTime UpdatedAt)
+            DateTime UpdatedAt,
+            PersistentProcessRule Source)
         {
             public static SavedProcessRule From(PersistentProcessRule rule)
             {
@@ -221,7 +319,8 @@ namespace ThreadPilot.ViewModels
                     applies.Count == 0 ? "nothing" : string.Join(", ", applies),
                     rule.ApplyAffinityOnStart ? rule.CpuAssignmentMode.ToString() : "-",
                     rule.IsEnabled,
-                    rule.UpdatedAt.ToLocalTime());
+                    rule.UpdatedAt.ToLocalTime(),
+                    rule);
             }
         }
 

--- a/ViewModels/ProcessViewModel.Behaviors.partial.cs
+++ b/ViewModels/ProcessViewModel.Behaviors.partial.cs
@@ -1171,44 +1171,14 @@ namespace ThreadPilot.ViewModels
         }
 
 
+        // Was hunting for a TabControl in the visual tree and setting SelectedIndex; the window has
+        // been a NavigationView for several versions, so the lookup returned null and the button did
+        // nothing at all. Navigation belongs to the window, which already owns this exact pattern
+        // for the Rules tab.
         [RelayCommand]
         private void CreateCustomMask()
         {
-            // Request to switch to Core Masks tab
-            System.Windows.Application.Current.Dispatcher.Invoke(() =>
-            {
-                var mainWindow = System.Windows.Application.Current.MainWindow;
-                if (mainWindow != null)
-                {
-                    // Find the TabControl in MainWindow
-                    var tabControl = FindVisualChild<System.Windows.Controls.TabControl>(mainWindow);
-                    if (tabControl != null)
-                    {
-                        // Switch to Core Masks tab (index 1)
-                        tabControl.SelectedIndex = 1;
-                    }
-                }
-            });
-        }
-
-        private static T? FindVisualChild<T>(System.Windows.DependencyObject obj)
-            where T : System.Windows.DependencyObject
-        {
-            for (int i = 0; i < System.Windows.Media.VisualTreeHelper.GetChildrenCount(obj); i++)
-            {
-                var child = System.Windows.Media.VisualTreeHelper.GetChild(obj, i);
-                if (child is T typedChild)
-                {
-                    return typedChild;
-                }
-
-                var childOfChild = FindVisualChild<T>(child);
-                if (childOfChild != null)
-                {
-                    return childOfChild;
-                }
-            }
-            return null;
+            this.OpenMasksRequested?.Invoke(this, EventArgs.Empty);
         }
 
         partial void OnSelectedCoreMaskChanged(CoreMask? oldValue, CoreMask? newValue)
@@ -1604,6 +1574,15 @@ namespace ThreadPilot.ViewModels
                 }
 
                 await this.processService.RefreshProcessInfo(process);
+                if (ReferenceEquals(this.SelectedProcess, process))
+                {
+                    // The chips were showing the soft assignment that has just been removed. Without
+                    // this they keep advertising cores the process is no longer pinned to until it
+                    // happens to be reselected - and a rule saved in between would capture them.
+                    this.UpdateCoreSelections(process.ProcessorAffinity, true);
+                    this.UpdateAffinityDisplayState();
+                }
+
                 this.SetStatus($"CPU Sets cleared for {process.Name}.", false);
                 await this.LogUserActionAsync(
                     "CpuSetsCleared",

--- a/ViewModels/ProcessViewModel.Behaviors.partial.cs
+++ b/ViewModels/ProcessViewModel.Behaviors.partial.cs
@@ -161,8 +161,6 @@ namespace ThreadPilot.ViewModels
                 {
                     this.Logger.LogWarning(ex, "Failed while handling selected process change for {ProcessName}", value.Name);
                 });
-                TaskSafety.FireAndForget(this.ResolveCpuAssignmentModeAsync(value), ex =>
-                    this.Logger.LogDebug(ex, "Could not resolve saved CPU assignment mode for {ProcessName}", value.Name));
             }
             else if (value == null)
             {
@@ -183,18 +181,24 @@ namespace ThreadPilot.ViewModels
             }
         }
 
-        private async Task ResolveCpuAssignmentModeAsync(ProcessModel process)
+        private async Task<(CpuAssignmentMode Mode, bool FromRule)> ResolveCpuAssignmentModeAsync(ProcessModel process)
         {
+            var defaultMode = this.settingsService?.Settings.DefaultCpuAssignmentMode ?? CpuAssignmentMode.Automatic;
             if (this.persistentRuleStore == null || this.persistentRuleMatcher == null)
             {
-                return;
+                return (defaultMode, false);
             }
 
-            var rules = await this.persistentRuleStore.LoadAsync().ConfigureAwait(false);
-            var rule = rules.FirstOrDefault(candidate => candidate.IsEnabled && this.persistentRuleMatcher.IsMatch(candidate, process));
-            if (rule != null && this.SelectedProcess?.ProcessId == process.ProcessId)
+            try
             {
-                await InvokeOnUiAsync(() => this.SetCpuAssignmentMode(rule.CpuAssignmentMode, overriddenByRule: true));
+                var rules = await this.persistentRuleStore.LoadAsync().ConfigureAwait(false);
+                var rule = rules.FirstOrDefault(candidate => candidate.IsEnabled && this.persistentRuleMatcher.IsMatch(candidate, process));
+                return rule == null ? (defaultMode, false) : (rule.CpuAssignmentMode, true);
+            }
+            catch (Exception ex)
+            {
+                this.Logger.LogDebug(ex, "Could not resolve saved CPU assignment mode for {ProcessName}", process.Name);
+                return (defaultMode, false);
             }
         }
 
@@ -237,11 +241,41 @@ namespace ThreadPilot.ViewModels
 
                 // Refresh process info to get current state from OS
                 await this.processService.RefreshProcessInfo(value);
+                var assignment = await this.ResolveCpuAssignmentModeAsync(value);
+                var cpuSetIndexes = await this.processService.GetCpuAssignmentLogicalProcessorIndexesAsync(
+                    value,
+                    CpuAssignmentMode.CpuSets);
+                IReadOnlyList<int>? softAssignmentIndexes;
+                if (cpuSetIndexes is { Count: > 0 })
+                {
+                    assignment = (CpuAssignmentMode.CpuSets, assignment.FromRule && assignment.Mode == CpuAssignmentMode.CpuSets);
+                    softAssignmentIndexes = cpuSetIndexes;
+                }
+                else
+                {
+                    softAssignmentIndexes = assignment.Mode == CpuAssignmentMode.IdealProcessor
+                        ? await this.processService.GetCpuAssignmentLogicalProcessorIndexesAsync(value, assignment.Mode)
+                        : null;
+                }
 
                 // Update UI on main thread with fresh data
-                System.Windows.Application.Current.Dispatcher.Invoke(() =>
+                await InvokeOnUiAsync(() =>
                 {
-                    this.UpdateCoreSelections(value.ProcessorAffinity);
+                    if (!ReferenceEquals(this.SelectedProcess, value))
+                    {
+                        return;
+                    }
+
+                    this.SetCpuAssignmentMode(assignment.Mode, assignment.FromRule);
+                    if (softAssignmentIndexes is { Count: > 0 })
+                    {
+                        this.UpdateCoreSelections(softAssignmentIndexes, assignment.Mode);
+                    }
+                    else
+                    {
+                        this.UpdateCoreSelections(value.ProcessorAffinity);
+                    }
+
                     this.UpdateAffinityDisplayState();
                     value.ForceNotifyProcessorAffinityChanged();
 
@@ -424,6 +458,33 @@ namespace ThreadPilot.ViewModels
 
         private void UpdateCoreSelections(long affinityMask, bool forceSync = false)
         {
+            this.currentSoftCpuAssignmentText = null;
+            this.UpdateCoreSelections(
+                core => (affinityMask & core.AffinityMask) != 0,
+                $"affinity mask 0x{affinityMask:X}",
+                forceSync);
+        }
+
+        private void UpdateCoreSelections(
+            IReadOnlyCollection<int> logicalProcessorIndexes,
+            CpuAssignmentMode mode,
+            bool forceSync = false)
+        {
+            var selectedIndexes = logicalProcessorIndexes.ToHashSet();
+            this.currentSoftCpuAssignmentText = mode == CpuAssignmentMode.CpuSets
+                ? $"Current CPU Sets: CPU {string.Join(", ", selectedIndexes.OrderBy(index => index))}"
+                : $"Current ideal processors: CPU {string.Join(", ", selectedIndexes.OrderBy(index => index))}";
+            this.UpdateCoreSelections(
+                core => selectedIndexes.Contains(core.LogicalCoreId),
+                this.currentSoftCpuAssignmentText,
+                forceSync);
+        }
+
+        private void UpdateCoreSelections(
+            Func<CpuCoreModel, bool> isSelected,
+            string source,
+            bool forceSync)
+        {
             if (this.CpuTopology == null || this.CpuCores.Count == 0)
             {
                 this.Logger.LogWarning(
@@ -438,27 +499,13 @@ namespace ThreadPilot.ViewModels
                 return;
             }
 
-            this.Logger.LogDebug(
-                "Updating core selections for affinity mask 0x{AffinityMask:X} ({AffinityMaskBinary})",
-                affinityMask, Convert.ToString(affinityMask, 2).PadLeft(Environment.ProcessorCount, '0'));
-
-            // Update each core's selection state based on the actual OS affinity mask
-            var updatedCores = new List<(int CoreId, bool WasSelected, bool IsSelected)>();
-
             try
             {
                 this.suppressCoreSelectionEvents = true;
 
                 foreach (var core in this.CpuCores)
                 {
-                    bool wasSelected = core.IsSelected;
-                    bool shouldBeSelected = (affinityMask & core.AffinityMask) != 0;
-
-                    if (wasSelected != shouldBeSelected)
-                    {
-                        core.IsSelected = shouldBeSelected;
-                        updatedCores.Add((core.LogicalCoreId, wasSelected, shouldBeSelected));
-                    }
+                    core.IsSelected = isSelected(core);
                 }
             }
             finally
@@ -466,29 +513,10 @@ namespace ThreadPilot.ViewModels
                 this.suppressCoreSelectionEvents = false;
             }
 
-            // The UI will automatically update since CpuCoreModel now implements INotifyPropertyChanged
-            // No need to force collection refresh as individual property changes will be notified
-
-            // Log the affinity update for debugging
             var selectedCoreIds = this.CpuCores.Where(c => c.IsSelected).Select(c => c.LogicalCoreId).OrderBy(id => id).ToList();
-            var totalCores = this.CpuCores.Count;
-            var selectedCount = selectedCoreIds.Count;
-
             this.Logger.LogInformation(
-                "Updated core selections for affinity mask 0x{AffinityMask:X}: " +
-                                "Selected {SelectedCount}/{TotalCores} cores: [{CoreIds}]",
-                affinityMask, selectedCount, totalCores, string.Join(", ", selectedCoreIds));
-
-            if (updatedCores.Count > 0)
-            {
-                this.Logger.LogDebug(
-                    "Core selection changes: {Changes}",
-                    string.Join("; ", updatedCores.Select(c => $"Core {c.CoreId}: {c.WasSelected} -> {c.IsSelected}")));
-            }
-            else
-            {
-                this.Logger.LogDebug("No core selection changes needed - UI already matches affinity mask");
-            }
+                "Updated core selections from {Source}: selected {SelectedCount}/{TotalCores} cores: [{CoreIds}]",
+                source, selectedCoreIds.Count, this.CpuCores.Count, string.Join(", ", selectedCoreIds));
 
             if (forceSync)
             {
@@ -521,12 +549,18 @@ namespace ThreadPilot.ViewModels
                 .ToList();
         }
 
+        private static List<int> GetSelectedLogicalProcessorIndexes(IReadOnlyList<bool> selection) =>
+            selection.Select((selected, index) => (selected, index))
+                .Where(item => item.selected)
+                .Select(item => item.index)
+                .ToList();
+
         private void UpdateAffinityDisplayState()
         {
             var currentMask = this.SelectedProcess?.ProcessorAffinity;
-            this.CurrentAffinityText = currentMask.HasValue
+            this.CurrentAffinityText = this.currentSoftCpuAssignmentText ?? (currentMask.HasValue
                 ? $"Current OS affinity: 0x{currentMask.Value:X}"
-                : "Current OS affinity: no process selected";
+                : "Current OS affinity: no process selected");
 
             if (this.SelectedProcess == null)
             {
@@ -538,7 +572,9 @@ namespace ThreadPilot.ViewModels
             if (!this.HasPendingAffinityEdits)
             {
                 this.PendingAffinityText = "Pending core mask: none";
-                this.AffinityEditStateText = "Current OS affinity is displayed. Select a core mask to stage a change.";
+                this.AffinityEditStateText = this.currentSoftCpuAssignmentText == null
+                    ? "Current OS affinity is displayed. Select a core mask to stage a change."
+                    : "Current soft CPU assignment is displayed. Select a core mask to stage a change.";
                 return;
             }
 
@@ -874,18 +910,30 @@ namespace ThreadPilot.ViewModels
             {
                 this.UpdateCoreSelections(process.ProcessorAffinity, true);
             }
+            else
+            {
+                this.UpdateCoreSelections(
+                    GetSelectedLogicalProcessorIndexes(pendingSelection),
+                    applyResult.EffectiveMode,
+                    true);
+            }
 
             process.ForceNotifyProcessorAffinityChanged();
             this.OnPropertyChanged(nameof(this.SelectedProcess));
             this.HasPendingAffinityEdits = false;
             this.UpdateAffinityDisplayState();
 
+            // Refresh first, then pass what the process actually has: this used to save nulls, and
+            // a rule saved through this menu item lost the memory and I/O priority of the rule it
+            // replaced. The service merges rather than overwrites now, but sending the real values
+            // is what makes this item a full snapshot rather than an affinity-only one.
+            await this.UpdateSelectedProcessSummaryAsync(process);
             var saveResult = await this.processRuleCreationService.SaveCurrentSettingsAsRuleAsync(
                 process,
                 pendingSelection,
-                currentMemoryPriority: null,
+                this.SelectedProcessSummary.MemoryPriority,
                 cpuAssignmentMode: this.SelectedCpuAssignmentMode,
-                currentIoPriority: null,
+                currentIoPriority: this.SelectedProcessSummary.IoPriority,
                 preventSystemSleepWhileRunning: this.IsIdleServerDisabled);
 
             this.ApplyRuleCreationResultStatus(saveResult);
@@ -894,6 +942,36 @@ namespace ThreadPilot.ViewModels
                 saveResult.UserMessage,
                 $"Process: {process.Name}, PID: {process.ProcessId}");
             await this.UpdateSelectedProcessSummaryAsync(process);
+        }
+
+        [RelayCommand]
+        private async Task DeleteSavedRule(ProcessModel? process)
+        {
+            var targetProcess = process ?? this.SelectedProcess;
+            if (targetProcess == null)
+            {
+                return;
+            }
+
+            if (this.processRuleCreationService == null)
+            {
+                this.SetContextError("Persistent rules are unavailable.");
+                return;
+            }
+
+            if (!ReferenceEquals(this.SelectedProcess, targetProcess))
+            {
+                this.SelectedProcess = targetProcess;
+            }
+
+            var result = await this.processRuleCreationService.DeleteRuleAsync(targetProcess);
+
+            this.ApplyRuleCreationResultStatus(result);
+            await this.LogUserActionAsync(
+                result.Success ? "PersistentRuleDeleted" : "PersistentRuleDeleteFailed",
+                result.UserMessage,
+                $"Process: {targetProcess.Name}, PID: {targetProcess.ProcessId}");
+            await this.UpdateSelectedProcessSummaryAsync(targetProcess);
         }
 
         private void ApplyRuleCreationResultStatus(ProcessRuleCreationResult result)
@@ -938,6 +1016,14 @@ namespace ThreadPilot.ViewModels
 
                     if (result.Success)
                     {
+                        if (result.EffectiveMode is CpuAssignmentMode.CpuSets or CpuAssignmentMode.IdealProcessor)
+                        {
+                            this.UpdateCoreSelections(
+                                GetSelectedLogicalProcessorIndexes(pendingSelection),
+                                result.EffectiveMode,
+                                true);
+                        }
+
                         this.HasPendingAffinityEdits = false;
                         this.UpdateAffinityDisplayState();
                         this.SetStatus($"CPU assignment applied successfully to {selectedProcess.Name} using {result.EffectiveMode}.", false);
@@ -1017,13 +1103,6 @@ namespace ThreadPilot.ViewModels
                 }
 
                 await this.UpdateSelectedProcessSummaryAsync(selectedProcess);
-            }
-            finally
-            {
-                await InvokeOnUiAsync(() =>
-                {
-                    this.ClearStatus();
-                });
             }
         }
 
@@ -1208,6 +1287,14 @@ namespace ThreadPilot.ViewModels
                             this.SetStatus(result.Message, false);
                         });
                         return;
+                    }
+
+                    if (result.EffectiveMode is CpuAssignmentMode.CpuSets or CpuAssignmentMode.IdealProcessor)
+                    {
+                        this.UpdateCoreSelections(
+                            GetSelectedLogicalProcessorIndexes(pendingSelection),
+                            result.EffectiveMode,
+                            true);
                     }
 
                     this.HasPendingAffinityEdits = false;
@@ -1903,7 +1990,8 @@ namespace ThreadPilot.ViewModels
 
         private void SetupRefreshTimer()
         {
-            this.refreshTimer = new System.Timers.Timer(5000); // PERFORMANCE OPTIMIZATION: Increased to 5 second refresh for better performance
+            this.refreshTimer = new System.Timers.Timer(
+                Math.Clamp(this.settingsService?.Settings.PollingIntervalMs ?? 5000, 1000, 60000));
             this.refreshTimer.Elapsed += async (s, e) =>
             {
                 if (this.isUiRefreshPaused || !this.isProcessViewActive)
@@ -2171,6 +2259,7 @@ namespace ThreadPilot.ViewModels
             }
 
             this.HasPendingAffinityEdits = false;
+            this.currentSoftCpuAssignmentText = null;
             this.UpdateAffinityDisplayState();
 
             // Reset power plan to current system default

--- a/ViewModels/ProcessViewModel.cs
+++ b/ViewModels/ProcessViewModel.cs
@@ -19,6 +19,8 @@ namespace ThreadPilot.ViewModels
     {
         public event EventHandler? OpenRulesRequested;
 
+        public event EventHandler? OpenMasksRequested;
+
         private readonly IProcessService processService;
         private readonly ProcessFilterService processFilterService;
         private readonly IVirtualizedProcessService virtualizedProcessService;

--- a/ViewModels/ProcessViewModel.cs
+++ b/ViewModels/ProcessViewModel.cs
@@ -51,6 +51,7 @@ namespace ThreadPilot.ViewModels
         private bool suppressCoreSelectionEvents;
         private bool suppressCpuAssignmentModeChanges;
         private bool cpuAssignmentModeOverriddenByRule;
+        private string? currentSoftCpuAssignmentText;
 
         [ObservableProperty]
         private bool isAutomationMonitoringEnabled = true;
@@ -269,6 +270,11 @@ namespace ThreadPilot.ViewModels
         private void OnSettingsChanged(object? sender, ApplicationSettingsChangedEventArgs e)
         {
             this.IsAutomationMonitoringEnabled = e.NewSettings.EnableAutomationMonitoring;
+            if (this.refreshTimer != null)
+            {
+                this.refreshTimer.Interval = Math.Clamp(e.NewSettings.PollingIntervalMs, 1000, 60000);
+            }
+
             if (!this.cpuAssignmentModeOverriddenByRule)
             {
                 this.SetCpuAssignmentMode(e.NewSettings.DefaultCpuAssignmentMode, overriddenByRule: false);

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -329,12 +329,16 @@ namespace ThreadPilot.ViewModels
 
                 // Handle autostart setting
                 var currentAutostartState = await this.autostartService.CheckAutostartStatusAsync();
-                if (this.Settings.AutostartWithWindows != currentAutostartState)
+                var startMinimizedChanged = this.Settings.StartMinimized != this.savedSettingsSnapshot.StartMinimized;
+                if (this.Settings.AutostartWithWindows != currentAutostartState ||
+                    (currentAutostartState && startMinimizedChanged))
                 {
                     bool autostartUpdated;
                     if (this.Settings.AutostartWithWindows)
                     {
-                        autostartUpdated = await this.autostartService.EnableAutostartAsync(this.Settings.StartMinimized);
+                        autostartUpdated = currentAutostartState
+                            ? await this.autostartService.UpdateAutostartAsync(this.Settings.StartMinimized)
+                            : await this.autostartService.EnableAutostartAsync(this.Settings.StartMinimized);
                     }
                     else
                     {

--- a/ViewModels/SystemTweaksViewModel.cs
+++ b/ViewModels/SystemTweaksViewModel.cs
@@ -138,7 +138,12 @@ namespace ThreadPilot.ViewModels
             {
                 this.Logger.LogError(ex, "Error updating status for tweak {TweakName}", item.Name);
                 item.IsAvailable = false;
-                item.ErrorMessage = ex.Message;
+
+                // The exception text belongs in the log, not on the card: "Requested registry access
+                // is not allowed." is a framework string that tells the user nothing they can act on.
+                item.ErrorMessage = this.Localize(
+                    "SystemTweaks_StatusDetectionFailed",
+                    "ThreadPilot could not read this setting on this system.");
             }
         }
 

--- a/Views/MasksView.xaml
+++ b/Views/MasksView.xaml
@@ -50,6 +50,7 @@
     <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -62,7 +63,30 @@
             </TextBlock>
         </StackPanel>
 
-        <Grid Grid.Row="1">
+        <Border Grid.Row="1"
+                Background="{DynamicResource CardSurfaceBrush}"
+                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                BorderThickness="1"
+                CornerRadius="{DynamicResource StandardCardCornerRadius}"
+                Padding="12,8"
+                Margin="0,0,0,10"
+                VerticalAlignment="Top">
+            <Border.Style>
+                <Style TargetType="Border">
+                    <Setter Property="Visibility" Value="Visible"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding TopologyReviewMessage}" Value="">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
+            <TextBlock Text="{Binding TopologyReviewMessage}"
+                       TextWrapping="Wrap"
+                       FontSize="12"/>
+        </Border>
+
+        <Grid Grid.Row="2">
              <Grid.ColumnDefinitions>
                  <ColumnDefinition Width="2*" MinWidth="200"/>
                  <ColumnDefinition Width="Auto"/>
@@ -240,7 +264,7 @@
         </Grid>
 
         <!-- Status Bar -->
-        <Border Grid.Row="2"
+        <Border Grid.Row="3"
                 Background="{DynamicResource StatusPillBackgroundBrush}"
                 BorderBrush="{DynamicResource StatusPillBorderBrush}"
                 BorderThickness="1"

--- a/Views/ProcessPowerPlanAssociationView.xaml
+++ b/Views/ProcessPowerPlanAssociationView.xaml
@@ -289,7 +289,15 @@
                                Margin="0,0,0,10"/>
 
                     <Grid Grid.Row="1">
-                        <DataGrid ItemsSource="{Binding SavedProcessRules}"
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="2*"/>
+                            <ColumnDefinition Width="10"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <DataGrid Grid.Column="0"
+                                  ItemsSource="{Binding SavedProcessRules}"
+                                  SelectedItem="{Binding SelectedSavedProcessRule, Mode=TwoWay}"
                                   AutoGenerateColumns="False"
                                   CanUserAddRows="False"
                                   IsReadOnly="True"
@@ -326,7 +334,57 @@
                             </DataGrid.Columns>
                         </DataGrid>
 
-                        <Border Padding="18"
+                        <GroupBox Grid.Column="2"
+                                  Width="330"
+                                  Header="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleEditor}"
+                                  VerticalAlignment="Top">
+                            <StackPanel IsEnabled="{Binding SelectedSavedProcessRule, Converter={StaticResource NullToBoolConverter}}">
+                                <TextBlock Text="{Binding SelectedSavedProcessRule.ProcessName}"
+                                           FontWeight="SemiBold"
+                                           Margin="0,0,0,8"/>
+
+                                <CheckBox Content="{DynamicResource MasksView_Enabled}"
+                                          IsChecked="{Binding SavedRuleIsEnabled, Mode=TwoWay}"
+                                          Margin="0,0,0,10"/>
+
+                                <TextBlock Text="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleCpuPriority}" Margin="0,0,0,3"/>
+                                <ComboBox ItemsSource="{Binding SavedRulePriorityOptions}"
+                                          SelectedItem="{Binding SavedRulePriority, Mode=TwoWay}"
+                                          Margin="0,0,0,10"/>
+
+                                <TextBlock Text="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleMemoryPriority}" Margin="0,0,0,3"/>
+                                <ComboBox ItemsSource="{Binding SavedRuleMemoryPriorityOptions}"
+                                          SelectedItem="{Binding SavedRuleMemoryPriority, Mode=TwoWay}"
+                                          Margin="0,0,0,10"/>
+
+                                <TextBlock Text="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleIoPriority}" Margin="0,0,0,3"/>
+                                <ComboBox ItemsSource="{Binding SavedRuleIoPriorityOptions}"
+                                          SelectedItem="{Binding SavedRuleIoPriority, Mode=TwoWay}"
+                                          Margin="0,0,0,10"/>
+
+                                <TextBlock Text="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleModeLabel}" Margin="0,0,0,3"/>
+                                <ComboBox ItemsSource="{Binding SavedRuleCpuAssignmentModeOptions}"
+                                          SelectedItem="{Binding SavedRuleCpuAssignmentMode, Mode=TwoWay}"
+                                          Margin="0,0,0,10"/>
+
+                                <CheckBox Content="{DynamicResource ProcessPowerPlanAssociationView_SavedRulePreventSleep}"
+                                          IsChecked="{Binding SavedRulePreventSleep, Mode=TwoWay}"
+                                          Margin="0,0,0,10"/>
+
+                                <TextBlock Text="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleEditorHint}"
+                                           Foreground="{DynamicResource TextSecondaryBrush}"
+                                           TextWrapping="Wrap"
+                                           Margin="0,0,0,10"/>
+
+                                <Button Content="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleSave}"
+                                        Command="{Binding SaveSavedProcessRuleCommand}"
+                                        Padding="10,4"
+                                        HorizontalAlignment="Left"/>
+                            </StackPanel>
+                        </GroupBox>
+
+                        <Border Grid.Column="0"
+                                Padding="18"
                                 IsHitTestVisible="False"
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Center">

--- a/Views/ProcessPowerPlanAssociationView.xaml
+++ b/Views/ProcessPowerPlanAssociationView.xaml
@@ -274,6 +274,81 @@
                 </Grid>
             </TabItem>
 
+            <!-- Saved Process Rules Tab -->
+            <TabItem Header="{DynamicResource ProcessPowerPlanAssociationView_SavedRulesHeader}">
+                <Grid Margin="10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0"
+                               Text="{DynamicResource ProcessPowerPlanAssociationView_SavedRulesDescription}"
+                               Foreground="{DynamicResource TextSecondaryBrush}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,10"/>
+
+                    <Grid Grid.Row="1">
+                        <DataGrid ItemsSource="{Binding SavedProcessRules}"
+                                  AutoGenerateColumns="False"
+                                  CanUserAddRows="False"
+                                  IsReadOnly="True"
+                                  GridLinesVisibility="Horizontal"
+                                  HeadersVisibility="Column"
+                                  BorderThickness="1">
+                            <DataGrid.Columns>
+                                <DataGridCheckBoxColumn Header="{DynamicResource MasksView_Enabled}"
+                                                       Binding="{Binding IsEnabled}"
+                                                       Width="60"/>
+                                <DataGridTextColumn Header="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleProcess}"
+                                                   Binding="{Binding ProcessName}"
+                                                   Width="150"/>
+                                <DataGridTextColumn Header="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleApplies}"
+                                                   Binding="{Binding Applies}"
+                                                   Width="*"/>
+                                <DataGridTextColumn Header="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleMode}"
+                                                   Binding="{Binding Mode}"
+                                                   Width="110"/>
+                                <DataGridTextColumn Header="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleUpdated}"
+                                                   Binding="{Binding UpdatedAt}"
+                                                   Width="140"/>
+                                <DataGridTemplateColumn Width="90">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <Button Content="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleDelete}"
+                                                    Padding="8,2"
+                                                    Margin="2"
+                                                    Command="{Binding DataContext.DeleteSavedProcessRuleCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                    CommandParameter="{Binding}"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
+
+                        <Border Padding="18"
+                                IsHitTestVisible="False"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center">
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding SavedProcessRules.Count}" Value="0">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <TextBlock Text="{DynamicResource ProcessPowerPlanAssociationView_NoSavedRules}"
+                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                       TextWrapping="Wrap"
+                                       TextAlignment="Center"/>
+                        </Border>
+                    </Grid>
+                </Grid>
+            </TabItem>
+
             <!-- Automation Monitoring Tab -->
             <TabItem Header="{DynamicResource ProcessPowerPlanAssociationView_AutomationMonitoring}">
                 <ScrollViewer Margin="10">

--- a/Views/ProcessView.xaml
+++ b/Views/ProcessView.xaml
@@ -300,6 +300,12 @@
                                                           ToolTip="{DynamicResource ProcessView_SaveRuleTooltip}"
                                                           Command="{Binding ApplyAffinityAndSaveAsRuleCommand}"
                                                           CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                                <Separator Style="{StaticResource ProcessContextMenuSeparatorStyle}"/>
+                                                <MenuItem Style="{StaticResource ProcessContextMenuItemStyle}"
+                                                          Header="{DynamicResource ProcessView_DeleteSavedRule}"
+                                                          ToolTip="{DynamicResource ProcessView_DeleteSavedRuleTooltip}"
+                                                          Command="{Binding DeleteSavedRuleCommand}"
+                                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                             </MenuItem>
                                             <MenuItem Style="{StaticResource ProcessContextMenuItemStyle}"
                                                       Header="{DynamicResource ProcessView_SetIoPriority}">

--- a/Views/SettingsView.xaml
+++ b/Views/SettingsView.xaml
@@ -190,6 +190,13 @@
                                        Style="{StaticResource DescriptionStyle}"
                                        Margin="20,0,0,15"/>
 
+                            <CheckBox Content="{DynamicResource SettingsView_ResetProcessChangesOnExit}"
+                                      IsChecked="{Binding Settings.ClearMasksOnClose}"
+                                      Margin="0,0,0,5"/>
+                            <TextBlock Text="{DynamicResource SettingsView_ResetProcessChangesOnExitDescription}"
+                                       Style="{StaticResource DescriptionStyle}"
+                                       Margin="20,0,0,15"/>
+
                             <CheckBox Content="{DynamicResource SettingsView_LowImpactMode}"
                                       IsChecked="{Binding Settings.EnableSelfLowImpactMode}"
                                       Margin="0,0,0,5"/>

--- a/Views/SystemTweaksView.xaml
+++ b/Views/SystemTweaksView.xaml
@@ -226,7 +226,7 @@
                                             Padding="10,4"
                                             AutomationProperties.Name="{Binding Name}">
                                         <Button.Style>
-                                            <Style TargetType="Button">
+                                            <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
                                                 <Setter Property="Visibility" Value="Collapsed"/>
                                                 <Style.Triggers>
                                                     <DataTrigger Binding="{Binding IsGuidedAction}" Value="True">

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.7.2.0" name="ThreadPilot.app"/>
+  <assemblyIdentity version="1.7.3.0" name="ThreadPilot.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.7.2",
+    [string]$Version = "1.7.3",
     [string]$Configuration = "Release",
     [switch]$SkipPublish
 )

--- a/build/build-release.ps1
+++ b/build/build-release.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.7.2",
+    [string]$Version = "1.7.3",
     [string]$Configuration = "Release",
     [string]$Runtime = "win-x64"
 )

--- a/build/package-release-zips.ps1
+++ b/build/package-release-zips.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.7.2"
+    [string]$Version = "1.7.3"
 )
 
 $ErrorActionPreference = "Stop"

--- a/chocolatey/threadpilot.nuspec
+++ b/chocolatey/threadpilot.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>threadpilot</id>
-    <version>1.7.2</version>
+    <version>1.7.3</version>
     <title>ThreadPilot</title>
     <authors>Prime Build</authors>
     <projectUrl>https://github.com/PrimeBuild-pc/ThreadPilot</projectUrl>
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Advanced Windows process and power plan manager with rules automation and performance controls.</description>
     <summary>ThreadPilot process and power plan manager.</summary>
-    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.7.2</releaseNotes>
+    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.7.3</releaseNotes>
     <tags>threadpilot process powerplan performance windows</tags>
   </metadata>
   <files>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project are documented in this file.
 
+## v1.7.3 - Rule integrity and verifiable CPU assignment
+
+### Fixed
+
+- Saved rules created before v1.7.3 now receive the same one-time CPU assignment migration as profiles: rules that still use `ThreadPilot automatic` with a topology-aware CPU selection move to `Affinity Mask`. Deliberate assignment modes, legacy affinity masks, and rules without a CPU selection are left unchanged.
+- Updating a rule through **Apply CPU Assignment and Save as Rule** preserves its memory priority, I/O priority, identity, creation time, and other settings instead of silently replacing the full rule with affinity-only data.
+- CPU Sets and Ideal Processor assignments are read back from Windows and shown in the Advanced Affinity Picker. Explicit process CPU Sets are detected even when the global default or saved rule says `Affinity Mask`, so changing process selection or restarting ThreadPilot no longer makes a successful soft assignment appear to have disappeared.
+- Successful CPU assignment messages remain visible in the process status instead of being cleared immediately after the operation.
+- The Process Management polling interval now controls the actual process-list refresh timer and updates it when settings are saved.
+- Changing **Start minimized** now refreshes the existing Windows autostart task, preventing a stale `--start-minimized` argument from overriding the new setting.
+- Built-in CPU masks are regenerated when the detected logical-processor count changes. User-created masks are preserved.
+
+### Added
+
+- **Reset process changes on exit** is now exposed in Settings and localized in all seven supported languages. The existing safe default remains enabled, but users can now choose whether closing ThreadPilot restores applied CPU masks and priorities.
+- A saved rule can now be removed from the selected process's **Rules** context submenu, with immediate status and summary feedback.
+
+### Validation
+
+- 739 automated tests pass in Release configuration.
+- Elevated Windows 11 UI smoke testing covered startup, navigation, settings save and restore, polling persistence, process refresh, CPU Sets, Ideal Processor, rule creation and deletion, status feedback, and CPU Sets read-back after a full ThreadPilot restart.
+- Test-created processes, rules, settings, and UI automation files were removed after verification.
+
 ## v1.7.2 - CPU assignment mode migration
 
 ### Fixed

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -10,4 +10,4 @@ ThreadPilot does not transmit the local process list, executable paths, hardware
 
 The Power Plans and Settings pages contain links to Discord and GitHub Issues. ThreadPilot opens these links only after an explicit user click; the destination then receives ordinary connection information under its own privacy terms. ThreadPilot does not automatically download community power plans.
 
-This policy describes ThreadPilot 1.7.2. Material changes to data collection or network behavior will be documented before release.
+This policy describes ThreadPilot 1.7.3. Material changes to data collection or network behavior will be documented before release.

--- a/docs/release/RELEASE_NOTES.md
+++ b/docs/release/RELEASE_NOTES.md
@@ -1,20 +1,45 @@
-## ThreadPilot v1.7.2
+## ThreadPilot v1.7.3
 
-A follow-up to v1.7.1 that closes the gap which stopped that release reaching the people who needed it.
+ThreadPilot 1.7.3 focuses on trust: an operation that reports success must remain visible, survive a UI refresh, and preserve the rest of the user's configuration.
 
-### What was still wrong
+### Saved rules no longer lose information
 
-v1.7.1 changed the shipped default CPU assignment mode from `ThreadPilot automatic` to `Affinity Mask`, because Automatic applies only Windows CPU Sets: a soft scheduling preference that leaves the affinity mask in Task Manager unchanged.
+**Apply CPU Assignment and Save as Rule** now updates the CPU portion of an existing rule without discarding its memory priority, I/O priority, identity, creation time, or other stored behavior. The selected-process summary is refreshed before saving so the rule captures the process state Windows actually reports.
 
-A new default only applies to a profile that has no stored value. Everyone upgrading had one, so they kept `Automatic` and kept seeing an affinity feature that appeared to do nothing. Verified against the published 1.7.1 build: a fresh profile started on `Affinity Mask`, an existing profile stayed on `Automatic`.
+Rules are no longer permanent. Open a process's context menu, expand **Rules**, and choose **Delete Saved Rule** to remove the matching rule. ThreadPilot updates the status and selected-process summary immediately.
 
-### What 1.7.2 does
+### CPU assignments are read back from Windows
 
-- **A one-time migration** moves a stored `Automatic` to `Affinity Mask` on first launch, and records that it ran.
-- **A one-time notice**, styled like the rest of the app and shown in the selected language, explains that the mode changed and why, and offers a shortcut to Settings. It appears only for profiles the migration actually moved, and only until acknowledged.
-- Choosing `ThreadPilot automatic` again afterwards is respected. The migration never runs twice and never overrides a later deliberate choice.
-- Fresh installations already ship with `Affinity Mask`, so they migrate nothing and see no notice.
+CPU Sets and Ideal Processor are soft Windows scheduling controls, so they do not change the classic affinity mask shown by Task Manager. Previous builds reapplied the affinity mask to the UI whenever a process was selected, making a successful soft assignment appear to have vanished and risking a later rule being saved with every CPU selected.
+
+The Advanced Affinity Picker now reads the effective CPU Sets or ideal processors from Windows and labels the result explicitly. Process CPU Sets are detected even when the global default or saved rule is `Affinity Mask`. This was verified by applying CPU Sets to a disposable Notepad process, switching away, restarting ThreadPilot, and confirming the same CPU set selection was read back from the operating system.
+
+Successful assignment feedback also remains in the process status instead of being cleared immediately after the operation.
+
+### Existing rules receive the v1.7.2 migration
+
+v1.7.2 migrated the global profile from `ThreadPilot automatic` to `Affinity Mask`, but saved rules had their own stored assignment mode and were not included. v1.7.3 performs a separate, one-time migration for topology-aware rules that still use `Automatic`.
+
+The migration intentionally leaves these rules untouched:
+
+- rules using a deliberately selected mode (`Affinity Mask`, `CPU Sets`, or `Ideal Processor`);
+- legacy affinity-mask rules, where Automatic already reaches a real affinity operation;
+- rules that do not contain a CPU selection.
+
+The migration flag is stored only after the updated rules are written successfully, so an interrupted save is retried on the next launch.
+
+### Settings now do what they say
+
+- **Reset process changes on exit** is available in Settings in every supported language. It remains enabled by default, preserving the established safety behavior, but can now be disabled when users want applied masks and priorities to remain after ThreadPilot exits.
+- **Polling interval** now changes the real Process Management refresh timer, including while ThreadPilot is running.
+- **Start minimized** now rewrites an enabled Windows autostart task when its value changes, preventing an old command-line flag from overriding the saved preference.
+- Built-in CPU masks are regenerated when the machine's logical-processor count changes, while user-created masks remain untouched.
 
 ### Verification
 
-718 unit tests, including migration coverage for an upgraded profile, a fresh profile, every non-Automatic mode, idempotency, and a deliberate return to Automatic after the notice.
+- Release build completed without warnings.
+- 739 automated tests passed in Release configuration.
+- The elevated Windows 11 application was opened and exercised through real UI Automation: navigation, settings changes and restoration, process refresh, CPU Sets, Ideal Processor, saved-rule creation and deletion, persistent success status, and read-back after restart all passed.
+- Temporary rules, settings, processes, and test automation artifacts were removed after the run.
+
+No manual migration or configuration reset is required when upgrading from v1.7.2.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=threadpilot
 sonar.projectName=ThreadPilot
-sonar.projectVersion=1.7.2
+sonar.projectVersion=1.7.3
 
 sonar.sourceEncoding=UTF-8
 sonar.sources=.


### PR DESCRIPTION
Started from a user report on Discord: a CPU assignment was applied, "save current settings as rule" was pressed, and on the next launch of the game nothing happened. The rule was being applied — in a mode the user could not see. Everything below came out of following that thread.

## The reported bug

**Saved rules were never migrated off Automatic.** 1.7.2 moved *profiles* off `CpuAssignmentMode.Automatic`, because Automatic applies only Windows CPU Sets — a soft scheduling preference that leaves the affinity mask in Task Manager unchanged. It did not move the rules already in `persistent_rules.json`, and a rule stores the mode it was saved with. So every rule captured before 1.7.1 kept applying CPU Sets on each process start: invisible, and indistinguishable from a rule that never runs. They are migrated once now, tracked by a flag separate from the profile one — sharing it would have skipped exactly the people this fixes.

## Rules

- **Saving a rule is a merge, not a rewrite.** "Apply CPU assignment and save as rule" sent no memory or I/O priority, and the rewrite dropped both from the rule it replaced — silent data loss, from the menu item next to the one that had just saved them.
- **Saved rules are visible.** They had no UI at all; the Rules tab shows power plan associations, which are a different system. They now have their own tab there that says so in plain words.
- **Saved rules can be edited, disabled and deleted.** Everything except the core selection, which stays with the picker in the Process tab.

## Buttons that did nothing, or lied

- **"+ Custom"** searched the visual tree for a `TabControl` and set `SelectedIndex`. The window has been a `NavigationView` for several versions, so the search returned null: no navigation, no error, no feedback.
- **Clearing CPU Sets** left the core chips advertising the assignment that had just been removed, and a rule saved in between captured those cores.
- **Successful operations left no trace.** A completion status was set and the operation's own `finally` wiped it before it could be read, while failures — which take the preserved path — stayed on screen. Fixed in `ClearStatus`, so priority, memory priority, I/O priority and registry enforcement got it too, not just the affinity path that was reported.
- **Three System Tweaks buttons were white on white** in dark theme: an inline `Style` with no `BasedOn` discards WPF-UI's implicit Button style.

## Detection and windowing

- **Ethernet power saving / interrupt moderation** scanned every network adapter subkey unguarded; one key the user cannot open — VPN and vendor virtual adapters ship with tighter ACLs — threw out of the whole scan, so the tweak declared itself unavailable while every real adapter was readable.
- **Memory Integrity** read only `CI\State`, empty on several builds. It reads `DeviceGuard\Scenarios` first now.
- Those failures displayed the raw framework string *"Requested registry access is not allowed."* The exception belongs in the log; the card gets a sentence.
- **Restoring from maximised** left the window filling the screen. The placement correction ran synchronously inside `OnStateChanged`, where `WindowState` is already `Normal` but `ActualWidth`/`Left` still describe the maximised frame — so it wrote the working area into `Width`/`Height` and destroyed the restore bounds, permanently.
- **Custom masks drawn for a different CPU** are now named in the Masks tab instead of quietly selecting the wrong cores. Built-ins are re-derived; user masks are not ThreadPilot's to redraw.

## Verification

Build clean, 751 tests pass (24 added). The UI paths were driven by hand in the running app: "+ Custom" navigating, the saved-rules tab listing and populating its editor from a real rule, the tweak cards reading `Disabled` instead of red, and maximise → restore returning 2576×1456 to 1280×864.

Not verified here, needs a second pair of eyes: restore on a secondary monitor and under mixed DPI, and the tweak detection on a machine whose adapters differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
