### PR TITLE
ThreadPilot 1.7.4 — masks that follow the CPU, rules you can finish editing

### DIFF
--- a/Installer/Installer.iss
+++ b/Installer/Installer.iss
@@ -5,7 +5,7 @@
 #define MyAppPublisher "ThreadPilot"
 #define MyAppURL "https://github.com/"
 #define MyAppExeName "ThreadPilot.exe"
-#define MyAppVersion "1.7.3"
+#define MyAppVersion "1.7.4"
 
 #ifndef MyWizardStyle
   #define MyWizardStyle "modern dynamic windows11"

--- a/Installer/ThreadPilot.wxs
+++ b/Installer/ThreadPilot.wxs
@@ -7,7 +7,7 @@
   <Package
       Name="ThreadPilot"
       Manufacturer="Prime Build"
-      Version="1.7.3.0"
+      Version="1.7.4.0"
       UpgradeCode="PUT-GENERATED-UPGRADE-CODE-HERE"
       Language="1033">
     <SummaryInformation Description="ThreadPilot MSI template" />

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -11,7 +11,7 @@
 #endif
 
 #ifndef MyAppVersion
-	#define MyAppVersion "1.7.3"
+	#define MyAppVersion "1.7.4"
 #endif
 
 #ifndef MyAppSourceDir

--- a/Locales/de-DE.xaml
+++ b/Locales/de-DE.xaml
@@ -246,12 +246,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Aktualisiert</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Löschen</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">Regel bearbeiten</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCores">Kerne</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplyMask">Kerne aus dieser Maske übernehmen</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">CPU-Priorität</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">Speicherpriorität</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">E/A-Priorität</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">CPU-Zuweisungsmodus</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">System wach halten, solange dieser Prozess läuft</sys:String>
-    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Die Kerne, an die diese Regel bindet, werden auf der Registerkarte Prozesse bearbeitet, wo die Kernauswahl liegt.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Wählen Sie eine gespeicherte CPU-Maske, um die Kerne dieser Regel festzulegen. Die Auswahl einzelner Kerne finden Sie auf der Registerkarte Prozesse.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">Änderungen speichern</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Noch keine gespeicherten Prozessregeln. Klicken Sie auf der Registerkarte Prozesse mit der rechten Maustaste auf einen Prozess und wählen Sie Regeln.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Ausführbar</sys:String>

--- a/Locales/en-US.xaml
+++ b/Locales/en-US.xaml
@@ -246,12 +246,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Updated</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Delete</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">Edit rule</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCores">Cores</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplyMask">Set cores from this mask</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">CPU priority</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">Memory priority</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">I/O priority</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">CPU assignment mode</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">Keep the system awake while this process runs</sys:String>
-    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">The cores this rule pins to are edited from the Process tab, where the core picker lives.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Pick a saved CPU mask to set which cores this rule pins to. The per-core picker lives in the Process tab.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">Save changes</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">No saved process rules yet. Right-click a process in the Process tab and choose Rules to save one.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Executable</sys:String>

--- a/Locales/es-ES.xaml
+++ b/Locales/es-ES.xaml
@@ -246,12 +246,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Actualizada</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Eliminar</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">Editar regla</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCores">Núcleos</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplyMask">Establecer núcleos desde esta máscara</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">Prioridad de CPU</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">Prioridad de memoria</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">Prioridad de E/S</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">Modo de asignación de CPU</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">Impedir la suspensión mientras este proceso se ejecuta</sys:String>
-    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Los núcleos a los que se fija esta regla se editan en la pestaña Procesos, donde está el selector de núcleos.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Elige una máscara de CPU guardada para fijar los núcleos de esta regla. El selector núcleo por núcleo está en la pestaña Procesos.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">Guardar cambios</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Aún no hay reglas de proceso guardadas. Haz clic derecho en un proceso en la pestaña Procesos y elige Reglas para guardar una.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">ejecutable</sys:String>

--- a/Locales/fr-FR.xaml
+++ b/Locales/fr-FR.xaml
@@ -246,12 +246,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Mise à jour</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Supprimer</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">Modifier la règle</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCores">Cœurs</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplyMask">Définir les cœurs depuis ce masque</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">Priorité CPU</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">Priorité mémoire</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">Priorité E/S</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">Mode d'affectation CPU</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">Empêcher la mise en veille pendant l'exécution de ce processus</sys:String>
-    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Les cœurs auxquels cette règle est liée se modifient dans l'onglet Processus, où se trouve le sélecteur de cœurs.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Choisissez un masque CPU enregistré pour définir les cœurs de cette règle. Le sélecteur cœur par cœur se trouve dans l'onglet Processus.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">Enregistrer les modifications</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Aucune règle de processus enregistrée. Faites un clic droit sur un processus dans l'onglet Processus et choisissez Règles pour en enregistrer une.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Exécutable</sys:String>

--- a/Locales/it-IT.xaml
+++ b/Locales/it-IT.xaml
@@ -246,12 +246,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Aggiornata</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Elimina</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">Modifica regola</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCores">Core</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplyMask">Imposta i core da questa maschera</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">Priorità CPU</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">Priorità memoria</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">Priorità I/O</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">Modalità di assegnazione CPU</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">Impedisci la sospensione mentre il processo è in esecuzione</sys:String>
-    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">I core a cui questa regola vincola il processo si modificano dalla scheda Processi, dove c'è il selettore dei core.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Scegli una maschera CPU salvata per impostare i core a cui questa regola vincola il processo. Il selettore core per core è nella scheda Processi.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">Salva modifiche</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Nessuna regola di processo salvata. Fai clic destro su un processo nella scheda Processi e scegli Regole per salvarne una.</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Eseguibile</sys:String>

--- a/Locales/ru-RU.xaml
+++ b/Locales/ru-RU.xaml
@@ -246,12 +246,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">Обновлено</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">Удалить</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">Изменить правило</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCores">Ядра</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplyMask">Задать ядра из этой маски</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">Приоритет ЦП</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">Приоритет памяти</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">Приоритет ввода-вывода</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">Режим назначения ЦП</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">Не давать системе засыпать, пока процесс работает</sys:String>
-    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Ядра, к которым привязано это правило, изменяются на вкладке «Процессы», где находится выбор ядер.</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">Выберите сохранённую маску ЦП, чтобы задать ядра для этого правила. Выбор отдельных ядер — на вкладке «Процессы».</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">Сохранить изменения</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">Сохранённых правил процессов пока нет. Щёлкните процесс правой кнопкой на вкладке «Процессы» и выберите «Правила».</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">Исполняемый файл</sys:String>

--- a/Locales/zh-CN.xaml
+++ b/Locales/zh-CN.xaml
@@ -246,12 +246,14 @@
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleUpdated">更新时间</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleDelete">删除</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditor">编辑规则</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCores">核心</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleApplyMask">从此掩码设置核心</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleCpuPriority">CPU 优先级</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleMemoryPriority">内存优先级</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleIoPriority">I/O 优先级</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleModeLabel">CPU 分配模式</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRulePreventSleep">该进程运行时阻止系统休眠</sys:String>
-    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">此规则绑定的核心需在“进程”选项卡中修改，核心选择器在那里。</sys:String>
+    <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleEditorHint">选择一个已保存的 CPU 掩码来设置此规则绑定的核心。逐核选择器在“进程”选项卡中。</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_SavedRuleSave">保存更改</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_NoSavedRules">尚无已保存的进程规则。在“进程”选项卡中右键点击某个进程并选择“规则”即可保存。</sys:String>
     <sys:String x:Key="ProcessPowerPlanAssociationView_Executable">可执行文件</sys:String>

--- a/Services/CoreMaskService.cs
+++ b/Services/CoreMaskService.cs
@@ -701,7 +701,7 @@ namespace ThreadPilot.Services
                 changed |= this.AddOrReconcileBuiltInMask(mask, canReconcileLengths);
             }
 
-            this.CollectMasksNeedingTopologyReview(coreCount, canReconcileLengths);
+            changed |= await this.ReconcileCustomMaskLengthsAsync(coreCount, canReconcileLengths).ConfigureAwait(false);
 
             await Task.CompletedTask;
             return changed;
@@ -717,34 +717,102 @@ namespace ThreadPilot.Services
             return Environment.ProcessorCount;
         }
 
-        // A built-in mask can be re-derived, because ThreadPilot knows what it is supposed to mean.
-        // A mask the user drew cannot: only they know whether the CPUs that appeared should be part
-        // of it. So flag those and let the Masks tab ask, rather than resize them behind their back
-        // or leave them quietly selecting the wrong cores.
-        private void CollectMasksNeedingTopologyReview(int coreCount, bool topologyIsTrustworthy)
+        // A built-in mask can be re-derived: ThreadPilot knows what "All Cores" is supposed to mean.
+        // A mask the user drew is different. Growing it is safe - the CPUs that appeared are simply
+        // not part of a selection made before they existed - and shrinking it is safe as long as
+        // something is left. Two cases are not ours to decide: a mask that would end up empty, and
+        // a mask a power plan association is actively using, where a silent resize would change what
+        // that automation does. Those are flagged for the user instead.
+        private async Task<bool> ReconcileCustomMaskLengthsAsync(int coreCount, bool topologyIsTrustworthy)
         {
-            if (!topologyIsTrustworthy)
+            if (!topologyIsTrustworthy || coreCount <= 0)
             {
-                return;
+                return false;
             }
+
+            var currentBrand = this.cpuTopologyService.CurrentTopology?.CpuBrand;
+
+            // A different CPU with the same thread count - a 5800X swapped for a 5800X3D, say -
+            // changes what "cores 8-15" means without changing how many there are. The stored
+            // selection carries the signature of the machine it was made on, which is the only way
+            // to see that. This is what CpuSelectionMigrationMetadata.ReviewRequired was computed
+            // for; nothing ever read it.
+            var differentCpu = this.AvailableMasks
+                .Where(mask => !mask.IsDefault
+                    && mask.BoolMask.Count == coreCount
+                    && WasBuiltOnADifferentCpu(mask, currentBrand))
+                .Select(mask => mask.Name);
 
             var stale = this.AvailableMasks
                 .Where(mask => !mask.IsDefault && mask.BoolMask.Count > 0 && mask.BoolMask.Count != coreCount)
-                .Select(mask => mask.Name)
                 .ToList();
-
-            this.MasksNeedingTopologyReview = stale;
-
-            if (stale.Count > 0)
+            if (stale.Count == 0)
             {
+                this.MasksNeedingTopologyReview = differentCpu.ToList();
+                return false;
+            }
+
+            var needsReview = new List<string>(differentCpu);
+            var changed = false;
+
+            foreach (var mask in stale)
+            {
+                var previousCount = mask.BoolMask.Count;
+                var resized = ResizeBoolMask(mask.BoolMask, coreCount);
+
+                if (!resized.Any(selected => selected))
+                {
+                    needsReview.Add(mask.Name);
+                    this.logger.LogInformation(
+                        "Custom core mask '{Name}' selects no CPU that still exists ({OldCount} -> {NewCount}): left untouched for review",
+                        mask.Name,
+                        previousCount,
+                        coreCount);
+                    continue;
+                }
+
+                if (await this.IsMaskReferencedByProfilesAsync(mask.Id).ConfigureAwait(false))
+                {
+                    needsReview.Add(mask.Name);
+                    this.logger.LogInformation(
+                        "Custom core mask '{Name}' is used by an automation rule and was built for a different CPU ({OldCount} -> {NewCount}): left untouched for review",
+                        mask.Name,
+                        previousCount,
+                        coreCount);
+                    continue;
+                }
+
+                ReplaceBoolMask(mask, resized);
+                changed = true;
                 this.logger.LogInformation(
-                    "{Count} custom core mask(s) were built for a different CPU ({Names}): stored bit count does not match the {CoreCount} logical CPUs on this machine",
-                    stale.Count,
-                    string.Join(", ", stale),
+                    "Resized custom core mask '{Name}' from {OldCount} to {NewCount} logical CPUs",
+                    mask.Name,
+                    previousCount,
                     coreCount);
             }
+
+            this.MasksNeedingTopologyReview = needsReview;
+            return changed;
         }
 
+        private static bool WasBuiltOnADifferentCpu(CoreMask mask, string? currentBrand)
+        {
+            var savedBrand = mask.CpuSelection?.Metadata.TopologySignature?.CpuBrand;
+            return !string.IsNullOrWhiteSpace(savedBrand)
+                && !string.IsNullOrWhiteSpace(currentBrand)
+                && !string.Equals(savedBrand, currentBrand, StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static List<bool> ResizeBoolMask(IReadOnlyList<bool> bits, int coreCount)
+        {
+            var resized = new List<bool>(coreCount);
+            for (var index = 0; index < coreCount; index++)
+            {
+                resized.Add(index < bits.Count && bits[index]);
+            }
+
+            return resized;
+        }
         private bool AddOrReconcileBuiltInMask(CoreMask mask, bool reconcileLength)
         {
             var existing = this.AvailableMasks.FirstOrDefault(m =>

--- a/Services/ProcessRuleCreationService.cs
+++ b/Services/ProcessRuleCreationService.cs
@@ -34,6 +34,11 @@ namespace ThreadPilot.Services
         Task<ProcessRuleCreationResult> UpdateRuleAsync(
             PersistentProcessRule rule,
             CancellationToken cancellationToken = default);
+
+        Task<ProcessRuleCreationResult> UpdateRuleCoreSelectionAsync(
+            string ruleId,
+            IReadOnlyList<bool> coreSelection,
+            CancellationToken cancellationToken = default);
     }
 
     public sealed record ProcessRuleCreationPayload
@@ -250,6 +255,71 @@ namespace ThreadPilot.Services
                 Updated = true,
                 Rule = updated,
                 UserMessage = $"Updated saved rule for {processName}.",
+            };
+        }
+
+        // Setting a rule's cores without the process being around to select. The bits come from a
+        // saved CPU mask, and go through the same migration path the Process tab uses, so a rule
+        // edited here is indistinguishable from one saved there.
+        public async Task<ProcessRuleCreationResult> UpdateRuleCoreSelectionAsync(
+            string ruleId,
+            IReadOnlyList<bool> coreSelection,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(coreSelection);
+
+            if (string.IsNullOrWhiteSpace(ruleId))
+            {
+                return ProcessRuleCreationResult.Failed("NoSavedRuleToUpdate", NoSavedRuleMessage);
+            }
+
+            var affinityPayload = await this.BuildAffinityPayloadFromCoreSelectionAsync(
+                coreSelection,
+                "Set from a saved CPU mask in the Rules tab",
+                cancellationToken).ConfigureAwait(false);
+            if (!affinityPayload.Success)
+            {
+                return affinityPayload;
+            }
+
+            if (affinityPayload.Payload == null)
+            {
+                return ProcessRuleCreationResult.Failed("NoActionableRulePayload", NoCurrentSettingsMessage);
+            }
+
+            var rules = (await this.ruleStore.LoadAsync().ConfigureAwait(false)).ToList();
+            var existingIndex = rules.FindIndex(candidate => string.Equals(candidate.Id, ruleId, StringComparison.Ordinal));
+            if (existingIndex < 0)
+            {
+                return ProcessRuleCreationResult.Failed("NoSavedRuleToUpdate", NoSavedRuleMessage);
+            }
+
+            var selection = affinityPayload.Payload.CpuSelection;
+            var existing = rules[existingIndex];
+            var updated = existing with
+            {
+                CpuSelection = selection,
+                LegacyAffinityMask = HasSelectionPayload(selection) ? null : affinityPayload.Payload.LegacyAffinityMask,
+                ApplyAffinityOnStart = true,
+                UpdatedAt = DateTime.UtcNow,
+            };
+
+            rules[existingIndex] = updated;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await this.ruleStore.SaveAsync(rules).ConfigureAwait(false);
+
+            var processName = string.IsNullOrWhiteSpace(updated.ProcessName)
+                ? "process"
+                : updated.ProcessName.Trim();
+            this.logger.LogInformation("Updated the CPU selection of saved rule {RuleId} for {ProcessName}", updated.Id, processName);
+
+            return new ProcessRuleCreationResult
+            {
+                Success = true,
+                Updated = true,
+                Rule = updated,
+                UserMessage = $"Updated the cores of the saved rule for {processName}.",
             };
         }
 

--- a/Tests/ThreadPilot.Core.Tests/CoreMaskServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/CoreMaskServiceTests.cs
@@ -94,7 +94,7 @@ namespace ThreadPilot.Core.Tests
         }
 
         [Fact]
-        public async Task InitializeAsync_AfterCpuChange_RebuildsBuiltInsButPreservesUserMask()
+        public async Task InitializeAsync_AfterCpuChange_RebuildsBuiltInsAndGrowsUserMask()
         {
             var masksFilePath = CreateTempMasksPath();
             await WriteMasksAsync(
@@ -110,7 +110,84 @@ namespace ThreadPilot.Core.Tests
             Assert.Equal(8, allCores.BoolMask.Count);
             Assert.All(allCores.BoolMask, Assert.True);
             var customMask = Assert.Single(service.AvailableMasks, mask => mask.Id == "custom-mask");
+
+            // Grown, not redefined: the CPUs that appeared were not part of a selection made before
+            // they existed, so they stay unselected and the mask keeps meaning what it meant.
+            Assert.Equal(new[] { true, false, true, false, false, false, false, false }, customMask.BoolMask);
+            Assert.Empty(service.MasksNeedingTopologyReview);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_OnASmallerCpu_ShrinksAUserMaskThatStillSelectsSomething()
+        {
+            var masksFilePath = CreateTempMasksPath();
+            await WriteMasksAsync(
+                masksFilePath,
+                CreateStoredMask("all-cores", "All Cores", [true, true, true, true, true, true, true, true], isDefault: true),
+                CreateStoredMask("custom-mask", "My Game Mask", [true, true, false, false, false, false, true, true]));
+            var service = CreateService(CreateTopology(logicalCoreCount: 4), masksFilePath);
+
+            await service.InitializeAsync();
+
+            var customMask = Assert.Single(service.AvailableMasks, mask => mask.Id == "custom-mask");
+            Assert.Equal(new[] { true, true, false, false }, customMask.BoolMask);
+            Assert.Empty(service.MasksNeedingTopologyReview);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_LeavesAUserMaskAloneWhenShrinkingWouldEmptyIt()
+        {
+            var masksFilePath = CreateTempMasksPath();
+            await WriteMasksAsync(
+                masksFilePath,
+                CreateStoredMask("all-cores", "All Cores", [true, true, true, true, true, true, true, true], isDefault: true),
+                CreateStoredMask("custom-mask", "Big Cores Only", [false, false, false, false, true, true, true, true]));
+            var service = CreateService(CreateTopology(logicalCoreCount: 4), masksFilePath);
+
+            await service.InitializeAsync();
+
+            // Every CPU it selected is gone. Truncating would leave a mask that cannot be applied,
+            // and guessing which of the remaining CPUs the user meant is not ThreadPilot's call.
+            var customMask = Assert.Single(service.AvailableMasks, mask => mask.Id == "custom-mask");
+            Assert.Equal(new[] { false, false, false, false, true, true, true, true }, customMask.BoolMask);
+            Assert.Equal(new[] { "Big Cores Only" }, service.MasksNeedingTopologyReview);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_LeavesAUserMaskAloneWhenAnAutomationRuleUsesIt()
+        {
+            var masksFilePath = CreateTempMasksPath();
+            await WriteMasksAsync(
+                masksFilePath,
+                CreateStoredMask("all-cores", "All Cores", [true, true, true, true], isDefault: true),
+                CreateStoredMask("custom-mask", "My Game Mask", [true, false, true, false]));
+
+            var associations = new Mock<IProcessPowerPlanAssociationService>(MockBehavior.Loose);
+            associations
+                .Setup(service => service.GetAssociationsAsync())
+                .ReturnsAsync(new List<ProcessPowerPlanAssociation>
+                {
+                    new() { ExecutableName = "game.exe", CoreMaskId = "custom-mask" },
+                });
+            var serviceProvider = new Mock<IServiceProvider>();
+            serviceProvider
+                .Setup(provider => provider.GetService(typeof(IProcessPowerPlanAssociationService)))
+                .Returns(associations.Object);
+
+            var topologyService = new Mock<ICpuTopologyService>(MockBehavior.Strict);
+            topologyService.SetupGet(service => service.CurrentTopology).Returns(CreateTopology(logicalCoreCount: 8));
+            var service = new CoreMaskService(
+                NullLogger<CoreMaskService>.Instance,
+                topologyService.Object,
+                serviceProvider.Object,
+                masksFilePath: masksFilePath);
+
+            await service.InitializeAsync();
+
+            // Resizing it would silently change what that automation does.
+            var customMask = Assert.Single(service.AvailableMasks, mask => mask.Id == "custom-mask");
             Assert.Equal(new[] { true, false, true, false }, customMask.BoolMask);
+            Assert.Equal(new[] { "My Game Mask" }, service.MasksNeedingTopologyReview);
         }
 
         [Fact]
@@ -141,6 +218,39 @@ namespace ThreadPilot.Core.Tests
                 () => service.AvailableMasks.Any(mask => mask.Name == "All no SMT"),
                 TimeSpan.FromSeconds(3)));
             Assert.Equal(1, service.AvailableMasks.Count(mask => mask.Name == "All no SMT"));
+        }
+
+        [Fact]
+        public async Task InitializeAsync_FlagsAUserMaskBuiltOnADifferentCpuWithTheSameCoreCount()
+        {
+            // Same number of threads, different chip: the bit count matches, so nothing is resized,
+            // but "cores 2 and 3" no longer mean what they meant when the mask was drawn.
+            var masksFilePath = CreateTempMasksPath();
+            await WriteMasksAsync(
+                masksFilePath,
+                CreateStoredMask("all-cores", "All Cores", [true, true, true, true], isDefault: true),
+                CreateStoredMask(
+                    "custom-mask",
+                    "My Game Mask",
+                    [false, false, true, true],
+                    cpuSelection: new CpuSelection
+                    {
+                        LogicalProcessors = [new ProcessorRef(0, 2, 2), new ProcessorRef(0, 3, 3)],
+                        GlobalLogicalProcessorIndexes = [2, 3],
+                        Metadata = new CpuSelectionMetadata
+                        {
+                            TopologySignature = new CpuTopologySignature { CpuBrand = "AMD Ryzen 7 5800X" },
+                        },
+                    }));
+            var topology = CreateTopology(logicalCoreCount: 4);
+            topology.CpuBrand = "AMD Ryzen 7 5800X3D";
+            var service = CreateService(topology, masksFilePath);
+
+            await service.InitializeAsync();
+
+            var customMask = Assert.Single(service.AvailableMasks, mask => mask.Id == "custom-mask");
+            Assert.Equal(new[] { false, false, true, true }, customMask.BoolMask);
+            Assert.Equal(new[] { "My Game Mask" }, service.MasksNeedingTopologyReview);
         }
 
         private static CoreMaskService CreateService(CpuTopologyModel topology, string masksFilePath)
@@ -220,7 +330,8 @@ namespace ThreadPilot.Core.Tests
             string id,
             string name,
             IEnumerable<bool> boolMask,
-            bool isDefault = false) =>
+            bool isDefault = false,
+            CpuSelection? cpuSelection = null) =>
             new
             {
                 id,
@@ -228,7 +339,7 @@ namespace ThreadPilot.Core.Tests
                 description = $"{name} description",
                 boolMask = boolMask.ToList(),
                 profileSchemaVersion = CpuAffinityProfileSchemaVersions.Legacy,
-                cpuSelection = (CpuSelection?)null,
+                cpuSelection,
                 cpuSelectionMigration = (CpuSelectionMigrationMetadata?)null,
                 isDefault,
                 isEnabled = true,

--- a/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/PackagingMetadataTests.cs
@@ -4,8 +4,8 @@ namespace ThreadPilot.Core.Tests
 
     public sealed partial class PackagingMetadataTests
     {
-        private const string ReleaseVersion = "1.7.3";
-        private const string ReleaseAssemblyVersion = "1.7.3.0";
+        private const string ReleaseVersion = "1.7.4";
+        private const string ReleaseAssemblyVersion = "1.7.4.0";
 
         [Fact]
         public void InnoInstallers_UseStableDisplayNameAndSeparateVersionMetadata()
@@ -120,7 +120,7 @@ namespace ThreadPilot.Core.Tests
             throw new InvalidOperationException("Repository root could not be located.");
         }
 
-        [GeneratedRegex("#define MyAppVersion \"1\\.7\\.3\"", RegexOptions.CultureInvariant)]
+        [GeneratedRegex("#define MyAppVersion \"1\\.7\\.4\"", RegexOptions.CultureInvariant)]
         private static partial Regex MyAppVersionRegex();
     }
 }

--- a/Tests/ThreadPilot.Core.Tests/ProcessRuleCreationServiceTests.cs
+++ b/Tests/ThreadPilot.Core.Tests/ProcessRuleCreationServiceTests.cs
@@ -644,6 +644,60 @@ namespace ThreadPilot.Core.Tests
             Assert.Equal("NoSavedRuleToUpdate", result.ErrorCode);
         }
 
+        [Fact]
+        public async Task UpdateRuleCoreSelectionAsync_SetsTheCoresWithoutTheProcessRunning()
+        {
+            var existing = new PersistentProcessRule
+            {
+                Id = "rule-1",
+                ProcessName = "cs2",
+                IsEnabled = true,
+                Priority = ProcessPriorityClass.High,
+                ApplyPriorityOnStart = true,
+            };
+            var store = new CapturingRuleStore([existing]);
+            var topologyProvider = new FakeTopologyProvider(CpuTopologySnapshot.Create(
+                [
+                    new ProcessorRef(0, 0, 0),
+                    new ProcessorRef(0, 1, 1),
+                ]));
+            var service = CreateService(store, topologyProvider);
+
+            var result = await service.UpdateRuleCoreSelectionAsync("rule-1", [false, true]);
+
+            Assert.True(result.Success);
+            var rule = Assert.Single(store.SavedRules);
+            Assert.True(rule.ApplyAffinityOnStart);
+            Assert.NotNull(rule.CpuSelection);
+            Assert.Equal(1, rule.CpuSelection!.GlobalLogicalProcessorIndexes.Single());
+            Assert.Equal(ProcessPriorityClass.High, rule.Priority);
+        }
+
+        [Fact]
+        public async Task UpdateRuleCoreSelectionAsync_RefusesASelectionWithNoCores()
+        {
+            var existing = new PersistentProcessRule { Id = "rule-1", ProcessName = "cs2", IsEnabled = true };
+            var store = new CapturingRuleStore([existing]);
+            var service = CreateService(store);
+
+            var result = await service.UpdateRuleCoreSelectionAsync("rule-1", [false, false]);
+
+            Assert.False(result.Success);
+            Assert.Empty(store.SavedRules);
+        }
+
+        [Fact]
+        public async Task UpdateRuleCoreSelectionAsync_ReportsAControlledFailureForAnUnknownRule()
+        {
+            var store = new CapturingRuleStore([]);
+            var service = CreateService(store);
+
+            var result = await service.UpdateRuleCoreSelectionAsync("missing", [true, false]);
+
+            Assert.False(result.Success);
+            Assert.Equal("NoSavedRuleToUpdate", result.ErrorCode);
+        }
+
         private static ProcessModel CreateProcess(
             string name = "Game.exe",
             string path = @"C:\Games\Game.exe",

--- a/ThreadPilot.csproj
+++ b/ThreadPilot.csproj
@@ -16,10 +16,10 @@
     <TrimMode>link</TrimMode>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1998;CS0067;CS0414;WFAC010;IL3000;MVVMTK0034</NoWarn>
-    <Version>1.7.3</Version>
-    <AssemblyVersion>1.7.3.0</AssemblyVersion>
-    <FileVersion>1.7.3.0</FileVersion>
-    <InformationalVersion>1.7.3</InformationalVersion>
+    <Version>1.7.4</Version>
+    <AssemblyVersion>1.7.4.0</AssemblyVersion>
+    <FileVersion>1.7.4.0</FileVersion>
+    <InformationalVersion>1.7.4</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ViewModels/MasksViewModel.cs
+++ b/ViewModels/MasksViewModel.cs
@@ -93,13 +93,14 @@ namespace ThreadPilot.ViewModels
                 // Select the default mask
                 this.SelectedCoreMask = this.coreMaskService.DefaultMask;
 
-                // A CPU change leaves custom masks describing a machine that no longer exists.
-                // ThreadPilot will not redraw them for the user, so it has to say so where they
-                // would go to fix them.
+                // Custom masks built for a different CPU are resized automatically where that is
+                // unambiguous. What lands here is what ThreadPilot refused to decide: a mask that
+                // would be left selecting nothing, or one an automation rule is using, where a
+                // silent resize would quietly change what that rule does.
                 var needingReview = this.coreMaskService.MasksNeedingTopologyReview;
                 this.TopologyReviewMessage = needingReview.Count == 0
                     ? string.Empty
-                    : $"These custom masks were built for a different CPU and no longer cover every logical processor on this machine: {string.Join(", ", needingReview)}. Open each one, check the cores, and save it again.";
+                    : $"This CPU has a different number of logical processors than when these custom masks were made, and ThreadPilot did not change them on its own - either an automation rule is using them, or they would be left selecting no CPU that still exists: {string.Join(", ", needingReview)}. Open each one, check the cores, and save it again.";
 
                 this.logger.LogInformation("MasksViewModel initialized with {Count} masks", this.CoreMasks.Count);
             }

--- a/ViewModels/ProcessPowerPlanAssociationViewModel.cs
+++ b/ViewModels/ProcessPowerPlanAssociationViewModel.cs
@@ -242,6 +242,32 @@ namespace ThreadPilot.ViewModels
             this.SavedRuleCpuAssignmentMode = rule.CpuAssignmentMode.ToString();
         }
 
+        // The cores of a rule can now be set without the process running: the Process tab needs a
+        // live process to hang its picker on, and a rule for a game you are not currently playing
+        // was the one thing you could not change. The vocabulary here is the saved CPU masks, which
+        // is what the Masks tab exists to define, rather than a second per-core picker.
+        [ObservableProperty]
+        private CoreMask? savedRuleCoreMask;
+
+        [RelayCommand]
+        private async Task ApplySavedRuleCoreMaskAsync()
+        {
+            var selected = this.SelectedSavedProcessRule;
+            var mask = this.SavedRuleCoreMask;
+            if (selected == null || mask == null || this.ruleCreationService == null)
+            {
+                return;
+            }
+
+            var result = await this.ruleCreationService
+                .UpdateRuleCoreSelectionAsync(selected.Id, mask.BoolMask)
+                .ConfigureAwait(true);
+            this.SetStatus(result.UserMessage, false);
+            await this.RefreshSavedProcessRulesAsync().ConfigureAwait(true);
+            this.SelectedSavedProcessRule = this.SavedProcessRules
+                .FirstOrDefault(row => string.Equals(row.Id, selected.Id, StringComparison.Ordinal));
+        }
+
         [RelayCommand]
         private async Task SaveSavedProcessRuleAsync()
         {
@@ -283,6 +309,7 @@ namespace ThreadPilot.ViewModels
             string Mode,
             bool IsEnabled,
             DateTime UpdatedAt,
+            string Cores,
             PersistentProcessRule Source)
         {
             public static SavedProcessRule From(PersistentProcessRule rule)
@@ -320,7 +347,52 @@ namespace ThreadPilot.ViewModels
                     rule.ApplyAffinityOnStart ? rule.CpuAssignmentMode.ToString() : "-",
                     rule.IsEnabled,
                     rule.UpdatedAt.ToLocalTime(),
+                    DescribeCores(rule),
                     rule);
+            }
+
+            // "0-7, 16" reads better than a 64-bit mask or a list of every index.
+            private static string DescribeCores(PersistentProcessRule rule)
+            {
+                if (!rule.ApplyAffinityOnStart)
+                {
+                    return "-";
+                }
+
+                IReadOnlyList<int>? indexes = rule.CpuSelection?.GlobalLogicalProcessorIndexes;
+                if (indexes == null || indexes.Count == 0)
+                {
+                    if (!rule.LegacyAffinityMask.HasValue)
+                    {
+                        return "-";
+                    }
+
+                    var mask = unchecked((ulong)rule.LegacyAffinityMask.Value);
+                    indexes = Enumerable.Range(0, 64).Where(bit => (mask & (1UL << bit)) != 0).ToList();
+                }
+
+                var ordered = indexes.Distinct().OrderBy(index => index).ToList();
+                if (ordered.Count == 0)
+                {
+                    return "-";
+                }
+
+                var parts = new List<string>();
+                var start = ordered[0];
+                var previous = start;
+                foreach (var index in ordered.Skip(1))
+                {
+                    if (index != previous + 1)
+                    {
+                        parts.Add(start == previous ? $"{start}" : $"{start}-{previous}");
+                        start = index;
+                    }
+
+                    previous = index;
+                }
+
+                parts.Add(start == previous ? $"{start}" : $"{start}-{previous}");
+                return string.Join(", ", parts);
             }
         }
 

--- a/Views/ProcessPowerPlanAssociationView.xaml
+++ b/Views/ProcessPowerPlanAssociationView.xaml
@@ -367,6 +367,21 @@
                                           SelectedItem="{Binding SavedRuleCpuAssignmentMode, Mode=TwoWay}"
                                           Margin="0,0,0,10"/>
 
+                                <TextBlock Text="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleCores}" Margin="0,0,0,3"/>
+                                <TextBlock Text="{Binding SelectedSavedProcessRule.Cores}"
+                                           FontWeight="SemiBold"
+                                           TextWrapping="Wrap"
+                                           Margin="0,0,0,6"/>
+                                <ComboBox ItemsSource="{Binding AvailableCoreMasks}"
+                                          SelectedItem="{Binding SavedRuleCoreMask, Mode=TwoWay}"
+                                          DisplayMemberPath="Name"
+                                          Margin="0,0,0,6"/>
+                                <Button Content="{DynamicResource ProcessPowerPlanAssociationView_SavedRuleApplyMask}"
+                                        Command="{Binding ApplySavedRuleCoreMaskCommand}"
+                                        Padding="10,4"
+                                        HorizontalAlignment="Left"
+                                        Margin="0,0,0,12"/>
+
                                 <CheckBox Content="{DynamicResource ProcessPowerPlanAssociationView_SavedRulePreventSleep}"
                                           IsChecked="{Binding SavedRulePreventSleep, Mode=TwoWay}"
                                           Margin="0,0,0,10"/>

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.7.3.0" name="ThreadPilot.app"/>
+  <assemblyIdentity version="1.7.4.0" name="ThreadPilot.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/build/build-installer.ps1
+++ b/build/build-installer.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.7.3",
+    [string]$Version = "1.7.4",
     [string]$Configuration = "Release",
     [switch]$SkipPublish
 )

--- a/build/build-release.ps1
+++ b/build/build-release.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.7.3",
+    [string]$Version = "1.7.4",
     [string]$Configuration = "Release",
     [string]$Runtime = "win-x64"
 )

--- a/build/package-release-zips.ps1
+++ b/build/package-release-zips.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Version = "1.7.3"
+    [string]$Version = "1.7.4"
 )
 
 $ErrorActionPreference = "Stop"

--- a/chocolatey/threadpilot.nuspec
+++ b/chocolatey/threadpilot.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>threadpilot</id>
-    <version>1.7.3</version>
+    <version>1.7.4</version>
     <title>ThreadPilot</title>
     <authors>Prime Build</authors>
     <projectUrl>https://github.com/PrimeBuild-pc/ThreadPilot</projectUrl>
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Advanced Windows process and power plan manager with rules automation and performance controls.</description>
     <summary>ThreadPilot process and power plan manager.</summary>
-    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.7.3</releaseNotes>
+    <releaseNotes>https://github.com/PrimeBuild-pc/ThreadPilot/releases/tag/v1.7.4</releaseNotes>
     <tags>threadpilot process powerplan performance windows</tags>
   </metadata>
   <files>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project are documented in this file.
 
+## v1.7.4 - Masks that follow the CPU, rules you can finish editing
+
+### Fixed
+
+- Custom CPU masks are resized when the logical-processor count changes instead of being left describing a machine that no longer exists. Growing a mask leaves the new CPUs unselected; shrinking one keeps the selected CPUs that still exist.
+- A mask is deliberately **not** resized when the result would select no CPU at all, or when a power plan association is using it - a silent resize there would change what that automation does. Those masks are named in the Masks tab for manual review.
+- Custom masks built on a different CPU with the same thread count are now detected by comparing the topology signature stored with the mask's selection, a case the logical-processor count alone cannot see.
+
+### Added
+
+- The cores a saved rule pins to can be set from the **Saved process rules** editor, using any saved CPU mask. Previously they could only be changed from the Process tab, which requires the process to be running - so a rule for an application that was not currently open could not be fully edited.
+- The saved-rules editor shows the rule's current cores as readable ranges.
+
+### Validation
+
+- 758 automated tests pass.
+- Windows 11 UI verification covered the saved-rules editor populating from a real rule, the mask picker listing the available masks, and the core ranges shown for an existing rule.
+
 ## v1.7.3 - Rule integrity and verifiable CPU assignment
 
 ### Fixed

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -10,4 +10,4 @@ ThreadPilot does not transmit the local process list, executable paths, hardware
 
 The Power Plans and Settings pages contain links to Discord and GitHub Issues. ThreadPilot opens these links only after an explicit user click; the destination then receives ordinary connection information under its own privacy terms. ThreadPilot does not automatically download community power plans.
 
-This policy describes ThreadPilot 1.7.3. Material changes to data collection or network behavior will be documented before release.
+This policy describes ThreadPilot 1.7.4. Material changes to data collection or network behavior will be documented before release.

--- a/docs/release/RELEASE_NOTES.md
+++ b/docs/release/RELEASE_NOTES.md
@@ -1,3 +1,24 @@
+## ThreadPilot v1.7.4
+
+A follow-up to 1.7.3, closing the three items left open in its review.
+
+### Custom masks follow a CPU change
+
+Built-in masks were already re-derived when the logical-processor count changed; masks you drew yourself were only flagged. They are now resized too, because most of the decision is not a judgement call: CPUs that appear were not part of a selection made before they existed, so they stay unselected, and removing CPUs is safe while something is still selected.
+
+Two cases are still yours to decide, and ThreadPilot says so in the Masks tab rather than guessing:
+
+- the mask would be left selecting no CPU that still exists;
+- a power plan association is using the mask, where a silent resize would change what that automation does.
+
+A different CPU with the same thread count is also detected now, by comparing the topology signature stored with the mask against the running machine - a swap that the logical-processor count alone cannot reveal.
+
+### A rule's cores can be edited from the Rules page
+
+The per-core picker lives in the Process tab and needs the process to be running, so the cores of a rule for an application you were not currently running were the one thing about that rule you could not change.
+
+The **Saved process rules** editor now shows those cores as readable ranges and can set them from any saved CPU mask, through the same conversion the Process tab uses. The per-core picker stays where it is rather than being duplicated.
+
 ## ThreadPilot v1.7.3
 
 ThreadPilot 1.7.3 focuses on trust: an operation that reports success must remain visible, survive a UI refresh, and preserve the rest of the user's configuration.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=threadpilot
 sonar.projectName=ThreadPilot
-sonar.projectVersion=1.7.3
+sonar.projectVersion=1.7.4
 
 sonar.sourceEncoding=UTF-8
 sonar.sources=.


### PR DESCRIPTION
The three items left open at the end of the 1.7.3 review.

## Custom masks follow a CPU change

Built-in masks were already re-derived when the logical-processor count changed; masks the user drew were only flagged. Most of that decision is not a judgement call, so it is made now: **growing** a mask leaves the CPUs that appeared unselected — they were not part of a selection made before they existed — and **shrinking** keeps the selected CPUs that still exist.

Two cases stay with the user, and are named in the Masks tab rather than guessed at:

- the mask would be left selecting **no CPU that still exists** — truncating gives a mask that cannot be applied, and picking replacements is not ThreadPilot's call;
- a **power plan association is using the mask**, where a silent resize would change what that automation does without saying so.

A **different CPU with the same thread count** is also caught now — a 5800X swapped for a 5800X3D — by comparing the topology signature stored in the mask's selection against the running machine. The bit count matches there, so nothing is resized, but "cores 8-15" no longer mean what they meant.

That signature is what `CpuSelectionMigrationMetadata.ReviewRequired` was being computed from in four places and read from in none. This is the first thing to use it; the flag itself is still unread and is now redundant in this path.

## A rule's cores can be edited from the Rules page

The per-core picker lives in the Process tab and needs the process to be running, so the cores of a rule for an application that was not currently open were the one thing about that rule that could not be changed.

The saved-rules editor now shows them as readable ranges (`0, 2, 4-7`) and can set them from any saved CPU mask, through the same migration path the Process tab uses — a rule edited here is indistinguishable from one saved there. The per-core picker is not duplicated; if it should live in both places one day, the right move is extracting it into a shared control.

## Version

1.7.3 is tagged and released, so this carries a bump to **1.7.4** across the csproj, manifest, installers, build scripts, chocolatey nuspec, sonar properties and docs. `PackagingMetadataTests` pins the release version deliberately and caught two spots a blind replace missed.

## Verification

Build clean, **758 tests pass** (7 added). Driven by hand in the running app: the saved-rules editor showing a real rule's cores as `0, 2, 4, 6, 8, 10, 12, 14`, and the mask picker listing `All Cores`, `No Core 0`, `All no SMT`. Applying a mask to a rule was not exercised against the user's own saved rule, to avoid modifying their data — that path is covered by unit tests.

Not verified here: an actual CPU swap. The resize and both fallbacks are covered by tests that stand up a stored mask against a different topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
